### PR TITLE
feat: enrich player item popup with bundle description and stats

### DIFF
--- a/lib/features/player/data/player_item_utils.dart
+++ b/lib/features/player/data/player_item_utils.dart
@@ -68,3 +68,22 @@ Map<String, dynamic> filterGameData(
 Map<String, dynamic> filterSpellGameData(Map<String, dynamic>? data) {
   return filterGameData(data, (_, __) => true);
 }
+
+/// Returns the highest item level unlockable at [thLevel] based on bundle metadata.
+/// Returns 0 if the item has no levels or is not available at that TH level.
+int maxLevelForTH(Map<String, dynamic>? meta, int thLevel) {
+  if (meta == null || thLevel <= 0) return 0;
+  final levels = meta['levels'];
+  if (levels is! List || levels.isEmpty) return 0;
+  int maxLevel = 0;
+  for (final entry in levels) {
+    if (entry is Map) {
+      final requiredTH = entry['required_townhall'];
+      final level = entry['level'];
+      if (requiredTH is num && level is num && requiredTH <= thLevel) {
+        if (level > maxLevel) maxLevel = level.toInt();
+      }
+    }
+  }
+  return maxLevel;
+}

--- a/lib/features/player/models/player_bb_hero.dart
+++ b/lib/features/player/models/player_bb_hero.dart
@@ -9,7 +9,8 @@ class PlayerBuilderBaseHero extends PlayerItem {
       required super.level,
       required super.maxLevel,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'hero',
           imageUrl: ImageAssets.getBuilderBaseHeroImage(name),
@@ -38,6 +39,7 @@ class PlayerBuilderBaseHero extends PlayerItem {
       maxLevel: maxLevel,
       isUnlocked: isUnlocked,
       village: meta?['village'] ?? 'builderBase',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_bb_troop.dart
+++ b/lib/features/player/models/player_bb_troop.dart
@@ -11,7 +11,8 @@ class PlayerBuilderBaseTroop extends PlayerItem {
       required super.maxLevel,
       required this.superTroopIsActive,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'builderBase',
           imageUrl: ImageAssets.getBuilderBaseTroopImage(name),
@@ -43,6 +44,7 @@ class PlayerBuilderBaseTroop extends PlayerItem {
       isUnlocked: isUnlocked,
       superTroopIsActive: superTroopIsActive ?? false,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_equipment.dart
+++ b/lib/features/player/models/player_equipment.dart
@@ -12,7 +12,8 @@ class PlayerEquipment extends PlayerItem {
       required super.maxLevel,
       required this.rarity,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'gear',
           imageUrl: ImageAssets.getGearImage(name),
@@ -43,7 +44,8 @@ class PlayerEquipment extends PlayerItem {
       maxLevel: maxLevel,
       isUnlocked: isUnlocked,
       village: meta?['village'] ?? 'home',
-      rarity: meta?['rarity'] ?? '1',
+      rarity: meta?['rarity']?.toString() ?? '1',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_hero.dart
+++ b/lib/features/player/models/player_hero.dart
@@ -13,6 +13,7 @@ class PlayerHero extends PlayerItem {
     required this.village,
     required this.equipment,
     required super.isUnlocked,
+    super.meta,
   }) : super(
           type: 'hero',
           imageUrl: ImageAssets.getHeroImage(name),
@@ -44,6 +45,7 @@ class PlayerHero extends PlayerItem {
       level: level,
       maxLevel: maxLevel,
       isUnlocked: isUnlocked,
+      meta: meta,
       equipment: rawJson?['equipment'] != null
           ? List<PlayerEquipedEquipment>.from(rawJson!['equipment']
               .map((x) => PlayerEquipedEquipment.fromJson(x)))

--- a/lib/features/player/models/player_item.dart
+++ b/lib/features/player/models/player_item.dart
@@ -7,6 +7,7 @@ class PlayerItem {
   final bool isMaxLevel;
   final bool? isActive;
   final bool isUnlocked;
+  final Map<String, dynamic>? meta;
 
   PlayerItem({
     required this.name,
@@ -16,5 +17,6 @@ class PlayerItem {
     required this.imageUrl,
     required this.isUnlocked,
     this.isActive,
+    this.meta,
   }) : isMaxLevel = level == maxLevel;
 }

--- a/lib/features/player/models/player_pet.dart
+++ b/lib/features/player/models/player_pet.dart
@@ -8,7 +8,8 @@ class PlayerPet extends PlayerItem {
       {required super.name,
       required super.level,
       required super.maxLevel,
-      required this.village})
+      required this.village,
+      super.meta})
       : super(
           isUnlocked: true,
           type: 'pet',
@@ -36,6 +37,7 @@ class PlayerPet extends PlayerItem {
       level: level,
       maxLevel: maxLevel,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_siege_machine.dart
+++ b/lib/features/player/models/player_siege_machine.dart
@@ -9,7 +9,8 @@ class PlayerSiegeMachine extends PlayerItem {
       required super.level,
       required super.maxLevel,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'pet',
           imageUrl: ImageAssets.getSiegeMachineImage(name),
@@ -39,6 +40,7 @@ class PlayerSiegeMachine extends PlayerItem {
       maxLevel: maxLevel,
       isUnlocked: isUnlocked,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_spell.dart
+++ b/lib/features/player/models/player_spell.dart
@@ -9,7 +9,8 @@ class PlayerSpell extends PlayerItem {
       required super.level,
       required super.maxLevel,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'spell',
           imageUrl: ImageAssets.getSpellImage(name),
@@ -38,6 +39,7 @@ class PlayerSpell extends PlayerItem {
       maxLevel: maxLevel,
       isUnlocked: isUnlocked,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_super_troop.dart
+++ b/lib/features/player/models/player_super_troop.dart
@@ -11,7 +11,8 @@ class PlayerSuperTroop extends PlayerItem {
       required super.maxLevel,
       required this.superTroopIsActive,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'troop',
           imageUrl: ImageAssets.getSuperTroopImage(name),
@@ -43,6 +44,7 @@ class PlayerSuperTroop extends PlayerItem {
       isUnlocked: isUnlocked,
       superTroopIsActive: superTroopIsActive ?? false,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 }

--- a/lib/features/player/models/player_troop.dart
+++ b/lib/features/player/models/player_troop.dart
@@ -11,7 +11,8 @@ class PlayerTroop extends PlayerItem {
       required super.maxLevel,
       required this.superTroopIsActive,
       required this.village,
-      required super.isUnlocked})
+      required super.isUnlocked,
+      super.meta})
       : super(
           type: 'troop',
           imageUrl: ImageAssets.getTroopImage(name),
@@ -49,6 +50,7 @@ class PlayerTroop extends PlayerItem {
       isUnlocked: isUnlocked,
       superTroopIsActive: superTroopIsActive ?? false,
       village: meta?['village'] ?? 'home',
+      meta: meta,
     );
   }
 

--- a/lib/features/player/presentation/player/player_item_section.dart
+++ b/lib/features/player/presentation/player/player_item_section.dart
@@ -247,6 +247,17 @@ class PlayerItemSection extends StatelessWidget {
         ? GameDataService.localizedNameForItem(meta)
         : item.name;
 
+    // Level-based stats
+    final effectiveLevel = item.level > 0 ? item.level : 1;
+    final currentLevelStats = _findLevelStats(meta, effectiveLevel);
+    final nextLevelStats = (item.level > 0 && item.level < item.maxLevel)
+        ? _findLevelStats(meta, item.level + 1)
+        : null;
+    final currentDps = (currentLevelStats?['dps'] as num?)?.toInt() ?? 0;
+    final currentHp = (currentLevelStats?['hitpoints'] as num?)?.toInt() ?? 0;
+    final currentHeal =
+        (currentLevelStats?['heal_on_activation'] as num?)?.toInt() ?? 0;
+
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -355,6 +366,49 @@ class PlayerItemSection extends StatelessWidget {
                             value: meta['upgrade_resource'].toString(),
                           ),
                       ],
+                      // Level-based stats
+                      if (currentDps > 0)
+                        _buildStatRow(
+                          context,
+                          icon: Icons.bolt_outlined,
+                          label: l10n.gameItemDps,
+                          value: currentDps.toString(),
+                        ),
+                      if (!isEquipment && currentHp > 0)
+                        _buildStatRow(
+                          context,
+                          icon: Icons.favorite_border,
+                          label: l10n.gameItemHitpoints,
+                          value: currentHp.toString(),
+                        ),
+                      if (isEquipment && currentHeal > 0)
+                        _buildStatRow(
+                          context,
+                          icon: Icons.healing,
+                          label: l10n.gameItemHealOnActivation,
+                          value: currentHeal.toString(),
+                        ),
+                      // Targeting (non-equipment only)
+                      if (!isEquipment &&
+                          (meta['is_air_targeting'] != null ||
+                              meta['is_ground_targeting'] != null))
+                        _buildTargetingRow(context, meta, l10n),
+                    ],
+                    if (nextLevelStats != null) ...[
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 10),
+                        child: Divider(height: 1),
+                      ),
+                      _buildUpgradeCostRow(
+                          context, meta!, isEquipment, nextLevelStats, l10n),
+                      if ((nextLevelStats['upgrade_time'] as num? ?? 0) > 0)
+                        _buildStatRow(
+                          context,
+                          icon: Icons.timer_outlined,
+                          label: l10n.gameItemUpgradeTime,
+                          value: _formatUpgradeTime(
+                              (nextLevelStats['upgrade_time'] as num).toInt()),
+                        ),
                     ],
                     const SizedBox(height: 12),
                     TextButton(
@@ -440,5 +494,142 @@ class PlayerItemSection extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Widget _buildTargetingRow(
+    BuildContext context,
+    Map<String, dynamic> meta,
+    AppLocalizations l10n,
+  ) {
+    final isGround = meta['is_ground_targeting'] == true;
+    final isAir = meta['is_air_targeting'] == true;
+    final isFlying = meta['is_flying'] == true;
+
+    if (!isGround && !isAir && !isFlying) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Icon(Icons.gps_fixed_outlined,
+              size: 16, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l10n.gameItemTargets,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Wrap(
+            spacing: 4,
+            children: [
+              if (isGround)
+                _buildTargetChip(context, l10n.gameItemTargetsGround,
+                    Colors.green),
+              if (isAir)
+                _buildTargetChip(
+                    context, l10n.gameItemTargetsAir, Colors.blue),
+              if (isFlying)
+                _buildTargetChip(
+                    context, l10n.gameItemFlying, Colors.lightBlue),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTargetChip(
+      BuildContext context, String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withAlpha(40),
+        border: Border.all(color: color, width: 1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(color: color, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+
+  Widget _buildUpgradeCostRow(
+    BuildContext context,
+    Map<String, dynamic> meta,
+    bool isEquipment,
+    Map<String, dynamic> nextLevelStats,
+    AppLocalizations l10n,
+  ) {
+    final String costText;
+    if (isEquipment) {
+      final cost = nextLevelStats['upgrade_cost'];
+      if (cost is Map) {
+        final parts = <String>[];
+        final shiny = (cost['shiny_ore'] as num? ?? 0).toInt();
+        final glowy = (cost['glowy_ore'] as num? ?? 0).toInt();
+        final starry = (cost['starry_ore'] as num? ?? 0).toInt();
+        if (shiny > 0) parts.add('$shiny Shiny');
+        if (glowy > 0) parts.add('$glowy Glowy');
+        if (starry > 0) parts.add('$starry Starry');
+        costText = parts.join(' · ');
+      } else {
+        costText = '';
+      }
+    } else {
+      final cost = (nextLevelStats['upgrade_cost'] as num? ?? 0);
+      if (cost <= 0) return const SizedBox.shrink();
+      final resource = meta['upgrade_resource']?.toString() ?? '';
+      costText = '${_formatLargeNumber(cost)} $resource'.trim();
+    }
+
+    if (costText.isEmpty) return const SizedBox.shrink();
+    return _buildStatRow(
+      context,
+      icon: Icons.upgrade_outlined,
+      label: l10n.gameItemUpgradeCost,
+      value: costText,
+    );
+  }
+
+  static Map<String, dynamic>? _findLevelStats(
+      Map<String, dynamic>? meta, int level) {
+    if (meta == null) return null;
+    final levels = meta['levels'];
+    if (levels is! List) return null;
+    for (final entry in levels) {
+      if (entry is Map && entry['level'] == level) {
+        return Map<String, dynamic>.from(entry);
+      }
+    }
+    return null;
+  }
+
+  static String _formatUpgradeTime(int seconds) {
+    if (seconds <= 0) return '';
+    final d = seconds ~/ 86400;
+    final h = (seconds % 86400) ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    if (d > 0) return h > 0 ? '${d}d ${h}h' : '${d}d';
+    if (h > 0) return m > 0 ? '${h}h ${m}m' : '${h}h';
+    final s = seconds % 60;
+    if (m > 0) return s > 0 ? '${m}m ${s}s' : '${m}m';
+    return '${s}s';
+  }
+
+  static String _formatLargeNumber(num value) {
+    if (value >= 1000000) {
+      final formatted = (value / 1000000).toStringAsFixed(1);
+      return '${formatted.endsWith('.0') ? formatted.replaceAll('.0', '') : formatted}M';
+    }
+    if (value >= 1000) {
+      final formatted = (value / 1000).toStringAsFixed(1);
+      return '${formatted.endsWith('.0') ? formatted.replaceAll('.0', '') : formatted}K';
+    }
+    return value.toInt().toString();
   }
 }

--- a/lib/features/player/presentation/player/player_item_section.dart
+++ b/lib/features/player/presentation/player/player_item_section.dart
@@ -51,28 +51,32 @@ class PlayerItemSection extends StatelessWidget {
                     TextSpan(text: title),
                     if (items[0] is! PlayerSuperTroop) ...[
                       const TextSpan(text: ' | '),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        child: CachedNetworkImage(
+                          imageUrl: ImageAssets.townHall(townHallLevel),
+                          width: 16,
+                          height: 16,
+                        ),
+                      ),
                       TextSpan(
-                        text: '${_formatPercentage(completionPercentage)}%',
+                        text: ' ${_formatPercentage(thPercentage)}%',
                         style: Theme.of(context).textTheme.bodyLarge,
                       ),
-                      if (townHallLevel > 0) ...[
-                        TextSpan(
-                          text: ' (',
-                          style: Theme.of(context).textTheme.bodyLarge,
+                      const TextSpan(text: ' | '),
+                      WidgetSpan(
+                        alignment: PlaceholderAlignment.middle,
+                        child: CachedNetworkImage(
+                          imageUrl: ImageAssets.townHall(
+                              GameDataService.getMaxTownHallLevel()),
+                          width: 16,
+                          height: 16,
                         ),
-                        WidgetSpan(
-                          alignment: PlaceholderAlignment.middle,
-                          child: CachedNetworkImage(
-                            imageUrl: ImageAssets.townHall(townHallLevel),
-                            width: 16,
-                            height: 16,
-                          ),
-                        ),
-                        TextSpan(
-                          text: ' ${_formatPercentage(thPercentage)}%)',
-                          style: Theme.of(context).textTheme.bodyLarge,
-                        ),
-                      ],
+                      ),
+                      TextSpan(
+                        text: ' ${_formatPercentage(completionPercentage)}%',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
                     ]
                   ],
                 ),

--- a/lib/features/player/presentation/player/player_item_section.dart
+++ b/lib/features/player/presentation/player/player_item_section.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:clashkingapp/features/player/models/player_item.dart';
 import 'package:clashkingapp/features/player/models/player_super_troop.dart';
 import 'package:clashkingapp/features/player/models/player_equipment.dart';
+import 'package:clashkingapp/core/services/game_data_service.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:shimmer/shimmer.dart';
 
@@ -176,6 +177,15 @@ class PlayerItemSection extends StatelessWidget {
 
   void _showItemDialog(BuildContext context, PlayerItem item) {
     final isSuperTroop = item is PlayerSuperTroop;
+    final isEquipment = item is PlayerEquipment;
+    final l10n = AppLocalizations.of(context)!;
+    final meta = item.meta;
+    final description = meta != null
+        ? GameDataService.localizedInfoForItem(meta)
+        : null;
+    final localizedName = meta != null
+        ? GameDataService.localizedNameForItem(meta)
+        : item.name;
 
     showDialog(
       context: context,
@@ -184,38 +194,191 @@ class PlayerItemSection extends StatelessWidget {
           shape:
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                CachedNetworkImage(
-                  errorWidget: (context, url, error) => Icon(Icons.error),
-                  imageUrl: item.imageUrl,
-                  width: 80,
-                  height: 80,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.of(context).size.height * 0.75,
+            ),
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CachedNetworkImage(
+                      errorWidget: (context, url, error) =>
+                          const Icon(Icons.error),
+                      imageUrl: item.imageUrl,
+                      width: 80,
+                      height: 80,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      localizedName,
+                      style: Theme.of(context).textTheme.titleLarge,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      isSuperTroop
+                          ? (item.superTroopIsActive
+                              ? l10n.generalActive
+                              : l10n.generalInactive)
+                          : l10n.gameLevel(item.level, item.maxLevel),
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    if (description != null && description.isNotEmpty) ...[
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 10),
+                        child: Divider(height: 1),
+                      ),
+                      Text(
+                        description,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurface
+                                  .withAlpha(200),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    if (meta != null && !isSuperTroop) ...[
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 10),
+                        child: Divider(height: 1),
+                      ),
+                      if (isEquipment) ...[
+                        if (meta['hero'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.person,
+                            label: l10n.gameItemHero,
+                            value: meta['hero'].toString(),
+                          ),
+                        if (meta['rarity_label'] != null)
+                          _buildRarityRow(context, l10n, meta),
+                      ] else ...[
+                        if (meta['housing_space'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.home_outlined,
+                            label: l10n.gameItemHousingSpace,
+                            value: meta['housing_space'].toString(),
+                          ),
+                        if (meta['attack_speed'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.speed_outlined,
+                            label: l10n.gameItemAttackSpeed,
+                            value:
+                                '${((meta['attack_speed'] as num) / 1000).toStringAsFixed(1)}s',
+                          ),
+                        if (meta['attack_range'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.my_location_outlined,
+                            label: l10n.gameItemAttackRange,
+                            value: meta['attack_range'].toString(),
+                          ),
+                        if (meta['movement_speed'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.directions_run_outlined,
+                            label: l10n.gameItemMovementSpeed,
+                            value: meta['movement_speed'].toString(),
+                          ),
+                        if (meta['upgrade_resource'] != null)
+                          _buildStatRow(
+                            context,
+                            icon: Icons.water_drop_outlined,
+                            label: l10n.gameItemUpgradeResource,
+                            value: meta['upgrade_resource'].toString(),
+                          ),
+                      ],
+                    ],
+                    const SizedBox(height: 12),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text(l10n.generalOk),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 12),
-                Text(
-                  item.name,
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  isSuperTroop
-                      ? (item.superTroopIsActive
-                          ? AppLocalizations.of(context)!.generalActive
-                          : AppLocalizations.of(context)!.generalInactive)
-                      : AppLocalizations.of(context)
-                              ?.gameLevel(item.level, item.maxLevel) ??
-                          "Level: ${item.level}/${item.maxLevel}",
-                  style: Theme.of(context).textTheme.bodyMedium,
-                ),
-              ],
+              ),
             ),
           ),
         );
       },
+    );
+  }
+
+  Widget _buildStatRow(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRarityRow(
+    BuildContext context,
+    AppLocalizations l10n,
+    Map<String, dynamic> meta,
+  ) {
+    final rarityLabel = meta['rarity_label']?.toString() ?? '';
+    final isEpic = meta['rarity']?.toString() == '2';
+    final color = isEpic ? Colors.purple : Colors.blue;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Icon(Icons.diamond_outlined,
+              size: 16, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l10n.gameItemRarity,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: color.withAlpha(40),
+              border: Border.all(color: color, width: 1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              rarityLabel,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/player/presentation/player/player_item_section.dart
+++ b/lib/features/player/presentation/player/player_item_section.dart
@@ -5,17 +5,21 @@ import 'package:clashkingapp/features/player/models/player_item.dart';
 import 'package:clashkingapp/features/player/models/player_super_troop.dart';
 import 'package:clashkingapp/features/player/models/player_equipment.dart';
 import 'package:clashkingapp/core/services/game_data_service.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/player/data/player_item_utils.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:shimmer/shimmer.dart';
 
 class PlayerItemSection extends StatelessWidget {
   final String title;
   final List<PlayerItem> items;
+  final int townHallLevel;
 
   const PlayerItemSection({
     super.key,
     required this.title,
     required this.items,
+    required this.townHallLevel,
   });
 
   @override
@@ -23,6 +27,7 @@ class PlayerItemSection extends StatelessWidget {
     if (items.isEmpty) return const SizedBox.shrink();
 
     final completionPercentage = _calculateCompletionPercentage();
+    final thPercentage = _calculateTHCompletionPercentage();
 
     final sortedItems = [...items]..sort((a, b) {
         if (a.isUnlocked == b.isUnlocked) return 0;
@@ -47,11 +52,27 @@ class PlayerItemSection extends StatelessWidget {
                     if (items[0] is! PlayerSuperTroop) ...[
                       const TextSpan(text: ' | '),
                       TextSpan(
-                        text: completionPercentage % 1 == 0
-                            ? '${completionPercentage.toInt()}%'
-                            : '${completionPercentage.toStringAsFixed(2)}%',
+                        text: '${_formatPercentage(completionPercentage)}%',
                         style: Theme.of(context).textTheme.bodyLarge,
                       ),
+                      if (townHallLevel > 0) ...[
+                        TextSpan(
+                          text: ' (',
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
+                        WidgetSpan(
+                          alignment: PlaceholderAlignment.middle,
+                          child: CachedNetworkImage(
+                            imageUrl: ImageAssets.townHall(townHallLevel),
+                            width: 16,
+                            height: 16,
+                          ),
+                        ),
+                        TextSpan(
+                          text: ' ${_formatPercentage(thPercentage)}%)',
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
+                      ],
                     ]
                   ],
                 ),
@@ -79,16 +100,39 @@ class PlayerItemSection extends StatelessWidget {
     return (totalAchieved / totalPossible) * 100;
   }
 
+  double _calculateTHCompletionPercentage() {
+    int totalPossible = 0;
+    int totalAchieved = 0;
+    for (final item in items) {
+      final thMax = maxLevelForTH(item.meta, townHallLevel);
+      if (thMax <= 0) continue;
+      totalPossible += thMax;
+      totalAchieved += item.level > thMax ? thMax : item.level;
+    }
+    if (totalPossible == 0) return 0;
+    return (totalAchieved / totalPossible) * 100;
+  }
+
+  String _formatPercentage(double pct) {
+    return pct % 1 == 0
+        ? pct.toInt().toString()
+        : pct.toStringAsFixed(2);
+  }
+
   Widget _buildItemTile(BuildContext context, PlayerItem item) {
     final isMax = item.level == item.maxLevel;
     final isLocked = !item.isUnlocked;
+    final thMaxLevel = maxLevelForTH(item.meta, townHallLevel);
+    final isTHMax = thMaxLevel > 0 && item.level >= thMaxLevel && !isMax;
 
     // Determine border color
     final borderColor = isLocked || item.level == 0
         ? Colors.grey
         : isMax
-            ? const Color(0xFFD4AF37) // Gold if max
-            : Theme.of(context).colorScheme.onSurface;
+            ? const Color(0xFFD4AF37) // Gold if overall max
+            : isTHMax
+                ? const Color(0xFFCD7F32) // Bronze if TH max
+                : Theme.of(context).colorScheme.onSurface;
 
     // Background color for unlocked PlayerEquipment
     Color? backgroundColor;
@@ -137,12 +181,12 @@ class PlayerItemSection extends StatelessWidget {
                   height: 16,
                   width: 20,
                   decoration: BoxDecoration(
-                    color: isMax ? Colors.transparent : Colors.black,
+                    color: (isMax || isTHMax) ? Colors.transparent : Colors.black,
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Stack(
                     children: [
-                      if (isMax && (!isLocked || item.level > 0))
+                      if (isMax)
                         Shimmer.fromColors(
                           baseColor: const Color(0xFFD4AF37),
                           highlightColor:
@@ -150,6 +194,18 @@ class PlayerItemSection extends StatelessWidget {
                           child: Container(
                             decoration: BoxDecoration(
                               color: const Color(0xFFD4AF37),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                        )
+                      else if (isTHMax)
+                        Shimmer.fromColors(
+                          baseColor: const Color(0xFFCD7F32),
+                          highlightColor:
+                              const Color(0xFFCD7F32).withAlpha(180),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFCD7F32),
                               borderRadius: BorderRadius.circular(4),
                             ),
                           ),

--- a/lib/features/player/presentation/player/player_page.dart
+++ b/lib/features/player/presentation/player/player_page.dart
@@ -78,19 +78,29 @@ class PlayerScreenState extends State<PlayerScreen>
         SizedBox(height: 10),
         PlayerSuperTroopSection(superTroops: player.superTroops),
         PlayerItemSection(
-            title: AppLocalizations.of(context)!.gameHeroes, items: player.heroes),
+            title: AppLocalizations.of(context)!.gameHeroes,
+            items: player.heroes,
+            townHallLevel: player.townHallLevel),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameEquipment,
-            items: player.equipments),
+            items: player.equipments,
+            townHallLevel: player.townHallLevel),
         PlayerItemSection(
-            title: AppLocalizations.of(context)!.gameTroops, items: player.troops),
+            title: AppLocalizations.of(context)!.gameTroops,
+            items: player.troops,
+            townHallLevel: player.townHallLevel),
         PlayerItemSection(
-            title: AppLocalizations.of(context)!.gameSpells, items: player.spells),
+            title: AppLocalizations.of(context)!.gameSpells,
+            items: player.spells,
+            townHallLevel: player.townHallLevel),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameSiegeMachines,
-            items: player.siegeMachines),
+            items: player.siegeMachines,
+            townHallLevel: player.townHallLevel),
         PlayerItemSection(
-            title: AppLocalizations.of(context)!.gamePets, items: player.pets),
+            title: AppLocalizations.of(context)!.gamePets,
+            items: player.pets,
+            townHallLevel: player.townHallLevel),
         SizedBox(height: 10),
       ],
     );
@@ -102,10 +112,12 @@ class PlayerScreenState extends State<PlayerScreen>
         SizedBox(height: 10),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameHeroes,
-            items: player.bbHeroes),
+            items: player.bbHeroes,
+            townHallLevel: player.builderHallLevel),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameTroops,
-            items: player.bbTroops),
+            items: player.bbTroops,
+            townHallLevel: player.builderHallLevel),
         SizedBox(height: 10),
       ],
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2117,5 +2117,12 @@
         "description": "Error details"
       }
     }
-  }
+  },
+  "gameItemHousingSpace": "Housing Space",
+  "gameItemAttackSpeed": "Attack Speed",
+  "gameItemAttackRange": "Attack Range",
+  "gameItemMovementSpeed": "Movement Speed",
+  "gameItemUpgradeResource": "Upgrade Resource",
+  "gameItemRarity": "Rarity",
+  "gameItemHero": "Hero"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2124,5 +2124,14 @@
   "gameItemMovementSpeed": "Movement Speed",
   "gameItemUpgradeResource": "Upgrade Resource",
   "gameItemRarity": "Rarity",
-  "gameItemHero": "Hero"
+  "gameItemHero": "Hero",
+  "gameItemDps": "DPS",
+  "gameItemHitpoints": "HP",
+  "gameItemHealOnActivation": "Heal",
+  "gameItemTargets": "Targets",
+  "gameItemTargetsGround": "Ground",
+  "gameItemTargetsAir": "Air",
+  "gameItemFlying": "Flying",
+  "gameItemUpgradeCost": "Upgrade cost",
+  "gameItemUpgradeTime": "Upgrade time"
 }

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,5 +1,8 @@
-﻿What’s new
+What’s new
 - Tapping a troop, spell, hero, equipment or pet now shows a detailed popup with description and stats (housing space, attack speed, range, movement speed, upgrade resource, hero and rarity for equipment)
+- Item popup now shows DPS, HP/Heal at current level, targeting type (Ground/Air/Flying), and next-level upgrade cost & time
+- Player item sections now show two progress percentages: current TH max-level completion and overall max-level completion
+- Town-hall-maxed items now have a bronze border indicator
 - Player league chips now show the league name instead of raw trophy counts
 - Player item icons now resolve directly from ClashKing assets instead of app-data image URLs
 - Seasonal event troops and spells are now hidden consistently in player progression lists

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,4 +1,5 @@
-What’s new
+﻿What’s new
+- Tapping a troop, spell, hero, equipment or pet now shows a detailed popup with description and stats (housing space, attack speed, range, movement speed, upgrade resource, hero and rarity for equipment)
 - Player league chips now show the league name instead of raw trophy counts
 - Player item icons now resolve directly from ClashKing assets instead of app-data image URLs
 - Seasonal event troops and spells are now hidden consistently in player progression lists


### PR DESCRIPTION
- Add meta field to PlayerItem base class to store bundle metadata
- Update all 9 subclasses to forward meta through constructors and fromRaw factories
- Rewrite _showItemDialog with localized name, description, and stats:
  - Troops/heroes/pets: housing space, attack speed, range, movement speed, upgrade resource
  - Spells: housing space, upgrade resource
  - Equipment: hero name and rarity chip (Common/Epic)
- Add l10n keys: gameItemHousingSpace, gameItemAttackSpeed, gameItemAttackRange,
  gameItemMovementSpeed, gameItemUpgradeResource, gameItemRarity, gameItemHero