### PR TITLE
fix: resolve SonarCloud issues - const, security, duplicate literals

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,6 +16,7 @@ linter:
     use_key_in_widget_constructors: true
     prefer_const_literals_to_create_immutables: true
     prefer_const_constructors_in_immutables: true
+    prefer_const_declarations: true
     avoid_print: false
     use_null_aware_elements: false
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,11 +11,11 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    prefer_const_constructors: false
-    prefer_final_fields: false
-    use_key_in_widget_constructors: false
-    prefer_const_literals_to_create_immutables: false
-    prefer_const_constructors_in_immutables: false
+    prefer_const_constructors: true
+    prefer_final_fields: true
+    use_key_in_widget_constructors: true
+    prefer_const_literals_to_create_immutables: true
+    prefer_const_constructors_in_immutables: true
     avoid_print: false
     use_null_aware_elements: false
 

--- a/lib/common/widgets/app_bar/app_bar.dart
+++ b/lib/common/widgets/app_bar/app_bar.dart
@@ -9,8 +9,10 @@ import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/features/settings/presentation/settings_page.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const CustomAppBar({super.key});
+
   @override
-  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +44,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => AddCocAccountPage(),
+                builder: (context) => const AddCocAccountPage(),
               ),
             );
           }
@@ -58,10 +60,10 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
                     width: 30,
                     child: CachedNetworkImage(
                       imageUrl: profile.townHallPic,
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                     ),
                   ),
-                  SizedBox(width: 4),
+                  const SizedBox(width: 4),
                   Text(
                     profile.name,
                     overflow: TextOverflow.ellipsis,
@@ -76,8 +78,8 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
             value: "manageAccounts",
             child: Row(
               children: <Widget>[
-                Icon(Icons.settings),
-                SizedBox(width: 4),
+                const Icon(Icons.settings),
+                const SizedBox(width: 4),
                 Text(AppLocalizations.of(context)?.generalManage ?? 'Manage'),
               ],
             ),
@@ -92,7 +94,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
               style: Theme.of(context).textTheme.bodyMedium,
               overflow: TextOverflow.ellipsis,
             ),
-            SizedBox(width: 5),
+            const SizedBox(width: 5),
             GestureDetector(
               onTap: () {
                 Navigator.push(
@@ -108,14 +110,14 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
                   child: CachedNetworkImage(
                     imageUrl: authService.currentUser?.avatarUrl ?? "",
                     fit: BoxFit.cover,
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                   ),
                 ),
               ),
             ),
           ],
         ),
-        SizedBox(width: 16),
+        const SizedBox(width: 16),
       ],
     );
   }

--- a/lib/common/widgets/app_bar/coc_accounts_app_bar.dart
+++ b/lib/common/widgets/app_bar/coc_accounts_app_bar.dart
@@ -5,6 +5,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class CocAccountsAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const CocAccountsAppBar({super.key});
+
   @override
   Size get preferredSize => const Size.fromHeight(60.0);
 
@@ -15,7 +17,7 @@ class CocAccountsAppBar extends StatelessWidget implements PreferredSizeWidget {
 
     return AppBar(
       leading: IconButton(
-        icon: Icon(Icons.logout),
+        icon: const Icon(Icons.logout),
         tooltip: AppLocalizations.of(context)!.authLogout,
         onPressed: () async {
           final authService = context.read<AuthService>();
@@ -32,7 +34,7 @@ class CocAccountsAppBar extends StatelessWidget implements PreferredSizeWidget {
                     overflow: TextOverflow.ellipsis,
                   )
                 : Text(AppLocalizations.of(context)!.generalLoading),
-            Padding(padding: EdgeInsets.all(5)),
+            const Padding(padding: EdgeInsets.all(5)),
             CircleAvatar(
               radius: 20,
               backgroundColor: Colors.transparent,
@@ -42,13 +44,13 @@ class CocAccountsAppBar extends StatelessWidget implements PreferredSizeWidget {
                         imageUrl: user.avatarUrl,
                         fit: BoxFit.cover,
                         placeholder: (context, url) =>
-                            CircularProgressIndicator(),
-                        errorWidget: (context, url, error) => Icon(Icons.error),
+                            const CircularProgressIndicator(),
+                        errorWidget: (context, url, error) => const Icon(Icons.error),
                       )
                     : null,
               ),
             ),
-            SizedBox(width: 16),
+            const SizedBox(width: 16),
           ],
         ),
       ],

--- a/lib/common/widgets/buttons/chip.dart
+++ b/lib/common/widgets/buttons/chip.dart
@@ -13,7 +13,7 @@ class ImageChip extends StatefulWidget {
   final BuildContext? context;
   final GestureTapCallback? onTap;
 
-  ImageChip({
+  const ImageChip({super.key, 
     required this.imageUrl,
     this.label = '',
     this.labelWidget = const SizedBox(),
@@ -41,7 +41,7 @@ class ImageChipState extends State<ImageChip> {
       _timer?.cancel();
     } else {
       tooltip?.ensureTooltipVisible();
-      _timer = Timer(Duration(seconds: 5), () {
+      _timer = Timer(const Duration(seconds: 5), () {
         tooltip?.deactivate();
         setState(() {
           _isTooltipVisible = false;
@@ -99,8 +99,8 @@ class ImageChipState extends State<ImageChip> {
                     .textTheme
                     .bodyMedium
                     ?.copyWith(color: Theme.of(context).colorScheme.onSurface),
-                showDuration: Duration(seconds: 5),
-                margin: EdgeInsets.symmetric(horizontal: 64),
+                showDuration: const Duration(seconds: 5),
+                margin: const EdgeInsets.symmetric(horizontal: 64),
                 decoration: BoxDecoration(
                   color: Theme.of(context)
                       .scaffoldBackgroundColor
@@ -111,7 +111,7 @@ class ImageChipState extends State<ImageChip> {
                       color: Colors.black.withValues(alpha: 0.1),
                       spreadRadius: 2,
                       blurRadius: 2,
-                      offset: Offset(0, 1),
+                      offset: const Offset(0, 1),
                     ),
                   ],
                 ),
@@ -133,7 +133,7 @@ class IconChip extends StatefulWidget {
   final BuildContext? context;
   final GestureTapCallback? onTap;
 
-  IconChip({
+  const IconChip({super.key, 
     required this.icon,
     required this.label,
     this.size = 24,
@@ -163,7 +163,7 @@ class IconChipState extends State<IconChip> {
     } else {
       tooltip?.ensureTooltipVisible();
       _timer?.cancel();
-      _timer = Timer(Duration(seconds: 5), () {
+      _timer = Timer(const Duration(seconds: 5), () {
         if (_isTooltipVisible) {
           tooltip?.deactivate();
           if (mounted) {
@@ -219,7 +219,7 @@ class IconChipState extends State<IconChip> {
                   .textTheme
                   .bodyMedium
                   ?.copyWith(color: Theme.of(context).colorScheme.onSurface),
-              margin: EdgeInsets.symmetric(horizontal: 64),
+              margin: const EdgeInsets.symmetric(horizontal: 64),
               decoration: BoxDecoration(
                 color: Theme.of(context)
                     .scaffoldBackgroundColor
@@ -230,7 +230,7 @@ class IconChipState extends State<IconChip> {
                     color: Colors.black.withValues(alpha: 0.1),
                     spreadRadius: 2,
                     blurRadius: 2,
-                    offset: Offset(0, 1),
+                    offset: const Offset(0, 1),
                   ),
                 ],
               ),
@@ -258,7 +258,7 @@ class CustomChip extends StatefulWidget {
   final double labelPadding;
   final String description;
 
-  CustomChip({
+  const CustomChip({super.key, 
     required this.icon,
     required this.label,
     this.size = 24,
@@ -285,7 +285,7 @@ class CustomChipState extends State<CustomChip> {
     } else {
       tooltip?.ensureTooltipVisible();
       _timer?.cancel();
-      _timer = Timer(Duration(seconds: 5), () {
+      _timer = Timer(const Duration(seconds: 5), () {
         if (_isTooltipVisible) {
           tooltip?.deactivate();
           if (mounted) {
@@ -317,7 +317,7 @@ class CustomChipState extends State<CustomChip> {
             .textTheme
             .bodyMedium
             ?.copyWith(color: Theme.of(context).colorScheme.onSurface),
-        margin: EdgeInsets.symmetric(horizontal: 64),
+        margin: const EdgeInsets.symmetric(horizontal: 64),
         decoration: BoxDecoration(
           color:
               Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.9),
@@ -327,7 +327,7 @@ class CustomChipState extends State<CustomChip> {
               color: Colors.black.withValues(alpha: 0.1),
               spreadRadius: 2,
               blurRadius: 2,
-              offset: Offset(0, 1),
+              offset: const Offset(0, 1),
             ),
           ],
         ),

--- a/lib/common/widgets/buttons/info_button.dart
+++ b/lib/common/widgets/buttons/info_button.dart
@@ -4,7 +4,7 @@ class InfoButton extends StatefulWidget {
   final TextSpan textSpan;
   final String title;
 
-  InfoButton({
+  const InfoButton({super.key, 
     required this.textSpan,
     required this.title,
   });
@@ -41,7 +41,7 @@ void showInfoPopup(BuildContext context, TextSpan textSpan, String title) {
         ),
         actions: <Widget>[
           TextButton(
-            child: Text('OK'),
+            child: const Text('OK'),
             onPressed: () {
               Navigator.of(context).pop();
             },

--- a/lib/common/widgets/buttons/pulsating_chip.dart
+++ b/lib/common/widgets/buttons/pulsating_chip.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class PulsatingChip extends StatefulWidget {
   final Widget child;
 
-  PulsatingChip({required this.child});
+  const PulsatingChip({super.key, required this.child});
 
   @override
   PulsatingChipState createState() => PulsatingChipState();

--- a/lib/common/widgets/buttons/war_button.dart
+++ b/lib/common/widgets/buttons/war_button.dart
@@ -19,13 +19,13 @@ Widget buildWarButton(BuildContext context,
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          MobileWebImage(
+          const MobileWebImage(
             width: 20,
             imageUrl: ImageAssets.war,
           ),
-          SizedBox(width: 8),
+          const SizedBox(width: 8),
           Shimmer.fromColors(
-            period: Duration(seconds: 3),
+            period: const Duration(seconds: 3),
             baseColor: Colors.white,
             highlightColor: Colors.white.withValues(alpha: 0.4),
             child: Text(label, style: Theme.of(context).textTheme.bodyMedium),

--- a/lib/common/widgets/error/error_page.dart
+++ b/lib/common/widgets/error/error_page.dart
@@ -10,7 +10,7 @@ class ErrorPage extends StatefulWidget {
   final Future<void> Function() onRetry;
   final bool isNetworkError;
 
-  ErrorPage({super.key, required this.onRetry, this.isNetworkError = false});
+  const ErrorPage({super.key, required this.onRetry, this.isNetworkError = false});
 
   @override
   State<ErrorPage> createState() => _ErrorPageState();
@@ -23,7 +23,7 @@ class _ErrorPageState extends State<ErrorPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
-      appBar: CocAccountsAppBar(),
+      appBar: const CocAccountsAppBar(),
       body: SingleChildScrollView(
         child: Center(
           child: ConstrainedBox(
@@ -56,7 +56,7 @@ class _ErrorPageState extends State<ErrorPage> {
                               ),
                             ),
                           ),
-                        MobileWebImage(
+                        const MobileWebImage(
                           imageUrl: ImageAssets.sleepingApprenticeBuilder,
                           fit: BoxFit.contain,
                         ),
@@ -78,7 +78,7 @@ class _ErrorPageState extends State<ErrorPage> {
                                   ),
                                 ],
                               ),
-                              child: Icon(
+                              child: const Icon(
                                 Icons.wifi_off,
                                 color: Colors.white,
                                 size: 20,
@@ -158,7 +158,7 @@ class _ErrorPageState extends State<ErrorPage> {
                         elevation: _isRetrying ? 1 : 3,
                       ),
                       icon: _isRetrying 
-                          ? SizedBox(
+                          ? const SizedBox(
                               width: 20,
                               height: 20,
                               child: CircularProgressIndicator(
@@ -212,7 +212,7 @@ class _ErrorPageState extends State<ErrorPage> {
                               ),
                         ),
                         style: TextButton.styleFrom(
-                          padding: EdgeInsets.symmetric(
+                          padding: const EdgeInsets.symmetric(
                               horizontal: 8, vertical: 4),
                         ),
                       ),

--- a/lib/common/widgets/icons/build_stars.dart
+++ b/lib/common/widgets/icons/build_stars.dart
@@ -9,7 +9,7 @@ Widget buildStarsIcon(int filledStars) {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 1),
           child: i < filledStars
-              ? MobileWebImage(
+              ? const MobileWebImage(
                   imageUrl: ImageAssets.attackStar, width: 12, height: 12)
               : const Icon(Icons.star_border, size: 14),
         ),

--- a/lib/common/widgets/icons/excel_download_icon.dart
+++ b/lib/common/widgets/icons/excel_download_icon.dart
@@ -12,7 +12,11 @@ class DownloadCwlExcelButton extends StatefulWidget {
   final String url;
   final String fileName;
 
-  const DownloadCwlExcelButton({super.key, required this.url, required this.fileName});
+  const DownloadCwlExcelButton({
+    super.key,
+    required this.url,
+    required this.fileName,
+  });
 
   @override
   State<DownloadCwlExcelButton> createState() => _DownloadCwlExcelButtonState();
@@ -44,11 +48,11 @@ class _DownloadCwlExcelButtonState extends State<DownloadCwlExcelButton> {
           ..click();
         html.Url.revokeObjectUrl(urlBlob);
       } else {
-        final dir = Platform.isAndroid || Platform.isIOS
-            ? await getExternalStorageDirectory()
-            : await getDownloadsDirectory();
+        final dir =
+            await getDownloadsDirectory() ??
+            await getApplicationDocumentsDirectory();
 
-        final filePath = '${dir!.path}/$filename';
+        final filePath = '${dir.path}/$filename';
         final file = File(filePath);
         await file.writeAsBytes(bytes);
 
@@ -56,7 +60,7 @@ class _DownloadCwlExcelButtonState extends State<DownloadCwlExcelButton> {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(content: Text(loc.downloadSuccess(filePath))),
           );
-          try{
+          try {
             await OpenFilex.open(filePath);
           } catch (e) {
             DebugUtils.debugError(' Error opening file : $e');
@@ -66,9 +70,9 @@ class _DownloadCwlExcelButtonState extends State<DownloadCwlExcelButton> {
     } catch (e) {
       DebugUtils.debugError(' Error downloading file : $e');
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(loc.downloadError)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(loc.downloadError)));
       }
     } finally {
       if (mounted) {
@@ -94,9 +98,9 @@ class _DownloadCwlExcelButtonState extends State<DownloadCwlExcelButton> {
             icon: const Icon(Icons.download),
             tooltip: loc.downloadTooltip,
             onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(loc.downloadInProgress)),
-              );
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(SnackBar(content: Text(loc.downloadInProgress)));
               downloadExcel(context);
             },
           );

--- a/lib/common/widgets/labels/beta_label.dart
+++ b/lib/common/widgets/labels/beta_label.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class BetaLabel extends StatelessWidget {
+  const BetaLabel({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Positioned(
@@ -10,11 +12,11 @@ class BetaLabel extends StatelessWidget {
       child: GestureDetector(
         onTap: () => showBetaPopup(context),
         child: Container(
-          padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.primary,
             borderRadius: BorderRadius.circular(8),
-            boxShadow: [
+            boxShadow: const [
               BoxShadow(
                 color: Colors.black26,
                 blurRadius: 4,
@@ -44,7 +46,7 @@ void showBetaPopup(BuildContext context) {
         content: Text(AppLocalizations.of(context)!.betaDescription),
         actions: <Widget>[
           TextButton(
-            child: Text('OK'),
+            child: const Text('OK'),
             onPressed: () {
               Navigator.of(context).pop();
             },

--- a/lib/core/app/my_app.dart
+++ b/lib/core/app/my_app.dart
@@ -19,7 +19,7 @@ FutureOr<void> backgroundCallback(Uri? data) async {
 }
 
 class MyApp extends StatelessWidget {
-  MyApp({super.key});
+  const MyApp({super.key});
 
   static final ThemeData darkTheme = ThemeData(
     scaffoldBackgroundColor: const Color.fromARGB(255, 61, 60, 60),
@@ -210,7 +210,7 @@ class MyApp extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           themeMode: Provider.of<ThemeNotifier>(context).themeMode,
           locale: appState.locale,
-          localizationsDelegates: [
+          localizationsDelegates: const [
             AppLocalizations.delegate,
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
@@ -222,7 +222,7 @@ class MyApp extends StatelessWidget {
           title: 'ClashKing',
           darkTheme: darkTheme,
           theme: lightTheme,
-          home: StartupWidget(),
+          home: const StartupWidget(),
         );
       },
     );

--- a/lib/core/app/my_app_state.dart
+++ b/lib/core/app/my_app_state.dart
@@ -13,7 +13,7 @@ class MyAppState extends ChangeNotifier {
   }
 
   final WarWidgetSyncService _warWidgetSyncService;
-  Locale _locale = Locale('en'); // Default language is English
+  Locale _locale = const Locale('en'); // Default language is English
   Locale get locale => _locale; // Getter for the locale
   bool isLoading = false; // Loading state of the app
 
@@ -46,7 +46,7 @@ class MyAppState extends ChangeNotifier {
       }
     }
 
-    return Locale('en'); // Fallback to English
+    return const Locale('en'); // Fallback to English
   }
 
 // Load the language from the shared preferences or set to the system locale

--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -47,7 +47,7 @@ class MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar(),
+      appBar: const CustomAppBar(),
       body: PageView(
         controller: _pageController,
         onPageChanged: _onPageChanged,
@@ -64,15 +64,15 @@ class MyHomePageState extends State<MyHomePage> {
         unselectedItemColor: Theme.of(context).colorScheme.tertiary,
         items: [
           BottomNavigationBarItem(
-            icon: Icon(Icons.dashboard),
+            icon: const Icon(Icons.dashboard),
             label: AppLocalizations.of(context)?.dashboardTitle ?? 'Dashboard',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.shield),
+            icon: const Icon(Icons.shield),
             label: AppLocalizations.of(context)?.clanTitle ?? 'Clan',
           ),
           BottomNavigationBarItem(
-            icon: Icon(CustomIcons.swordCross),
+            icon: const Icon(CustomIcons.swordCross),
             label: AppLocalizations.of(context)?.warLeague ?? 'War/League',
           ),
           /*BottomNavigationBarItem(

--- a/lib/core/constants/layout_constants.dart
+++ b/lib/core/constants/layout_constants.dart
@@ -1,2 +1,8 @@
+import 'package:flutter/foundation.dart';
+
 /// The maximum width for the app content on larger screens (desktop/tablet).
 const double kMaxContentWidth = 800.0;
+
+/// Vertical spacing between chip rows.
+/// Negative on mobile compensates for chip internal padding; positive on web avoids row overlap.
+double get kChipRunSpacing => kIsWeb ? 4.0 : -7.0;

--- a/lib/core/functions/functions.dart
+++ b/lib/core/functions/functions.dart
@@ -7,18 +7,20 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'dart:io' show Platform;
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
-final storage = const FlutterSecureStorage();
+const storage = FlutterSecureStorage();
 
 Future<void> storePrefs(String name, String token) async {
   try {
     await storage.write(key: name, value: token);
   } catch (exception, stackTrace) {
-    final hint = Hint.withMap(
-        {'message': 'Error storing prefs', 'name': name});
-    Sentry.captureException(exception, stackTrace: stackTrace,
-        withScope: (scope) {
-      scope.setContexts('Storage Context', hint);
-    });
+    final hint = Hint.withMap({'message': 'Error storing prefs', 'name': name});
+    Sentry.captureException(
+      exception,
+      stackTrace: stackTrace,
+      withScope: (scope) {
+        scope.setContexts('Storage Context', hint);
+      },
+    );
   }
 }
 
@@ -92,7 +94,9 @@ String getEndedAgoText(DateTime? endTime, material.BuildContext context) {
   if (difference.inMinutes < 1) {
     return l10n.timeEndedJustNow; // "Ended just now"
   } else if (difference.inMinutes < 60) {
-    return l10n.timeEndedMinutesAgo(difference.inMinutes); // "Ended X minutes ago"
+    return l10n.timeEndedMinutesAgo(
+      difference.inMinutes,
+    ); // "Ended X minutes ago"
   } else if (difference.inHours < 24) {
     return l10n.timeEndedHoursAgo(difference.inHours); // "Ended X hours ago"
   } else {
@@ -150,14 +154,17 @@ String formatSecondsToHHMM(double seconds) {
 DateTime findLastMondayOfMonth(int year, int month) {
   DateTime firstDayOfNextMonth = DateTime(year, month + 1, 1);
 
-  DateTime lastDayOfMonth = firstDayOfNextMonth.subtract(const Duration(days: 1));
+  DateTime lastDayOfMonth = firstDayOfNextMonth.subtract(
+    const Duration(days: 1),
+  );
 
   int weekdayOfLastDay = lastDayOfMonth.weekday;
 
   int daysToLastMonday = (weekdayOfLastDay - DateTime.monday) % 7;
 
-  DateTime lastMondayOfMonth =
-      lastDayOfMonth.subtract(Duration(days: daysToLastMonday));
+  DateTime lastMondayOfMonth = lastDayOfMonth.subtract(
+    Duration(days: daysToLastMonday),
+  );
 
   return lastMondayOfMonth;
 }

--- a/lib/core/functions/functions.dart
+++ b/lib/core/functions/functions.dart
@@ -7,7 +7,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'dart:io' show Platform;
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
-final storage = FlutterSecureStorage();
+final storage = const FlutterSecureStorage();
 
 Future<void> storePrefs(String name, String token) async {
   try {
@@ -150,7 +150,7 @@ String formatSecondsToHHMM(double seconds) {
 DateTime findLastMondayOfMonth(int year, int month) {
   DateTime firstDayOfNextMonth = DateTime(year, month + 1, 1);
 
-  DateTime lastDayOfMonth = firstDayOfNextMonth.subtract(Duration(days: 1));
+  DateTime lastDayOfMonth = firstDayOfNextMonth.subtract(const Duration(days: 1));
 
   int weekdayOfLastDay = lastDayOfMonth.weekday;
 

--- a/lib/core/functions/legend_functions.dart
+++ b/lib/core/functions/legend_functions.dart
@@ -26,8 +26,8 @@ DateTime findSeasonStartDate(DateTime date) {
   date = DateTime.utc(year, month, day, 0, 0, 0, 0);
 
   DateTime lastDayCurrentMonth = (month == 12)
-      ? DateTime.utc(year + 1, 1, 1).subtract(Duration(days: 1))
-      : DateTime.utc(year, month + 1, 1).subtract(Duration(days: 1));
+      ? DateTime.utc(year + 1, 1, 1).subtract(const Duration(days: 1))
+      : DateTime.utc(year, month + 1, 1).subtract(const Duration(days: 1));
 
   int daysToLastMondayOfCurrentMonth =
       (lastDayCurrentMonth.weekday - DateTime.monday + 7) % 7;
@@ -77,7 +77,7 @@ List<DateTime> findSeasonStartEndDate(DateTime currentDate) {
     seasonStart =
         findLastMondayOfMonth(currentDate.year, currentDate.month - 1);
     seasonEnd = findLastMondayOfMonth(currentDate.year, currentDate.month)
-        .subtract(Duration(days: 1));
+        .subtract(const Duration(days: 1));
   }
   return [seasonStart, seasonEnd];
 }

--- a/lib/core/functions/war_functions.dart
+++ b/lib/core/functions/war_functions.dart
@@ -34,7 +34,7 @@ Map<int, int> countStars(List<WarMember> members) {
 List<Widget> generateStars(int numberOfStars, double size) {
   return List<Widget>.generate(3, (index) {
     return CachedNetworkImage(
-      errorWidget: (context, url, error) => Icon(Icons.error),
+      errorWidget: (context, url, error) => const Icon(Icons.error),
       imageUrl: index < numberOfStars
           ? "https://assets.clashk.ing/icons/Icon_BB_Star.png"
           : "https://assets.clashk.ing/icons/Icon_BB_Empty_Star.png",

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -15,7 +15,7 @@ class ApiService {
   static const String apiUrlV2 = "https://go.api.clashk.ing/v2";
   static const String assetUrl = "https://assets.clashk.ing";
   static const String proxyUrl = "https://proxy.clashk.ing/v1";
-  static const String cocAssetsUrl = "https://coc-assets.clashk.ing";
+  static const String cocAssetsUrl = "https://proxy.clashk.ing/images";
   static const String bunnyUrl = "https://cdn.clashk.ing";
   static const String discordUrl = "https://discord.gg/clashking";
   static const Duration _defaultTimeout = Duration(seconds: 15);

--- a/lib/core/services/game_data_service.dart
+++ b/lib/core/services/game_data_service.dart
@@ -10,14 +10,14 @@ class GameDataService {
   static const String _translationsUrl =
       "${ApiService.apiUrlV2}/static/app-translations";
 
-  static Map<String, dynamic> _petsData = {};
-  static Map<String, dynamic> _heroesData = {};
-  static Map<String, dynamic> _troopsData = {};
-  static Map<String, dynamic> _spellsData = {};
-  static Map<String, dynamic> _gearsData = {};
-  static Map<String, dynamic> _leagueData = {};
-  static Map<String, dynamic> _playerLeagueData = {};
-  static Map<String, dynamic> _gameData = {};
+  static final Map<String, dynamic> _petsData = {};
+  static final Map<String, dynamic> _heroesData = {};
+  static final Map<String, dynamic> _troopsData = {};
+  static final Map<String, dynamic> _spellsData = {};
+  static final Map<String, dynamic> _gearsData = {};
+  static final Map<String, dynamic> _leagueData = {};
+  static final Map<String, dynamic> _playerLeagueData = {};
+  static final Map<String, dynamic> _gameData = {};
   static final Map<String, dynamic> _bundleData = {};
   static final Map<String, String> _translationsData = {};
   static String _translationLocale = 'EN';

--- a/lib/features/auth/data/auth_service.dart
+++ b/lib/features/auth/data/auth_service.dart
@@ -357,7 +357,7 @@ class AuthService extends ChangeNotifier {
     _accessToken = null;
     notifyListeners();
     globalNavigatorKey.currentState?.pushReplacement(
-      MaterialPageRoute(builder: (context) => LoginPage()),
+      MaterialPageRoute(builder: (context) => const LoginPage()),
     );
   }
 

--- a/lib/features/auth/presentation/account_management_page.dart
+++ b/lib/features/auth/presentation/account_management_page.dart
@@ -6,6 +6,8 @@ import 'package:provider/provider.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class AccountManagementPage extends StatefulWidget {
+  const AccountManagementPage({super.key});
+
   @override
   AccountManagementPageState createState() => AccountManagementPageState();
 }
@@ -83,23 +85,23 @@ class AccountManagementPageState extends State<AccountManagementPage> {
         builder: (context, authService, child) {
           final user = authService.currentUser;
           if (user == null) {
-            return Center(child: Text('No user data available'));
+            return const Center(child: Text('No user data available'));
           }
 
           return SingleChildScrollView(
-            padding: EdgeInsets.all(24),
+            padding: const EdgeInsets.all(24),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // User Info Section
                 _buildUserInfoSection(user),
 
-                SizedBox(height: 32),
+                const SizedBox(height: 32),
 
                 // Connected Accounts Section
                 _buildConnectedAccountsSection(user),
 
-                SizedBox(height: 32),
+                const SizedBox(height: 32),
 
                 // Link Accounts Section
                 if (!user.hasEmailAuth) _buildLinkEmailSection(),
@@ -116,7 +118,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
       elevation: 2,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
-        padding: EdgeInsets.all(20),
+        padding: const EdgeInsets.all(20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -127,10 +129,10 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                   backgroundImage: NetworkImage(user.avatarUrl),
                   onBackgroundImageError: (_, _) {},
                   child: user.avatarUrl.isEmpty
-                      ? Icon(Icons.person, size: 30)
+                      ? const Icon(Icons.person, size: 30)
                       : null,
                 ),
-                SizedBox(width: 16),
+                const SizedBox(width: 16),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -142,7 +144,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                             ),
                       ),
                       if (user.email != null) ...[
-                        SizedBox(height: 4),
+                        const SizedBox(height: 4),
                         Text(
                           user.email!,
                           style:
@@ -151,7 +153,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                                   ),
                         ),
                       ],
-                      SizedBox(height: 4),
+                      const SizedBox(height: 4),
                       Text(
                         'User ID: ${user.userId}',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -180,7 +182,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
               ),
         ),
 
-        SizedBox(height: 16),
+        const SizedBox(height: 16),
 
         // Discord Account
         Card(
@@ -188,7 +190,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
           shape:
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           child: ListTile(
-            leading: CircleAvatar(
+            leading: const CircleAvatar(
               backgroundColor: Color(0xFF5865F2),
               child: Icon(Icons.discord, color: Colors.white),
             ),
@@ -197,12 +199,12 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                 ? AppLocalizations.of(context)!.authAccountConnectedStatus
                 : AppLocalizations.of(context)!.authAccountNotConnected),
             trailing: user.hasDiscordAuth
-                ? Icon(Icons.check_circle, color: Colors.green)
-                : Icon(Icons.circle_outlined, color: Colors.grey),
+                ? const Icon(Icons.check_circle, color: Colors.green)
+                : const Icon(Icons.circle_outlined, color: Colors.grey),
           ),
         ),
 
-        SizedBox(height: 8),
+        const SizedBox(height: 8),
 
         // Email Account
         Card(
@@ -212,22 +214,22 @@ class AccountManagementPageState extends State<AccountManagementPage> {
           child: ListTile(
             leading: CircleAvatar(
               backgroundColor: Theme.of(context).primaryColor,
-              child: Icon(Icons.email, color: Colors.white),
+              child: const Icon(Icons.email, color: Colors.white),
             ),
             title: Text(AppLocalizations.of(context)!.authAccountEmailAndPassword),
             subtitle: Text(user.hasEmailAuth
                 ? AppLocalizations.of(context)!.authAccountConnectedStatus
                 : AppLocalizations.of(context)!.authAccountNotConnected),
             trailing: user.hasEmailAuth
-                ? Icon(Icons.check_circle, color: Colors.green)
-                : Icon(Icons.circle_outlined, color: Colors.grey),
+                ? const Icon(Icons.check_circle, color: Colors.green)
+                : const Icon(Icons.circle_outlined, color: Colors.grey),
           ),
         ),
 
         if (user.hasMultipleAuthMethods) ...[
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
           Container(
-            padding: EdgeInsets.all(12),
+            padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               color: Colors.green.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(8),
@@ -237,8 +239,8 @@ class AccountManagementPageState extends State<AccountManagementPage> {
             ),
             child: Row(
               children: [
-                Icon(Icons.security, color: Colors.green),
-                SizedBox(width: 8),
+                const Icon(Icons.security, color: Colors.green),
+                const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     AppLocalizations.of(context)!.authAccountSecured,
@@ -263,20 +265,20 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                 fontWeight: FontWeight.bold,
               ),
         ),
-        SizedBox(height: 8),
+        const SizedBox(height: 8),
         Text(
           AppLocalizations.of(context)!.authAccountAddEmailAuth,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 color: Colors.grey[600],
               ),
         ),
-        SizedBox(height: 16),
+        const SizedBox(height: 16),
         Card(
           elevation: 2,
           shape:
               RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
           child: Padding(
-            padding: EdgeInsets.all(20),
+            padding: const EdgeInsets.all(20),
             child: Form(
               key: _formKey,
               child: Column(
@@ -286,7 +288,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     controller: _usernameController,
                     decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.authUsernameLabel,
-                      prefixIcon: Icon(Icons.person),
+                      prefixIcon: const Icon(Icons.person),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
                       ),
@@ -303,7 +305,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     },
                   ),
 
-                  SizedBox(height: 16),
+                  const SizedBox(height: 16),
 
                   // Email Field
                   TextFormField(
@@ -311,7 +313,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     keyboardType: TextInputType.emailAddress,
                     decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.authEmail,
-                      prefixIcon: Icon(Icons.email),
+                      prefixIcon: const Icon(Icons.email),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
                       ),
@@ -329,7 +331,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     },
                   ),
 
-                  SizedBox(height: 16),
+                  const SizedBox(height: 16),
 
                   // Password Field
                   TextFormField(
@@ -337,7 +339,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     obscureText: _obscurePassword,
                     decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.authPasswordLabel,
-                      prefixIcon: Icon(Icons.lock),
+                      prefixIcon: const Icon(Icons.lock),
                       suffixIcon: IconButton(
                         icon: Icon(_obscurePassword
                             ? Icons.visibility
@@ -365,7 +367,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     },
                   ),
 
-                  SizedBox(height: 24),
+                  const SizedBox(height: 24),
 
                   // Link Button
                   SizedBox(
@@ -373,22 +375,22 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                     child: ElevatedButton(
                       onPressed: _isLoading ? null : _linkEmailAccount,
                       style: ElevatedButton.styleFrom(
-                        padding: EdgeInsets.symmetric(vertical: 16),
+                        padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
                       child: _isLoading
-                          ? CircularProgressIndicator(color: Colors.white)
+                          ? const CircularProgressIndicator(color: Colors.white)
                           : Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Icon(Icons.link),
-                                SizedBox(width: 8),
+                                const Icon(Icons.link),
+                                const SizedBox(width: 8),
                                 Text(
                                   AppLocalizations.of(context)!
                                       .authAccountLinkEmail,
-                                  style: TextStyle(
+                                  style: const TextStyle(
                                       fontSize: 16,
                                       fontWeight: FontWeight.bold),
                                 ),

--- a/lib/features/auth/presentation/email_verification_page.dart
+++ b/lib/features/auth/presentation/email_verification_page.dart
@@ -63,7 +63,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
         if (mounted) {
           // Navigate to StartupWidget to show loading screen and handle proper navigation
           Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (context) => StartupWidget()),
+            MaterialPageRoute(builder: (context) => const StartupWidget()),
           );
         }
       }
@@ -71,7 +71,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
       if (mounted) {
         if (e.toString().contains("503") || e.toString().contains("500")) {
           Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (context) => MaintenanceScreen()),
+            MaterialPageRoute(builder: (context) => const MaintenanceScreen()),
           );
         } else {
           String errorString = e.toString().toLowerCase();
@@ -183,11 +183,11 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
       ),
       body: ResponsiveLayoutWrapper(
         child: SingleChildScrollView(
-          padding: EdgeInsets.all(16),
+          padding: const EdgeInsets.all(16),
           child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
 
             // Logo
             Center(
@@ -195,13 +195,13 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                 height: 100,
                 width: 100,
                 child: CachedNetworkImage(
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: logoUrl,
                 ),
               ),
             ),
 
-            SizedBox(height: 24),
+            const SizedBox(height: 24),
 
             Text(
               AppLocalizations.of(context)!.authEmailVerificationCheckEmail,
@@ -211,7 +211,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
               textAlign: TextAlign.center,
             ),
 
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
 
             Text(
               AppLocalizations.of(context)!.authEmailVerificationSentTo,
@@ -222,7 +222,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
               textAlign: TextAlign.center,
             ),
 
-            SizedBox(height: 8),
+            const SizedBox(height: 8),
 
             Text(
               widget.email,
@@ -232,7 +232,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
               textAlign: TextAlign.center,
             ),
 
-            SizedBox(height: 24),
+            const SizedBox(height: 24),
 
             // Verification card
             Card(
@@ -249,7 +249,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                       textAlign: TextAlign.center,
                     ),
 
-                    SizedBox(height: 32),
+                    const SizedBox(height: 32),
 
                     // 6-digit code input
                     TextFormField(
@@ -285,14 +285,14 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                       },
                     ),
 
-                    SizedBox(height: 32),
+                    const SizedBox(height: 32),
 
                     // Show loading when verifying
                     if (_isLoading) ...[
                       Column(
                         children: [
-                          CircularProgressIndicator(),
-                          SizedBox(height: 16),
+                          const CircularProgressIndicator(),
+                          const SizedBox(height: 16),
                           Text(
                             AppLocalizations.of(context)!
                                 .authEmailVerificationVerifying,
@@ -329,7 +329,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                         ),
                       ),
 
-                      SizedBox(height: 20),
+                      const SizedBox(height: 20),
 
                       // Resend email button
                       SizedBox(
@@ -357,7 +357,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                         ),
                       ),
 
-                      SizedBox(height: 16),
+                      const SizedBox(height: 16),
 
                       // Back to login
                       Center(
@@ -365,7 +365,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                           onPressed: () {
                             // Navigate back to login page specifically
                             Navigator.of(context).pushAndRemoveUntil(
-                              MaterialPageRoute(builder: (context) => LoginPage()),
+                              MaterialPageRoute(builder: (context) => const LoginPage()),
                               (route) => false,
                             );
                           },

--- a/lib/features/auth/presentation/forgot_password_page.dart
+++ b/lib/features/auth/presentation/forgot_password_page.dart
@@ -9,6 +9,8 @@ import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:provider/provider.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
+  const ForgotPasswordPage({super.key});
+
   @override
   ForgotPasswordPageState createState() => ForgotPasswordPageState();
 }
@@ -83,7 +85,7 @@ class ForgotPasswordPageState extends State<ForgotPasswordPage> {
                     height: 100,
                     width: 100,
                     child: CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: logoUrl,
                     ),
                   ),
@@ -120,7 +122,7 @@ class ForgotPasswordPageState extends State<ForgotPasswordPage> {
                       padding: const EdgeInsets.all(16.0),
                       child: Column(
                         children: [
-                          SizedBox(height: 16),
+                          const SizedBox(height: 16),
                           TextFormField(
                             controller: _emailController,
                             keyboardType: TextInputType.emailAddress,
@@ -228,7 +230,7 @@ class ForgotPasswordPageState extends State<ForgotPasswordPage> {
                       ),
                       child: Column(
                         children: [
-                          Icon(
+                          const Icon(
                             Icons.check_circle,
                             size: 48,
                             color: Colors.green,

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -58,7 +58,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
               content: Text(AppLocalizations.of(context)!
                   .authErrorEmailAlreadyRegistered),
               backgroundColor: Colors.orange,
-              duration: Duration(seconds: 3),
+              duration: const Duration(seconds: 3),
             ),
           );
         }
@@ -141,7 +141,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
 
     if (isMaintenanceError(e)) {
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => MaintenanceScreen()),
+        MaterialPageRoute(builder: (context) => const MaintenanceScreen()),
       );
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -170,7 +170,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
               constraints:
                   BoxConstraints(minHeight: MediaQuery.of(context).size.height),
               child: Padding(
-                padding: EdgeInsets.all(24),
+                padding: const EdgeInsets.all(24),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -182,23 +182,23 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                           width: 80,
                           child: CachedNetworkImage(
                             errorWidget: (context, url, error) =>
-                                Icon(Icons.error),
+                                const Icon(Icons.error),
                             imageUrl: logoUrl,
                           ),
                         ),
-                        SizedBox(height: 12),
+                        const SizedBox(height: 12),
                         SizedBox(
                           width: 160,
                           child: CachedNetworkImage(
                             errorWidget: (context, url, error) =>
-                                Icon(Icons.error),
+                                const Icon(Icons.error),
                             imageUrl: textLogoUrl,
                           ),
                         ),
                       ],
                     ),
 
-                    SizedBox(height: 16),
+                    const SizedBox(height: 16),
 
                     // ClashKing Description
                     Text(
@@ -208,7 +208,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                       textAlign: TextAlign.center,
                     ),
 
-                    SizedBox(height: 24),
+                    const SizedBox(height: 24),
 
                     // Auth Tabs
                     ConstrainedBox(
@@ -245,23 +245,23 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                               indicatorPadding: const EdgeInsets.symmetric(
                                   horizontal: 8, vertical: 8),
                               dividerColor: Colors.transparent,
-                              labelStyle: TextStyle(
+                              labelStyle: const TextStyle(
                                 fontWeight: FontWeight.w600,
                                 fontSize: 14,
                               ),
-                              unselectedLabelStyle: TextStyle(
+                              unselectedLabelStyle: const TextStyle(
                                 fontWeight: FontWeight.w500,
                                 fontSize: 14,
                               ),
                               tabs: [
                                 Tab(
-                                  icon: Icon(Icons.discord, size: 20),
+                                  icon: const Icon(Icons.discord, size: 20),
                                   text: AppLocalizations.of(context)!
                                       .authDiscordTitle,
                                   height: 50,
                                 ),
                                 Tab(
-                                  icon: Icon(Icons.email_outlined, size: 20),
+                                  icon: const Icon(Icons.email_outlined, size: 20),
                                   text: AppLocalizations.of(context)!.authEmail,
                                   height: 50,
                                 ),
@@ -288,7 +288,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                       ),
                     ),
 
-                    SizedBox(height: 16),
+                    const SizedBox(height: 16),
 
                     // Help Section
                     Column(
@@ -302,7 +302,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                                   color:
                                       Theme.of(context).colorScheme.onSurface),
                         ),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
@@ -326,11 +326,11 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                                     ),
                               ),
                               style: TextButton.styleFrom(
-                                padding: EdgeInsets.symmetric(
+                                padding: const EdgeInsets.symmetric(
                                     horizontal: 8, vertical: 4),
                               ),
                             ),
-                            SizedBox(width: 8),
+                            const SizedBox(width: 8),
                             TextButton.icon(
                               onPressed: () async => launchUrl(
                                 Uri.parse(
@@ -353,7 +353,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                                     ),
                               ),
                               style: TextButton.styleFrom(
-                                padding: EdgeInsets.symmetric(
+                                padding: const EdgeInsets.symmetric(
                                     horizontal: 8, vertical: 4),
                               ),
                             ),
@@ -379,13 +379,13 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              SizedBox(height: 12),
-              Icon(
+              const SizedBox(height: 12),
+              const Icon(
                 Icons.discord,
                 size: 48,
                 color: Color(0xFF5865F2),
               ),
-              SizedBox(height: 12),
+              const SizedBox(height: 12),
               Text(
                 AppLocalizations.of(context)!.authDiscordSignIn,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
@@ -393,7 +393,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                     ),
                 textAlign: TextAlign.center,
               ),
-              SizedBox(height: 6),
+              const SizedBox(height: 6),
               Text(
                 AppLocalizations.of(context)!.authDiscordDescription,
                 style: Theme.of(context)
@@ -410,16 +410,16 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
           child: ElevatedButton(
             onPressed: _isLoading ? null : _signInWithDiscord,
             style: ElevatedButton.styleFrom(
-              backgroundColor: Color(0xFF5865F2),
+              backgroundColor: const Color(0xFF5865F2),
               foregroundColor: Colors.white,
-              padding: EdgeInsets.symmetric(vertical: 14),
+              padding: const EdgeInsets.symmetric(vertical: 14),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
               ),
               elevation: 2,
             ),
             child: _isLoading
-                ? SizedBox(
+                ? const SizedBox(
                     height: 20,
                     width: 20,
                     child: CircularProgressIndicator(
@@ -430,18 +430,18 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                 : Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Icon(Icons.discord, size: 20),
-                      SizedBox(width: 8),
+                      const Icon(Icons.discord, size: 20),
+                      const SizedBox(width: 8),
                       Text(
                         AppLocalizations.of(context)!.authDiscordContinue,
-                        style: TextStyle(
+                        style: const TextStyle(
                             fontSize: 15, fontWeight: FontWeight.w600),
                       ),
                     ],
                   ),
           ),
         ),
-        SizedBox(height: 8),
+        const SizedBox(height: 8),
       ],
     );
   }
@@ -455,7 +455,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
             child: SingleChildScrollView(
               child: Column(
                 children: [
-                  SizedBox(height: 8),
+                  const SizedBox(height: 8),
 
                   // Email description
                   Text(
@@ -465,7 +465,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                     textAlign: TextAlign.center,
                   ),
 
-                  SizedBox(height: 12),
+                  const SizedBox(height: 12),
 
                   // Email Field
                   TextFormField(
@@ -473,12 +473,12 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                     keyboardType: TextInputType.emailAddress,
                     decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.authEmail,
-                      prefixIcon: Icon(Icons.email_outlined, size: 20),
+                      prefixIcon: const Icon(Icons.email_outlined, size: 20),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
                       ),
                       contentPadding:
-                          EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                          const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
                       isDense: true,
                     ),
                     validator: (value) {
@@ -494,7 +494,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                     },
                   ),
 
-                  SizedBox(height: 10),
+                  const SizedBox(height: 10),
 
                   // Password Field
                   TextFormField(
@@ -503,7 +503,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                     decoration: InputDecoration(
                       labelText:
                           AppLocalizations.of(context)!.authPasswordLabel,
-                      prefixIcon: Icon(Icons.lock_outline, size: 20),
+                      prefixIcon: const Icon(Icons.lock_outline, size: 20),
                       suffixIcon: IconButton(
                         icon: Icon(
                             _obscurePassword
@@ -517,7 +517,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                         borderRadius: BorderRadius.circular(12),
                       ),
                       contentPadding:
-                          EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                          const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
                       isDense: true,
                     ),
                     validator: (value) {
@@ -530,7 +530,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                   ),
 
                   // Authentication Links
-                  SizedBox(height: 6),
+                  const SizedBox(height: 6),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
@@ -538,12 +538,12 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                         onPressed: () {
                           Navigator.of(context).push(
                             MaterialPageRoute(
-                                builder: (context) => RegisterPage()),
+                                builder: (context) => const RegisterPage()),
                           );
                         },
                         style: TextButton.styleFrom(
                           padding:
-                              EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                              const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                         ),
                         child: Text(
                           AppLocalizations.of(context)!.authSignUp,
@@ -558,13 +558,13 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                         onPressed: () {
                           Navigator.of(context).push(
                             MaterialPageRoute(
-                              builder: (context) => ForgotPasswordPage(),
+                              builder: (context) => const ForgotPasswordPage(),
                             ),
                           );
                         },
                         style: TextButton.styleFrom(
                           padding:
-                              EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                              const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
                         ),
                         child: Text(
                           AppLocalizations.of(context)!.authPasswordForgot,
@@ -588,14 +588,14 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
             child: ElevatedButton(
               onPressed: _isLoading ? null : _signInWithEmail,
               style: ElevatedButton.styleFrom(
-                padding: EdgeInsets.symmetric(vertical: 14),
+                padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),
                 elevation: 2,
               ),
               child: _isLoading
-                  ? SizedBox(
+                  ? const SizedBox(
                       height: 20,
                       width: 20,
                       child: CircularProgressIndicator(
@@ -606,12 +606,12 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                   : Text(
                       AppLocalizations.of(context)!.authLogin,
                       style:
-                          TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+                          const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
                     ),
             ),
           ),
 
-          SizedBox(height: 8),
+          const SizedBox(height: 8),
         ],
       ),
     );
@@ -691,10 +691,10 @@ class _PostAuthLoadingScreenState extends State<_PostAuthLoadingScreen> {
       if (mounted) {
         if (context.read<CocAccountService>().cocAccounts.isNotEmpty) {
           // ✅ User has CoC account → Go to home page
-          nextPage = MyHomePage();
+          nextPage = const MyHomePage();
         } else {
           // ❌ No account → Go to add account page
-          nextPage = AddCocAccountPage();
+          nextPage = const AddCocAccountPage();
         }
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(builder: (_) => nextPage),

--- a/lib/features/auth/presentation/maintenance_page.dart
+++ b/lib/features/auth/presentation/maintenance_page.dart
@@ -14,7 +14,7 @@ class MaintenanceScreen extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          MobileWebImage(
+          const MobileWebImage(
               imageUrl: ImageAssets.sleepingApprenticeBuilder, width: 250),
           const SizedBox(height: 20),
           Text(
@@ -34,7 +34,7 @@ class MaintenanceScreen extends StatelessWidget {
           const SizedBox(height: 40),
           TextButton(
               onPressed: () => Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(builder: (context) => StartupWidget()),
+                    MaterialPageRoute(builder: (context) => const StartupWidget()),
                   ),
               child:
                   Row(mainAxisAlignment: MainAxisAlignment.center, children: [

--- a/lib/features/auth/presentation/register_page.dart
+++ b/lib/features/auth/presentation/register_page.dart
@@ -11,6 +11,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
 
 class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
   @override
   RegisterPageState createState() => RegisterPageState();
 }
@@ -97,7 +99,7 @@ class RegisterPageState extends State<RegisterPage> {
       if (mounted) {
         if (e.toString().contains("503") || e.toString().contains("500")) {
           Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (context) => MaintenanceScreen()),
+            MaterialPageRoute(builder: (context) => const MaintenanceScreen()),
           );
         } else {
           String errorString = e.toString().toLowerCase();
@@ -138,7 +140,7 @@ class RegisterPageState extends State<RegisterPage> {
                 overflow: TextOverflow.visible, // Show all text
               ),
               backgroundColor: Colors.red,
-              duration: Duration(seconds: 6), // Longer duration for longer text
+              duration: const Duration(seconds: 6), // Longer duration for longer text
               action: SnackBarAction(
                 label: AppLocalizations.of(context)!.generalOk,
                 textColor: Colors.white,
@@ -214,7 +216,7 @@ class RegisterPageState extends State<RegisterPage> {
       ),
       body: ResponsiveLayoutWrapper(
         child: SingleChildScrollView(
-          padding: EdgeInsets.all(16),
+          padding: const EdgeInsets.all(16),
           child: Form(
           key: _formKey,
           child: Column(
@@ -226,13 +228,13 @@ class RegisterPageState extends State<RegisterPage> {
                   height: 100,
                   width: 100,
                   child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: logoUrl,
                   ),
                 ),
               ),
 
-              SizedBox(height: 32),
+              const SizedBox(height: 32),
 
               Text(
                 AppLocalizations.of(context)!.authJoinClashKing,
@@ -242,7 +244,7 @@ class RegisterPageState extends State<RegisterPage> {
                 textAlign: TextAlign.center,
               ),
 
-              SizedBox(height: 8),
+              const SizedBox(height: 8),
 
               Text(
                 AppLocalizations.of(context)!.authCreateAccountToGetStarted,
@@ -253,7 +255,7 @@ class RegisterPageState extends State<RegisterPage> {
                 textAlign: TextAlign.center,
               ),
 
-              SizedBox(height: 32),
+              const SizedBox(height: 32),
 
               // Registration form card
               Center(
@@ -265,7 +267,7 @@ class RegisterPageState extends State<RegisterPage> {
                       padding: const EdgeInsets.all(16.0),
                       child: Column(
                         children: [
-                      SizedBox(height: 8),
+                      const SizedBox(height: 8),
                       // Username Field
                       TextFormField(
                         controller: _usernameController,
@@ -274,7 +276,7 @@ class RegisterPageState extends State<RegisterPage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.authUsernameLabel,
-                          prefixIcon: Icon(Icons.person),
+                          prefixIcon: const Icon(Icons.person),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(12),
                           ),
@@ -292,7 +294,7 @@ class RegisterPageState extends State<RegisterPage> {
                         },
                       ),
 
-                      SizedBox(height: 20),
+                      const SizedBox(height: 20),
 
                       // Email Field
                       TextFormField(
@@ -303,7 +305,7 @@ class RegisterPageState extends State<RegisterPage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.authEmail,
-                          prefixIcon: Icon(Icons.email),
+                          prefixIcon: const Icon(Icons.email),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(12),
                           ),
@@ -322,7 +324,7 @@ class RegisterPageState extends State<RegisterPage> {
                         },
                       ),
 
-                      SizedBox(height: 20),
+                      const SizedBox(height: 20),
 
                       // Password Field
                       TextFormField(
@@ -333,7 +335,7 @@ class RegisterPageState extends State<RegisterPage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.authPasswordLabel,
-                          prefixIcon: Icon(Icons.lock),
+                          prefixIcon: const Icon(Icons.lock),
                           suffixIcon: IconButton(
                             icon: Icon(_obscurePassword
                                 ? Icons.visibility
@@ -362,7 +364,7 @@ class RegisterPageState extends State<RegisterPage> {
                       ),
 
                       // Dynamic password requirements checklist (placed below password field)
-                      SizedBox(height: 8),
+                      const SizedBox(height: 8),
                       Builder(builder: (context) {
                         final header = AppLocalizations.of(context)!.authPasswordHeader;
                         final labelUpper = AppLocalizations.of(context)!.authPasswordUppercase;
@@ -381,7 +383,7 @@ class RegisterPageState extends State<RegisterPage> {
                                   size: 16,
                                   color: met ? Colors.green : Theme.of(context).hintColor,
                                 ),
-                                SizedBox(width: 8),
+                                const SizedBox(width: 8),
                                 Expanded(
                                   child: Text(
                                     label,
@@ -416,7 +418,7 @@ class RegisterPageState extends State<RegisterPage> {
                         );
                       }),
 
-                      SizedBox(height: 20),
+                      const SizedBox(height: 20),
 
                       // Confirm Password Field
                       TextFormField(
@@ -427,7 +429,7 @@ class RegisterPageState extends State<RegisterPage> {
                         decoration: InputDecoration(
                           labelText:
                               AppLocalizations.of(context)!.authPasswordConfirm,
-                          prefixIcon: Icon(Icons.lock_outline),
+                          prefixIcon: const Icon(Icons.lock_outline),
                           suffixIcon: IconButton(
                             icon: Icon(_obscureConfirmPassword
                                 ? Icons.visibility
@@ -454,7 +456,7 @@ class RegisterPageState extends State<RegisterPage> {
                         onFieldSubmitted: (_) => _register(),
                       ),
 
-                      SizedBox(height: 32),
+                      const SizedBox(height: 32),
 
                       // Register Button
                       SizedBox(
@@ -491,7 +493,7 @@ class RegisterPageState extends State<RegisterPage> {
                                 ),
                         ),
                       ),
-                      SizedBox(height: 16),
+                      const SizedBox(height: 16),
 
                       // Back to Login
                       TextButton(

--- a/lib/features/auth/presentation/reset_password_page.dart
+++ b/lib/features/auth/presentation/reset_password_page.dart
@@ -96,7 +96,7 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(
+                const Icon(
                   Icons.check_circle,
                   size: 64,
                   color: Colors.green,
@@ -130,7 +130,7 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
         // Then navigate to login page
         if (mounted) {
           Navigator.of(context).pushAndRemoveUntil(
-            MaterialPageRoute(builder: (context) => LoginPage()),
+            MaterialPageRoute(builder: (context) => const LoginPage()),
             (route) => false,
           );
         }
@@ -180,7 +180,7 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
                     height: 100,
                     width: 100,
                     child: CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: logoUrl,
                     ),
                   ),
@@ -343,7 +343,7 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
                                     size: 16,
                                     color: met ? Colors.green : Theme.of(context).hintColor,
                                   ),
-                                  SizedBox(width: 8),
+                                  const SizedBox(width: 8),
                                   Expanded(
                                     child: Text(
                                       label,

--- a/lib/features/auth/presentation/startup_widget.dart
+++ b/lib/features/auth/presentation/startup_widget.dart
@@ -14,6 +14,8 @@ import 'package:clashkingapp/common/widgets/loading/app_loading_screen.dart';
 import 'package:clashkingapp/common/widgets/error/error_page.dart';
 
 class StartupWidget extends StatefulWidget {
+  const StartupWidget({super.key});
+
   @override
   StartupWidgetState createState() => StartupWidgetState();
 }
@@ -84,7 +86,7 @@ class StartupWidgetState extends State<StartupWidget> {
           isNetworkError: isNetworkError(error),
           onRetry: () async {
             Navigator.of(context).pushReplacement(
-              MaterialPageRoute(builder: (context) => StartupWidget()),
+              MaterialPageRoute(builder: (context) => const StartupWidget()),
             );
           },
         ),
@@ -98,14 +100,14 @@ class StartupWidgetState extends State<StartupWidget> {
       if (authService.isAuthenticated && mounted) {
         if (context.read<CocAccountService>().cocAccounts.isNotEmpty) {
           // ✅ User connected and has CoC account → Go to home page
-          nextPage = MyHomePage();
+          nextPage = const MyHomePage();
         } else {
           // ❌ No account → Go to add account page
-          nextPage = AddCocAccountPage();
+          nextPage = const AddCocAccountPage();
         }
       } else {
         // ❌ User not connected → Go to login page
-        nextPage = LoginPage();
+        nextPage = const LoginPage();
       }
       if (mounted) {
         Navigator.of(context).pushReplacement(

--- a/lib/features/clan/presentation/clan_capital/clan_capital_header.dart
+++ b/lib/features/clan/presentation/clan_capital/clan_capital_header.dart
@@ -11,7 +11,7 @@ class ClanCapitalHeader extends StatefulWidget {
   final List<String> user;
   final Clan? clanInfo;
 
-  ClanCapitalHeader({
+  const ClanCapitalHeader({
     super.key,
     required this.user,
     required this.clanInfo,
@@ -43,7 +43,7 @@ class ClanCapitalHeaderState extends State<ClanCapitalHeader>
                       Colors.black.withValues(alpha: 0.3),
                       BlendMode.darken,
                     ),
-                    child: MobileWebImage(
+                    child: const MobileWebImage(
                       imageUrl: ImageAssets.clanCapitalPageBackground,
                       width: double.infinity,
                       fit: BoxFit.cover,
@@ -64,7 +64,7 @@ class ClanCapitalHeaderState extends State<ClanCapitalHeader>
                 bottom: -62,
                 child: Row(
                   children: [
-                    Column(
+                    const Column(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       mainAxisSize: MainAxisSize.max,
                       children: [
@@ -86,12 +86,12 @@ class ClanCapitalHeaderState extends State<ClanCapitalHeader>
                         SizedBox(height: 8),
                       ],
                     ),
-                    SizedBox(width: 16),
+                    const SizedBox(width: 16),
                     Column(
                       children: [
                         ClipRect(
                           child: Transform.translate(
-                            offset: Offset(0, -6),
+                            offset: const Offset(0, -6),
                             child: Transform.scale(
                               scale: (widget.clanInfo?.clanCapital
                                           ?.capitalHallLevel ==
@@ -114,8 +114,8 @@ class ClanCapitalHeaderState extends State<ClanCapitalHeader>
                         ),
                       ],
                     ),
-                    SizedBox(width: 16),
-                    Column(
+                    const SizedBox(width: 16),
+                    const Column(
                       children: [
                         SizedBox(height: 10),
                         SizedBox(
@@ -136,13 +136,13 @@ class ClanCapitalHeaderState extends State<ClanCapitalHeader>
               ),
             ],
           ),
-          SizedBox(height: 80),
+          const SizedBox(height: 80),
           ImageChip(
                             context: context,
             imageUrl: ImageAssets.capitalTrophy,
             label: NumberFormat('#,###').format(widget.clanInfo?.clanCapitalPoints),
           ),
-          SizedBox(height: 8),
+          const SizedBox(height: 8),
         ],
       ),
     );

--- a/lib/features/clan/presentation/clan_capital/clan_capital_page.dart
+++ b/lib/features/clan/presentation/clan_capital/clan_capital_page.dart
@@ -10,7 +10,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 
 class ClanCapitalScreen extends StatefulWidget {
   final Clan clanInfo;
-  ClanCapitalScreen({super.key, required this.clanInfo});
+  const ClanCapitalScreen({super.key, required this.clanInfo});
 
   @override
   ClanCapitalScreenState createState() => ClanCapitalScreenState();
@@ -38,13 +38,13 @@ class ClanCapitalScreenState extends State<ClanCapitalScreen>
 
   void incrementWeek() {
     setState(() {
-      selectedWeek = selectedWeek.add(Duration(days: 7));
+      selectedWeek = selectedWeek.add(const Duration(days: 7));
     });
   }
 
   void decrementWeek() {
     setState(() {
-      selectedWeek = selectedWeek.subtract(Duration(days: 7));
+      selectedWeek = selectedWeek.subtract(const Duration(days: 7));
     });
   }
 
@@ -77,19 +77,19 @@ class ClanCapitalScreenState extends State<ClanCapitalScreen>
     } else {
       return Column(
         children: [
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
           Card(
             child: Padding(
-              padding: EdgeInsets.all(16),
+              padding: const EdgeInsets.all(16),
               child: Text(
                 AppLocalizations.of(context)?.generalNoDataAvailable ??
                     'No data available',
               ),
             ),
           ),
-          SizedBox(height: 32),
+          const SizedBox(height: 32),
           CachedNetworkImage(
-            errorWidget: (context, url, error) => Icon(Icons.error),
+            errorWidget: (context, url, error) => const Icon(Icons.error),
             imageUrl: ImageAssets.villager,
             height: 250,
             width: 200,

--- a/lib/features/clan/presentation/clan_capital/clan_capital_raid.dart
+++ b/lib/features/clan/presentation/clan_capital/clan_capital_raid.dart
@@ -20,6 +20,8 @@ class ClanCapitalRaid extends StatefulWidget {
 }
 
 class ClanCapitalRaidState extends State<ClanCapitalRaid> {
+  static const String _numberFormat = '#,###';
+
   String filterBy = "all";
   bool filterAccountActive = false;
   int week = 0;
@@ -54,18 +56,19 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: EdgeInsets.only(left: 8, right: 8, top: 2),
+          padding: const EdgeInsets.only(left: 8, right: 8, top: 2),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               IconButton(
                 icon: Icon(
-                    filterBy == "all"
-                        ? LucideIcons.list
-                        : filterBy == "done"
-                            ? LucideIcons.check
-                            : LucideIcons.x,
-                    color: Theme.of(context).colorScheme.tertiary),
+                  filterBy == "all"
+                      ? LucideIcons.list
+                      : filterBy == "done"
+                      ? LucideIcons.check
+                      : LucideIcons.x,
+                  color: Theme.of(context).colorScheme.tertiary,
+                ),
                 onPressed: () {
                   setState(() {
                     switch (filterBy) {
@@ -86,23 +89,30 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
                 width: 30,
                 height: 30,
                 child: IconButton(
-                  icon: Icon(Icons.arrow_back,
-                      color: Theme.of(context).colorScheme.onSurface, size: 16),
+                  icon: Icon(
+                    Icons.arrow_back,
+                    color: Theme.of(context).colorScheme.onSurface,
+                    size: 16,
+                  ),
                   onPressed: decrementRaid,
                 ),
               ),
               Text(
-                DateFormat('dd MMMM yyyy',
-                        Localizations.localeOf(context).languageCode)
-                    .format(raid.startTime),
+                DateFormat(
+                  'dd MMMM yyyy',
+                  Localizations.localeOf(context).languageCode,
+                ).format(raid.startTime),
                 style: Theme.of(context).textTheme.labelLarge,
               ),
               SizedBox(
                 width: 30,
                 height: 30,
                 child: IconButton(
-                  icon: Icon(Icons.arrow_forward,
-                      color: Theme.of(context).colorScheme.onSurface, size: 16),
+                  icon: Icon(
+                    Icons.arrow_forward,
+                    color: Theme.of(context).colorScheme.onSurface,
+                    size: 16,
+                  ),
                   onPressed: incrementRaid,
                 ),
               ),
@@ -126,10 +136,13 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
           buildLastRaidsMembers(raid, activeUserTags, filterAccountActive),
         if ((filterBy == "all" || filterBy == "notDone") && isOngoing)
           ...buildNonParticipantWidgets(
-              nonParticipants, activeUserTags, filterAccountActive)
+            nonParticipants,
+            activeUserTags,
+            filterAccountActive,
+          )
         else
-          SizedBox.shrink(),
-        SizedBox(height: 10),
+          const SizedBox.shrink(),
+        const SizedBox(height: 10),
       ],
     );
   }
@@ -148,57 +161,67 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
     return nonParticipants;
   }
 
-  List<Widget> buildNonParticipantWidgets(List<ClanMember> nonParticipants,
-      List<String> activeUserTags, bool filterAccountActive) {
+  List<Widget> buildNonParticipantWidgets(
+    List<ClanMember> nonParticipants,
+    List<String> activeUserTags,
+    bool filterAccountActive,
+  ) {
     return nonParticipants
-        .where((member) =>
-            !filterAccountActive || activeUserTags.contains(member.tag))
+        .where(
+          (member) =>
+              !filterAccountActive || activeUserTags.contains(member.tag),
+        )
         .map((member) {
-      return Card(
-        margin: EdgeInsets.only(left: 12, right: 12, bottom: 4, top: 4),
-        elevation: 4,
-        shape: RoundedRectangleBorder(
-          side: BorderSide(color: Colors.red, width: 2),
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              SizedBox(
-                height: 40,
-                width: 40,
-                child: MobileWebImage(
-                  imageUrl: ImageAssets.capitalVacantHouse,
-                ),
-              ),
-              SizedBox(width: 8),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      member.name,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                      overflow: TextOverflow.ellipsis,
+          return Card(
+            margin: const EdgeInsets.only(
+              left: 12,
+              right: 12,
+              bottom: 4,
+              top: 4,
+            ),
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              side: const BorderSide(color: Colors.red, width: 2),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const SizedBox(
+                    height: 40,
+                    width: 40,
+                    child: MobileWebImage(
+                      imageUrl: ImageAssets.capitalVacantHouse,
                     ),
-                    Text(
-                      member.tag,
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium
-                          ?.copyWith(color: Colors.grey),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          member.name,
+                          style: Theme.of(context).textTheme.bodyLarge,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Text(
+                          member.tag,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
+                  ),
+                  const Icon(Icons.close, color: Colors.red),
+                ],
               ),
-              Icon(Icons.close, color: Colors.red),
-            ],
-          ),
-        ),
-      );
-    }).toList();
+            ),
+          );
+        })
+        .toList();
   }
 
   Widget buildLastRaids(dynamic firstRaid, locale, isOngoing) {
@@ -207,12 +230,18 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
         SizedBox(
           width: double.infinity,
           child: Card(
-            margin: EdgeInsets.only(left: 12, right: 12, bottom: 4, top: 4),
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            margin: const EdgeInsets.only(
+              left: 12,
+              right: 12,
+              bottom: 4,
+              top: 4,
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
             elevation: 4,
             child: Padding(
-              padding: EdgeInsets.all(16),
+              padding: const EdgeInsets.all(16),
               child: Column(
                 children: [
                   Row(
@@ -224,53 +253,56 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
                             : AppLocalizations.of(context)!.raidsLast,
                         style: Theme.of(context).textTheme.titleMedium,
                       ),
-                      SizedBox(width: 4),
+                      const SizedBox(width: 4),
                       isOngoing
-                          ? MobileWebImage(
+                          ? const MobileWebImage(
                               height: 24,
                               width: 24,
                               imageUrl: ImageAssets.swordGif,
                             )
-                          : SizedBox.shrink(),
+                          : const SizedBox.shrink(),
                     ],
                   ),
                   Text(
                     "(${DateFormat.yMMMd(locale).format(firstRaid.startTime)} - ${DateFormat.yMMMd(locale).format(firstRaid.endTime)})",
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                  SizedBox(height: 8),
+                  const SizedBox(height: 8),
                   Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        children: [
-                          Column(
-                            children: [
-                              Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  SizedBox(
-                                    height: 32,
-                                    width: 32,
-                                    child: MobileWebImage(
-                                      imageUrl: ImageAssets.capitalGold,
-                                    ),
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      children: [
+                        Column(
+                          children: [
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const SizedBox(
+                                  height: 32,
+                                  width: 32,
+                                  child: MobileWebImage(
+                                    imageUrl: ImageAssets.capitalGold,
                                   ),
-                                  SizedBox(width: 4),
-                                  Text(
-                                    isOngoing
-                                        ? AppLocalizations.of(context)!
-                                            .generalComingSoon
-                                        : '${6 * firstRaid.offensiveReward + firstRaid.defensiveReward}',
-                                    style:
-                                        Theme.of(context).textTheme.titleMedium,
-                                  ),
-                                ],
-                              )
-                            ],
-                          ),
-                        ],
-                      )),
-                  SizedBox(height: 8),
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  isOngoing
+                                      ? AppLocalizations.of(
+                                          context,
+                                        )!.generalComingSoon
+                                      : '${6 * firstRaid.offensiveReward + firstRaid.defensiveReward}',
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.titleMedium,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
                   SizedBox(
                     width: double.infinity,
                     child: Align(
@@ -283,32 +315,36 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
                             children: [
                               Row(
                                 children: [
-                                  SizedBox(
+                                  const SizedBox(
                                     height: 24,
                                     width: 24,
                                     child: MobileWebImage(
                                       imageUrl: ImageAssets.raidAttacks,
                                     ),
                                   ),
-                                  SizedBox(width: 2),
+                                  const SizedBox(width: 2),
                                   Text(
-                                    "${NumberFormat('#,###', Localizations.localeOf(context).toString()).format(firstRaid.raidsCompleted)} ${AppLocalizations.of(context)!.raidsCompleted}",
+                                    "${NumberFormat(_numberFormat, Localizations.localeOf(context).toString()).format(firstRaid.raidsCompleted)} ${AppLocalizations.of(context)!.raidsCompleted}",
                                   ),
                                 ],
                               ),
                               Row(
                                 children: [
-                                  Text(NumberFormat(
-                                          '#,###',
-                                          Localizations.localeOf(context)
-                                              .toString())
-                                      .format(firstRaid.capitalTotalLoot)),
-                                  SizedBox(width: 2),
-                                  SizedBox(
+                                  Text(
+                                    NumberFormat(
+                                      _numberFormat,
+                                      Localizations.localeOf(
+                                        context,
+                                      ).toString(),
+                                    ).format(firstRaid.capitalTotalLoot),
+                                  ),
+                                  const SizedBox(width: 2),
+                                  const SizedBox(
                                     height: 24,
                                     width: 24,
                                     child: MobileWebImage(
-                                        imageUrl: ImageAssets.capitalGold),
+                                      imageUrl: ImageAssets.capitalGold,
+                                    ),
                                   ),
                                 ],
                               ),
@@ -323,30 +359,33 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
                                     child: Transform.scale(
                                       scale: 1.3,
                                       child: MobileWebImage(
-                                          height: 24,
-                                          width: 24,
-                                          fit: BoxFit.cover,
-                                          imageUrl: ImageAssets.capitalHall(5)),
+                                        height: 24,
+                                        width: 24,
+                                        fit: BoxFit.cover,
+                                        imageUrl: ImageAssets.capitalHall(5),
+                                      ),
                                     ),
                                   ),
-                                  SizedBox(width: 2),
+                                  const SizedBox(width: 2),
                                   Text(
-                                      "${firstRaid.enemyDistrictsDestroyed} ${AppLocalizations.of(context)!.raidsDistrictsDestroyed}"),
+                                    "${firstRaid.enemyDistrictsDestroyed} ${AppLocalizations.of(context)!.raidsDistrictsDestroyed}",
+                                  ),
                                 ],
                               ),
                               Row(
                                 children: [
                                   Text("${firstRaid.totalAttacks}"),
-                                  SizedBox(width: 2),
+                                  const SizedBox(width: 2),
                                   ClipRect(
                                     child: Transform.scale(
                                       scale: 0.8,
-                                      child: MobileWebImage(
-                                          height: 24,
-                                          width: 24,
-                                          fit: BoxFit.cover,
-                                          imageUrl:
-                                              ImageAssets.capitalThickSwords),
+                                      child: const MobileWebImage(
+                                        height: 24,
+                                        width: 24,
+                                        fit: BoxFit.cover,
+                                        imageUrl:
+                                            ImageAssets.capitalThickSwords,
+                                      ),
                                     ),
                                   ),
                                 ],
@@ -361,16 +400,19 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
               ),
             ),
           ),
-        )
+        ),
       ],
     );
   }
 
-  Widget buildLastRaidsMembers(CapitalHistoryItem firstRaid,
-      List<String> activeUserTags, bool filterAccountActive) {
+  Widget buildLastRaidsMembers(
+    CapitalHistoryItem firstRaid,
+    List<String> activeUserTags,
+    bool filterAccountActive,
+  ) {
     return Column(
       children: [
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
         SizedBox(
           width: double.infinity,
           child: Column(
@@ -379,9 +421,12 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
                 "${AppLocalizations.of(context)!.clanMembers} (${firstRaid.members?.length ?? 0}/50)",
                 style: Theme.of(context).textTheme.titleMedium,
               ),
-              SizedBox(height: 10),
+              const SizedBox(height: 10),
               ...buildMemberWidgets(
-                  firstRaid.members ?? [], activeUserTags, filterAccountActive)
+                firstRaid.members ?? [],
+                activeUserTags,
+                filterAccountActive,
+              ),
             ],
           ),
         ),
@@ -389,98 +434,110 @@ class ClanCapitalRaidState extends State<ClanCapitalRaid> {
     );
   }
 
-  List<Widget> buildMemberWidgets(List<RaidMember> raidMembers,
-      List<String> activeUserTags, bool filterAccountActive) {
+  List<Widget> buildMemberWidgets(
+    List<RaidMember> raidMembers,
+    List<String> activeUserTags,
+    bool filterAccountActive,
+  ) {
     raidMembers.sort(
-        (a, b) => b.capitalResourcesLooted.compareTo(a.capitalResourcesLooted));
+      (a, b) => b.capitalResourcesLooted.compareTo(a.capitalResourcesLooted),
+    );
 
     return raidMembers
-        .where((member) =>
-            !filterAccountActive || activeUserTags.contains(member.tag))
+        .where(
+          (member) =>
+              !filterAccountActive || activeUserTags.contains(member.tag),
+        )
         .map((member) {
-      bool isInDiscord = activeUserTags.contains(member.tag);
+          bool isInDiscord = activeUserTags.contains(member.tag);
 
-      return Card(
-        margin: EdgeInsets.only(left: 12, right: 12, bottom: 4, top: 4),
-        elevation: 4,
-        shape: RoundedRectangleBorder(
-          side: BorderSide(
-            color: isInDiscord ? Colors.green : Colors.transparent,
-            width: 2,
-          ),
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              SizedBox(
-                height: 40,
-                width: 40,
-                child: MobileWebImage(
-                  imageUrl: ImageAssets.capitalClanHouse,
-                ),
+          return Card(
+            margin: const EdgeInsets.only(
+              left: 12,
+              right: 12,
+              bottom: 4,
+              top: 4,
+            ),
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              side: BorderSide(
+                color: isInDiscord ? Colors.green : Colors.transparent,
+                width: 2,
               ),
-              SizedBox(width: 8),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      member.name,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    Text(
-                      member.tag,
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium
-                          ?.copyWith(color: Colors.grey),
-                    ),
-                  ],
-                ),
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    '${member.attacks}/${member.attackLimit + member.bonusAttackLimit}',
-                    style: Theme.of(context).textTheme.bodyLarge,
+                  const SizedBox(
+                    height: 40,
+                    width: 40,
+                    child: MobileWebImage(
+                      imageUrl: ImageAssets.capitalClanHouse,
+                    ),
                   ),
-                  Text(
-                    NumberFormat(
-                            '#,###', Localizations.localeOf(context).toString())
-                        .format(member.capitalResourcesLooted),
-                    style: Theme.of(context).textTheme.bodyLarge,
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          member.name,
+                          style: Theme.of(context).textTheme.bodyLarge,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Text(
+                          member.tag,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodyMedium?.copyWith(color: Colors.grey),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${member.attacks}/${member.attackLimit + member.bonusAttackLimit}',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                      Text(
+                        NumberFormat(
+                          _numberFormat,
+                          Localizations.localeOf(context).toString(),
+                        ).format(member.capitalResourcesLooted),
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(width: 8),
+                  const Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      SizedBox(
+                        height: 24,
+                        width: 24,
+                        child: MobileWebImage(
+                          imageUrl: ImageAssets.raidAttacks,
+                        ),
+                      ),
+                      SizedBox(
+                        height: 24,
+                        width: 24,
+                        child: MobileWebImage(
+                          imageUrl: ImageAssets.capitalGold,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-              SizedBox(width: 8),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  SizedBox(
-                    height: 24,
-                    width: 24,
-                    child: MobileWebImage(
-                      imageUrl: ImageAssets.raidAttacks,
-                    ),
-                  ),
-                  SizedBox(
-                    height: 24,
-                    width: 24,
-                    child: MobileWebImage(
-                      imageUrl: ImageAssets.capitalGold,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      );
-    }).toList();
+            ),
+          );
+        })
+        .toList();
   }
 }

--- a/lib/features/clan/presentation/clan_info/clan_header.dart
+++ b/lib/features/clan/presentation/clan_info/clan_header.dart
@@ -39,7 +39,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
               _buildAction(context),
             ],
           ),
-          SizedBox(height: 46),
+          const SizedBox(height: 46),
           _buildClanTitleSection(context, loc),
           const SizedBox(height: 12),
           _buildClanChips(context, loc),
@@ -65,7 +65,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
             BlendMode.darken,
           ),
           child: CachedNetworkImage(
-            errorWidget: (context, url, error) => Icon(Icons.error),
+            errorWidget: (context, url, error) => const Icon(Icons.error),
             imageUrl: ImageAssets.clanPageBackground,
             fit: BoxFit.cover,
           ),
@@ -90,7 +90,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
     return Positioned(
       bottom: -52,
       child: CachedNetworkImage(
-        errorWidget: (context, url, error) => Icon(Icons.error),
+        errorWidget: (context, url, error) => const Icon(Icons.error),
         imageUrl: clanInfo.badgeUrls.large,
         width: 150,
       ),
@@ -322,7 +322,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
             onPressed: () {
               showMenu(
                 context: context,
-                position: RelativeRect.fromLTRB(100, 100, 0, 0),
+                position: const RelativeRect.fromLTRB(100, 100, 0, 0),
                 items: [
                   PopupMenuItem(
                     value: 'Stats',
@@ -330,7 +330,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
                       children: [
                         MobileWebImage(
                             imageUrl: clanInfo.badgeUrls.small, width: 20),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.generalStats),
                       ],
                     ),

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -180,7 +180,7 @@ class ClanMembersState extends State<ClanMembers> {
                           children: [
                             CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl:
                                   ImageAssets.townHall(member.townHallLevel),
                               width: 40,
@@ -278,7 +278,7 @@ class ClanMembersState extends State<ClanMembers> {
       children: [
         const SizedBox(width: 20),
         CachedNetworkImage(
-            errorWidget: (context, url, error) => Icon(Icons.error),
+            errorWidget: (context, url, error) => const Icon(Icons.error),
             imageUrl: imageUrl,
             width: 24),
         const SizedBox(width: 8),

--- a/lib/features/clan/presentation/join_leave/clan_join_leave.dart
+++ b/lib/features/clan/presentation/join_leave/clan_join_leave.dart
@@ -9,7 +9,7 @@ import 'package:scrollable_tab_view/scrollable_tab_view.dart';
 class ClanJoinLeaveScreen extends StatefulWidget {
   final Clan clanInfo;
 
-  ClanJoinLeaveScreen({super.key, required this.clanInfo});
+  const ClanJoinLeaveScreen({super.key, required this.clanInfo});
 
   @override
   ClanJoinLeaveScreenState createState() => ClanJoinLeaveScreenState();

--- a/lib/features/clan/presentation/join_leave/clan_join_leave_events.dart
+++ b/lib/features/clan/presentation/join_leave/clan_join_leave_events.dart
@@ -84,7 +84,7 @@ class ClanJoinLeaveEventsState extends State<ClanJoinLeaveEvents>
             Row(
               children: [
                 IconButton(
-                  icon: Icon(Icons.calendar_today, size: 24),
+                  icon: const Icon(Icons.calendar_today, size: 24),
                   onPressed: () async {
                     DateTime? picked = await showDatePicker(
                       context: context,
@@ -100,7 +100,7 @@ class ClanJoinLeaveEventsState extends State<ClanJoinLeaveEvents>
                   },
                 ),
                 IconButton(
-                  icon: Icon(LucideIcons.listRestart),
+                  icon: const Icon(LucideIcons.listRestart),
                   onPressed: resetDateFilter,
                   tooltip: loc.generalReset,
                 ),
@@ -113,7 +113,7 @@ class ClanJoinLeaveEventsState extends State<ClanJoinLeaveEvents>
             ),
             Row(
               children: [
-                SizedBox(
+                const SizedBox(
                   width: 48,
                 ),
                 IconButton(

--- a/lib/features/clan/presentation/join_leave/clan_join_leave_header.dart
+++ b/lib/features/clan/presentation/join_leave/clan_join_leave_header.dart
@@ -9,7 +9,7 @@ import 'package:clipboard/clipboard.dart';
 class ClanJoinLeaveHeader extends StatefulWidget {
   final Clan clanInfo;
 
-  ClanJoinLeaveHeader({super.key, required this.clanInfo});
+  const ClanJoinLeaveHeader({super.key, required this.clanInfo});
 
   @override
   ClanJoinLeaveHeaderState createState() => ClanJoinLeaveHeaderState();
@@ -37,7 +37,7 @@ class ClanJoinLeaveHeaderState extends State<ClanJoinLeaveHeader>
                   BlendMode.darken,
                 ),
                 child: CachedNetworkImage(
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: backgroundImageUrl,
                   width: double.infinity,
                   fit: BoxFit.cover,
@@ -49,7 +49,7 @@ class ClanJoinLeaveHeaderState extends State<ClanJoinLeaveHeader>
             bottom: 10,
             child: Column(children: [
               CachedNetworkImage(
-                errorWidget: (context, url, error) => Icon(Icons.error),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
                 imageUrl: widget.clanInfo.badgeUrls.large,
                 width: 100,
               ),
@@ -74,10 +74,10 @@ class ClanJoinLeaveHeaderState extends State<ClanJoinLeaveHeader>
                   });
                 },
                 child: Container(
-                  padding: EdgeInsets.only(top: 2.0, bottom: 4.0),
+                  padding: const EdgeInsets.only(top: 2.0, bottom: 4.0),
                   child: Text(
                     widget.clanInfo.tag,
-                    style: TextStyle(color: Colors.white),
+                    style: const TextStyle(color: Colors.white),
                   ),
                 ),
               ),

--- a/lib/features/clan/presentation/join_leave/clan_join_leave_stats.dart
+++ b/lib/features/clan/presentation/join_leave/clan_join_leave_stats.dart
@@ -53,34 +53,34 @@ class _ClanJoinLeaveStatsState extends State<ClanJoinLeaveStats> {
                   StatTile(
                     label: AppLocalizations.of(context)!.warEventsTitle,
                     value: '${stats.totalEvents}',
-                    icon: Icon(Icons.event),
+                    icon: const Icon(Icons.event),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveJoins,
                     value: '${stats.totalJoins}',
                     icon:
-                        Icon(LucideIcons.logIn, size: 24, color: Colors.green),
+                        const Icon(LucideIcons.logIn, size: 24, color: Colors.green),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveLeaves,
                     value: '${stats.totalLeaves}',
-                    icon: Icon(LucideIcons.logOut, size: 24, color: Colors.red),
+                    icon: const Icon(LucideIcons.logOut, size: 24, color: Colors.red),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveUniquePlayers,
                     value: '${stats.uniquePlayers}',
-                    icon: Icon(Icons.group),
+                    icon: const Icon(Icons.group),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveMovingPlayers,
                     value: '${stats.movingPlayers}',
-                    icon: Icon(LucideIcons.activity,
-                        color: const Color.fromARGB(255, 255, 196, 0)),
+                    icon: const Icon(LucideIcons.activity,
+                        color: Color.fromARGB(255, 255, 196, 0)),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveStillInClan,
                     value: '${stats.playerStillInClan}',
-                    icon: MobileWebImage(
+                    icon: const MobileWebImage(
                       imageUrl: ImageAssets.clanCastle,
                       width: 24,
                       height: 24,
@@ -89,25 +89,25 @@ class _ClanJoinLeaveStatsState extends State<ClanJoinLeaveStats> {
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveLeftForever,
                     value: '${stats.playerLeftClan}',
-                    icon: Icon(Icons.waving_hand),
+                    icon: const Icon(Icons.waving_hand),
                   ),
                   StatTile(
                     label: AppLocalizations.of(context)!.joinLeaveRejoinedPlayers,
                     value: '${stats.rejoinedPlayers}',
-                    icon: Icon(Icons.repeat),
+                    icon: const Icon(Icons.repeat),
                   ),
                   if (stats.avgTimeBetweenJoinLeave != null)
                     StatTile(
                       label: AppLocalizations.of(context)!.joinLeaveAvgTimeJoinLeave,
                       value: formatSecondsToHHMM(
                           stats.avgTimeBetweenJoinLeave ?? 0),
-                      icon: Icon(Icons.timer),
+                      icon: const Icon(Icons.timer),
                     ),
                   if (stats.mostMovingHour != null)
                     StatTile(
                       label: AppLocalizations.of(context)!.joinLeavePeakHour,
                       value: '${stats.mostMovingHour}:00',
-                      icon: Icon(Icons.access_time),
+                      icon: const Icon(Icons.access_time),
                     ),
                 ],
               ),
@@ -124,8 +124,8 @@ class _ClanJoinLeaveStatsState extends State<ClanJoinLeaveStats> {
                     final player = entry.value;
                     final icon = index < podiumIcons.length
                         ? Text(podiumIcons[index],
-                            style: TextStyle(fontSize: 20))
-                        : Icon(LucideIcons.user);
+                            style: const TextStyle(fontSize: 20))
+                        : const Icon(LucideIcons.user);
 
                     return StatTile(
                       label: player.name,

--- a/lib/features/coc_accounts/data/coc_account_service.dart
+++ b/lib/features/coc_accounts/data/coc_account_service.dart
@@ -276,7 +276,7 @@ class CocAccountService extends ChangeNotifier {
       spanFetchAccounts.finish();
 
       if (cocAccounts.isEmpty) {
-        transaction.finish(status: SpanStatus.ok());
+        transaction.finish(status: const SpanStatus.ok());
         return;
       }
 
@@ -293,7 +293,7 @@ class CocAccountService extends ChangeNotifier {
           playerTags, playerService, clanService, warCwlService);
       spanBulkLoad.finish();
 
-      transaction.finish(status: SpanStatus.ok());
+      transaction.finish(status: const SpanStatus.ok());
       _lastRefresh = DateTime.now();
       initializeSelectedTag();
     } on HttpException catch (e) {
@@ -306,7 +306,7 @@ class CocAccountService extends ChangeNotifier {
       }
     } catch (e, stack) {
       transaction.throwable = e;
-      transaction.status = SpanStatus.internalError();
+      transaction.status = const SpanStatus.internalError();
       transaction.finish();
       Sentry.captureException(e, stackTrace: stack);
       rethrow;

--- a/lib/features/coc_accounts/presentation/coc_account_management_page.dart
+++ b/lib/features/coc_accounts/presentation/coc_account_management_page.dart
@@ -16,6 +16,8 @@ import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/core/utils/debug_utils.dart';
 
 class AddCocAccountPage extends StatefulWidget {
+  const AddCocAccountPage({super.key});
+
   @override
   AddCocAccountPageState createState() => AddCocAccountPageState();
 }
@@ -83,7 +85,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
       Navigator.of(context).pop();
       Navigator.of(
         context,
-      ).pushReplacement(MaterialPageRoute(builder: (context) => MyHomePage()));
+      ).pushReplacement(MaterialPageRoute(builder: (context) => const MyHomePage()));
     }
   }
 
@@ -113,7 +115,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
         }
       },
       child: Scaffold(
-        appBar: CocAccountsAppBar(),
+        appBar: const CocAccountsAppBar(),
         resizeToAvoidBottomInset: false,
         body: ResponsiveLayoutWrapper(
           child: Column(
@@ -122,7 +124,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
               Expanded(
                 child: Column(
                   children: [
-                    SizedBox(height: 16),
+                    const SizedBox(height: 16),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16.0),
                       child: Column(
@@ -132,20 +134,20 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                             width: 70,
                             child: CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl: logoUrl,
                             ),
                           ),
-                          SizedBox(height: 16),
+                          const SizedBox(height: 16),
                           SizedBox(
                             width: 150,
                             child: CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl: textLogoUrl,
                             ),
                           ),
-                          SizedBox(height: 32),
+                          const SizedBox(height: 32),
                           if (_isFirstConnection) ...[
                             Text(
                               AppLocalizations.of(context)!.accountsWelcome,
@@ -178,7 +180,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                         ],
                       ),
                     ),
-                    SizedBox(height: 16),
+                    const SizedBox(height: 16),
                     Expanded(
                       child: Card(
                         child: Padding(
@@ -200,11 +202,11 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                         ),
                                       ),
                                       suffixIcon: _isAddingLoading
-                                          ? SizedBox(
+                                          ? const SizedBox(
                                               height: 24,
                                               width: 24,
                                               child: Padding(
-                                                padding: const EdgeInsets.all(
+                                                padding: EdgeInsets.all(
                                                   8.0,
                                                 ),
                                                 child:
@@ -232,13 +234,13 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                     ],
                                   ),
                                   if (_errorMessage.isNotEmpty) ...[
-                                    SizedBox(height: 8),
+                                    const SizedBox(height: 8),
                                     Text(
                                       _errorMessage,
-                                      style: TextStyle(color: Colors.red),
+                                      style: const TextStyle(color: Colors.red),
                                     ),
                                   ],
-                                  SizedBox(height: 8),
+                                  const SizedBox(height: 8),
                                   Row(
                                     children: [
                                       Icon(
@@ -248,7 +250,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                           context,
                                         ).colorScheme.primary,
                                       ),
-                                      SizedBox(width: 8),
+                                      const SizedBox(width: 8),
                                       Expanded(
                                         child: Text(
                                           AppLocalizations.of(
@@ -267,7 +269,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                       ),
                                     ],
                                   ),
-                                  SizedBox(height: 8),
+                                  const SizedBox(height: 8),
                                 ],
                               ),
                               Expanded(
@@ -313,7 +315,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                 child: CachedNetworkImage(
                                                   errorWidget:
                                                       (context, url, error) =>
-                                                          Icon(Icons.error),
+                                                          const Icon(Icons.error),
                                                   imageUrl:
                                                       ImageAssets.townHall(
                                                     _tempUserAccounts[index]
@@ -366,7 +368,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                         mainAxisSize:
                                                             MainAxisSize.min,
                                                         children: [
-                                                          Icon(
+                                                          const Icon(
                                                             Icons.verified,
                                                             color: Colors.green,
                                                             size: 16,
@@ -379,7 +381,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                               context,
                                                             )!
                                                                 .accountVerified,
-                                                            style: TextStyle(
+                                                            style: const TextStyle(
                                                               color:
                                                                   Colors.green,
                                                               fontSize: 12,
@@ -438,7 +440,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                           mainAxisSize:
                                                               MainAxisSize.min,
                                                           children: [
-                                                            Icon(
+                                                            const Icon(
                                                               Icons
                                                                   .warning_outlined,
                                                               color:
@@ -454,7 +456,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                                 context,
                                                               )!
                                                                   .accountVerify,
-                                                              style: TextStyle(
+                                                              style: const TextStyle(
                                                                 color: Colors
                                                                     .orange,
                                                                 fontSize: 12,
@@ -497,12 +499,12 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                                             _tempUserAccounts[
                                                                     index]
                                                                 ["player_tag"]
-                                                        ? SizedBox(
+                                                        ? const SizedBox(
                                                             height: 24,
                                                             width: 24,
                                                             child: Padding(
                                                               padding:
-                                                                  const EdgeInsets
+                                                                  EdgeInsets
                                                                       .all(
                                                                 8.0,
                                                               ),

--- a/lib/features/pages/presentation/clan_page.dart
+++ b/lib/features/pages/presentation/clan_page.dart
@@ -81,8 +81,8 @@ class ClanPage extends StatelessWidget {
         child: ListView(children: <Widget>[
           LastRefreshIndicator(lastRefresh: cocService.lastRefresh),
           const SizedBox(height: 4),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8.0),
             child: ClanSearchCard(),
           ),
           if (hasClan)
@@ -95,8 +95,8 @@ class ClanPage extends StatelessWidget {
                       builder: (context) => ClanInfoScreen(clanInfo: clanInfo),
                     ),
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: ClanInfoCard(),
                   ),
                 ),
@@ -108,8 +108,8 @@ class ClanPage extends StatelessWidget {
                           ClanJoinLeaveScreen(clanInfo: clanInfo),
                     ),
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: ClanJoinLeaveCard(),
                   ),
                 ),
@@ -122,16 +122,16 @@ class ClanPage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: ClanCapitalCard(),
                   ),
                 ),
               ],
             )
           else
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0),
               child: Card(child: NoClanCard()),
             ),
           const SizedBox(height: 16),

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -86,8 +86,8 @@ class DashboardPage extends StatelessWidget {
             : ListView(
                 children: <Widget>[
                   LastRefreshIndicator(lastRefresh: cocService.lastRefresh),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
+                  const Padding(
+                    padding: EdgeInsets.all(8.0),
                     child: CreatorCodeCard(),
                   ),
                   Padding(
@@ -105,7 +105,7 @@ class DashboardPage extends StatelessWidget {
                           );
                         }
                       },
-                      child: PlayerSearchCard(),
+                      child: const PlayerSearchCard(),
                     ),
                   ),
                   const Padding(

--- a/lib/features/pages/presentation/war_cwl_page.dart
+++ b/lib/features/pages/presentation/war_cwl_page.dart
@@ -93,7 +93,7 @@ class WarCwlPage extends StatelessWidget {
             LastRefreshIndicator(lastRefresh: cocService.lastRefresh),
             const SizedBox(height: 4),
             if (!hasClan)
-              Padding(
+              const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 8.0),
                 child: Card(child: NoClanCard()),
               )
@@ -106,7 +106,7 @@ class WarCwlPage extends StatelessWidget {
                   ),
                 ),
                 child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8.0),
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: WarCard(
                       currentWarInfo: warCwl.warInfo, clanTag: clan.tag),
                 ),
@@ -137,7 +137,7 @@ class WarCwlPage extends StatelessWidget {
                               ),
                             ),
                           ),
-                          child: CwlCard(),
+                          child: const CwlCard(),
                         ),
                         if (warCwl.getActiveWarByTag(clan.tag) != null)
                           GestureDetector(
@@ -148,7 +148,7 @@ class WarCwlPage extends StatelessWidget {
                                     war: warCwl.getActiveWarByTag(clan.tag)!),
                               ),
                             ),
-                            child: CurrentWarInfoCard(),
+                            child: const CurrentWarInfoCard(),
                           )
                       ],
                     ),

--- a/lib/features/pages/widgets/clan_capital_card.dart
+++ b/lib/features/pages/widgets/clan_capital_card.dart
@@ -34,12 +34,12 @@ class ClanCapitalCard extends StatelessWidget {
                           imageUrl:
                               'https://assets.clashk.ing/capital-base/capital-hall-pics/Building_CC_Capital_Hall_level_${clanInfo?.clanCapital?.capitalHallLevel}.png'),
                     ),
-                    SizedBox(
+                    const SizedBox(
                       width: 100,
                     ),
                   ],
                 ),
-                SizedBox(width: 12),
+                const SizedBox(width: 12),
                 Expanded(
                   flex: 7,
                   child: Column(
@@ -50,7 +50,7 @@ class ClanCapitalCard extends StatelessWidget {
                         textAlign: TextAlign.center,
                         softWrap: true,
                       ),
-                      SizedBox(height: 2.0),
+                      const SizedBox(height: 2.0),
                       Wrap(
                         alignment: WrapAlignment.start,
                         spacing: 7.0,

--- a/lib/features/pages/widgets/clan_info_card.dart
+++ b/lib/features/pages/widgets/clan_info_card.dart
@@ -57,7 +57,7 @@ class ClanInfoCard extends StatelessWidget {
                     ),
                   ],
                 ),
-                SizedBox(width: 12),
+                const SizedBox(width: 12),
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
@@ -73,14 +73,14 @@ class ClanInfoCard extends StatelessWidget {
                             height: 10,
                           ),
                         ],
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(
                           clanInfo.name,
                           style: Theme.of(context).textTheme.titleSmall,
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         Icon(
@@ -88,24 +88,24 @@ class ClanInfoCard extends StatelessWidget {
                           size: 16,
                           color: Theme.of(context).colorScheme.onSurface,
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(
                           '${clanInfo.members.toString()}/50   |   ',
                           style: Theme.of(context).textTheme.labelLarge,
                         ),
-                        SizedBox(
+                        const SizedBox(
                             height: 16,
                             width: 16,
                             child:
                                 MobileWebImage(imageUrl: ImageAssets.trophies)),
-                        SizedBox(width: 4),
+                        const SizedBox(width: 4),
                         Text(
                           clanInfo.clanPoints.toString(),
                           style: Theme.of(context).textTheme.labelLarge,
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         SizedBox(
@@ -115,7 +115,7 @@ class ClanInfoCard extends StatelessWidget {
                               imageUrl: ImageAssets.getLeagueImage(
                                   clanInfo.warLeague?.name ?? "Unranked")),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(
                           clanInfo.warLeague?.name ?? "Unranked",
                           style: Theme.of(context).textTheme.labelLarge,

--- a/lib/features/pages/widgets/clan_join_leave_card.dart
+++ b/lib/features/pages/widgets/clan_join_leave_card.dart
@@ -10,7 +10,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class ClanJoinLeaveCard extends StatelessWidget {
-  ClanJoinLeaveCard({
+  const ClanJoinLeaveCard({
     super.key,
   });
 
@@ -30,10 +30,10 @@ class ClanJoinLeaveCard extends StatelessWidget {
           children: <Widget>[
             Row(
               children: [
-                Column(
+                const Column(
                   children: <Widget>[
                     SizedBox(width: 100),
-                    const SizedBox(height: 12),
+                    SizedBox(height: 12),
                     SizedBox(
                       height: 80,
                       width: 80,

--- a/lib/features/pages/widgets/clan_no_clan_card.dart
+++ b/lib/features/pages/widgets/clan_no_clan_card.dart
@@ -4,21 +4,23 @@ import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class NoClanCard extends StatelessWidget {
+  const NoClanCard({super.key});
+
   @override
   Widget build(BuildContext context) {
     return DefaultTextStyle(
-      style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+      style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
       child: Card(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
           child: Row(
             children: <Widget>[
-              SizedBox(
+              const SizedBox(
                 height: 80,
                 width: 80,
                 child: MobileWebImage(imageUrl: ImageAssets.clanCastle),
               ),
-              SizedBox(width: 16),
+              const SizedBox(width: 16),
               Expanded(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/features/pages/widgets/clan_search_card.dart
+++ b/lib/features/pages/widgets/clan_search_card.dart
@@ -111,7 +111,7 @@ class ClanSearchCardState extends State<ClanSearchCard> {
                             showDialog<String>(
                               context: context,
                               builder: (BuildContext context) {
-                                return ClanSearchFilters();
+                                return const ClanSearchFilters();
                               },
                             ).then((String? filters) {
                               if (filters != null) {

--- a/lib/features/pages/widgets/clan_search_filters_dialog.dart
+++ b/lib/features/pages/widgets/clan_search_filters_dialog.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:cached_network_image/cached_network_image.dart';
 
 class ClanSearchFilters extends StatefulWidget {
+  const ClanSearchFilters({super.key});
+
   @override
   ClanSearchFiltersState createState() => ClanSearchFiltersState();
 }
@@ -143,7 +145,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
     ];
 
     return AlertDialog(
-      insetPadding: EdgeInsets.all(16),
+      insetPadding: const EdgeInsets.all(16),
       backgroundColor: Theme.of(context).colorScheme.surface,
       surfaceTintColor: Colors.transparent,
       title: Text(AppLocalizations.of(context)!.generalFilters,
@@ -157,7 +159,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                 color: Theme.of(context).scaffoldBackgroundColor,
                 child: Column(
                   children: [
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(AppLocalizations.of(context)!.warFrequency,
                         style: Theme.of(context).textTheme.bodyMedium),
                     DropdownButton<String>(
@@ -183,7 +185,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                 color: Theme.of(context).scaffoldBackgroundColor,
                 child: Column(
                   children: [
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(AppLocalizations.of(context)!.clanLocation,
                         style: Theme.of(context).textTheme.bodyMedium),
                     Row(
@@ -235,7 +237,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                                                 color: Theme.of(context)
                                                     .colorScheme
                                                     .onSurface),
-                                        SizedBox(width: 8.0),
+                                        const SizedBox(width: 8.0),
                                         Text(item['name'],
                                             overflow: TextOverflow.ellipsis),
                                       ],
@@ -253,7 +255,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                             },
                           ),
                         ),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                       ],
                     ),
                   ],
@@ -263,16 +265,16 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                 color: Theme.of(context).scaffoldBackgroundColor,
                 child: Column(
                   children: [
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(AppLocalizations.of(context)!.clanMembers,
                         style: Theme.of(context).textTheme.bodyMedium),
                     Row(
                       children: [
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Expanded(
                           flex: 1,
                           child: IconButton(
-                            padding: EdgeInsets.only(right: 8),
+                            padding: const EdgeInsets.only(right: 8),
                             icon: Icon(Icons.remove,
                                 color: Theme.of(context).colorScheme.onSurface,
                                 size: 16),
@@ -313,7 +315,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                             onPressed: _incrementMin,
                           ),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         IconButton(
                           icon: Icon(Icons.remove,
                               color: Theme.of(context).colorScheme.onSurface,
@@ -354,10 +356,10 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                             onPressed: _incrementMax,
                           ),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 ),
               ),
@@ -365,16 +367,16 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                 color: Theme.of(context).scaffoldBackgroundColor,
                 child: Column(
                   children: [
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(AppLocalizations.of(context)!.clanMinimumPoints,
                         style: Theme.of(context).textTheme.bodyMedium),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         Expanded(
                           flex: 1,
                           child: IconButton(
-                            padding: EdgeInsets.only(right: 8),
+                            padding: const EdgeInsets.only(right: 8),
                             icon: Icon(Icons.remove,
                                 color: Theme.of(context).colorScheme.onSurface,
                                 size: 16),
@@ -419,7 +421,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 ),
               ),
@@ -427,16 +429,16 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                 color: Theme.of(context).scaffoldBackgroundColor,
                 child: Column(
                   children: [
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(AppLocalizations.of(context)!.clanMinimumLevel,
                         style: Theme.of(context).textTheme.bodyMedium),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         Expanded(
                           flex: 1,
                           child: IconButton(
-                            padding: EdgeInsets.only(right: 8),
+                            padding: const EdgeInsets.only(right: 8),
                             icon: Icon(Icons.remove,
                                 color: Theme.of(context).colorScheme.onSurface,
                                 size: 16),
@@ -481,7 +483,7 @@ class ClanSearchFiltersState extends State<ClanSearchFilters> {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 ),
               ),

--- a/lib/features/pages/widgets/clan_search_result_tiles.dart
+++ b/lib/features/pages/widgets/clan_search_result_tiles.dart
@@ -8,7 +8,7 @@ import 'package:clashkingapp/features/clan/presentation/clan_info/clan_page.dart
 class ClanSearchResultTile extends StatefulWidget {
   final dynamic clan;
 
-  ClanSearchResultTile({required this.clan});
+  const ClanSearchResultTile({super.key, required this.clan});
 
   @override
   ClanSearchResultTileState createState() => ClanSearchResultTileState();
@@ -32,7 +32,7 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
             context: context,
             barrierDismissible: false,
             builder: (BuildContext context) {
-              return Center(
+              return const Center(
                 child: CircularProgressIndicator(),
               );
             },
@@ -61,11 +61,11 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
           child: Row(
             children: [
               Padding(
-                padding: EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Column(
                   children: [
                     Padding(
-                      padding: EdgeInsets.only(right: 8),
+                      padding: const EdgeInsets.only(right: 8),
                       child: SizedBox(
                         width: 50,
                         child: CachedNetworkImage(
@@ -77,7 +77,7 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
                   ],
                 ),
               ),
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -99,8 +99,8 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
                                       .clan['location']['countryCode']
                                       .toLowerCase()),
                                   width: 16)
-                              : SizedBox.shrink(),
-                          SizedBox(width: 8),
+                              : const SizedBox.shrink(),
+                          const SizedBox(width: 8),
                           CachedNetworkImage(
                             errorWidget: (context, url, error) =>
                                 const Icon(Icons.error),
@@ -115,7 +115,7 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
                         style: Theme.of(context).textTheme.labelLarge!.copyWith(
                             color: Theme.of(context).colorScheme.tertiary),
                       ),
-                      SizedBox(width: 8),
+                      const SizedBox(width: 8),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.start,
                         children: [

--- a/lib/features/pages/widgets/cwl_card.dart
+++ b/lib/features/pages/widgets/cwl_card.dart
@@ -26,7 +26,7 @@ class CwlCardState extends State<CwlCard> {
 
     final clanTag = playerService.getSelectedProfile(cocService)?.clanTag;
     if (clanTag == null || clanTag.isEmpty) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     final clanWarLeague = clanService.getClanByTag(clanTag)?.warLeague?.name;
@@ -34,7 +34,7 @@ class CwlCardState extends State<CwlCard> {
     final clan = warCwl?.leagueInfo?.getClanDetails(clanTag);
 
     if (clanWarLeague == null || clan == null) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     return Card(
@@ -47,11 +47,11 @@ class CwlCardState extends State<CwlCard> {
               height: 70,
               width: 70,
               child: CachedNetworkImage(
-                errorWidget: (context, url, error) => Icon(Icons.error),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
                 imageUrl: ImageAssets.getLeagueImage(clanWarLeague),
               ),
             ),
-            SizedBox(width: 24),
+            const SizedBox(width: 24),
             Expanded(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/features/pages/widgets/cwl_war_card.dart
+++ b/lib/features/pages/widgets/cwl_war_card.dart
@@ -140,7 +140,7 @@ class CurrentWarInfoCard extends StatelessWidget {
             height: 70,
             child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
               imageUrl: clan.badgeUrls.large,
               fit: BoxFit.cover,
             ),

--- a/lib/features/pages/widgets/player_card.dart
+++ b/lib/features/pages/widgets/player_card.dart
@@ -34,7 +34,7 @@ class PlayerCard extends StatelessWidget {
         : AppLocalizations.of(context)?.warStatusUnready ?? 'Unready';
 
     return DefaultTextStyle(
-      style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+      style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
       child: GestureDetector(
         onTap: () {
           Navigator.push(
@@ -59,7 +59,7 @@ class PlayerCard extends StatelessWidget {
                           width: 100,
                           child: CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl: player.townHallPic),
                         ),
                         Text(
@@ -68,7 +68,7 @@ class PlayerCard extends StatelessWidget {
                                   .textTheme
                                   .labelLarge
                                   ?.copyWith(fontWeight: FontWeight.bold)) ??
-                              TextStyle(fontWeight: FontWeight.bold),
+                              const TextStyle(fontWeight: FontWeight.bold),
                         ),
                         Text(
                           player.tag,
@@ -76,7 +76,7 @@ class PlayerCard extends StatelessWidget {
                         ),
                       ],
                     ),
-                    SizedBox(width: 8),
+                    const SizedBox(width: 8),
                     Expanded(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,
@@ -99,7 +99,7 @@ class PlayerCard extends StatelessWidget {
                               IconChip(
                                   icon: LucideIcons.chevronsUpDown,
                                   label: player.donationRatio,
-                                  color: Color.fromARGB(255, 0, 136, 255),
+                                  color: const Color.fromARGB(255, 0, 136, 255),
                                   size: 20,
                                   description: AppLocalizations.of(context)!
                                       .playerRatioDescription(

--- a/lib/features/pages/widgets/player_info_card.dart
+++ b/lib/features/pages/widgets/player_info_card.dart
@@ -19,7 +19,7 @@ class PlayerInfosCard extends StatelessWidget {
     final selectedProfile = playerService.getSelectedProfile(cocAccountService);
 
     if (selectedProfile == null) {
-      return Center(
+      return const Center(
         child: CircularProgressIndicator(),
       );
     }
@@ -38,7 +38,7 @@ class PlayerInfosCard extends StatelessWidget {
         : AppLocalizations.of(context)?.warStatusUnready ?? 'Unready';
 
     return DefaultTextStyle(
-      style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+      style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
       child: Card(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
@@ -61,7 +61,7 @@ class PlayerInfosCard extends StatelessWidget {
                                 .textTheme
                                 .labelLarge
                                 ?.copyWith(fontWeight: FontWeight.bold) ??
-                            TextStyle(fontWeight: FontWeight.bold),
+                            const TextStyle(fontWeight: FontWeight.bold),
                       ),
                       Text(
                         selectedProfile.tag,
@@ -69,7 +69,7 @@ class PlayerInfosCard extends StatelessWidget {
                       ),
                     ],
                   ),
-                  SizedBox(width: 8),
+                  const SizedBox(width: 8),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.center,
@@ -93,7 +93,7 @@ class PlayerInfosCard extends StatelessWidget {
                             IconChip(
                                 icon: LucideIcons.chevronsUpDown,
                                 label: ratioDonation.toStringAsFixed(2),
-                                color: Color.fromARGB(255, 0, 136, 255),
+                                color: const Color.fromARGB(255, 0, 136, 255),
                                 size: 20,
                                 description: AppLocalizations.of(context)!
                                     .playerRatioDescription(

--- a/lib/features/pages/widgets/player_legend_card.dart
+++ b/lib/features/pages/widgets/player_legend_card.dart
@@ -11,10 +11,10 @@ import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/common/widgets/buttons/chip.dart';
 import 'package:provider/provider.dart';
 
+const String _numberFormat = '#,###';
+
 class PlayerLegendCard extends StatelessWidget {
-  const PlayerLegendCard({
-    super.key,
-  });
+  const PlayerLegendCard({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -36,8 +36,10 @@ class PlayerLegendCard extends StatelessWidget {
                 player.legendsBySeason!.allSeasons.isNotEmpty
             ? Card(
                 child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
@@ -50,10 +52,11 @@ class PlayerLegendCard extends StatelessWidget {
                                 children: [
                                   Text(
                                     AppLocalizations.of(context)!.legendsTitle,
-                                    style:
-                                        Theme.of(context).textTheme.labelLarge,
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.labelLarge,
                                   ),
-                                  MobileWebImage(
+                                  const MobileWebImage(
                                     imageUrl: ImageAssets.legendBlazon,
                                     width: 100,
                                     height: 100,
@@ -65,10 +68,11 @@ class PlayerLegendCard extends StatelessWidget {
                                   bottom: 40,
                                   child: Text(
                                     NumberFormat(
-                                            '#,###',
-                                            Localizations.localeOf(context)
-                                                .toString())
-                                        .format(player.trophies),
+                                      _numberFormat,
+                                      Localizations.localeOf(
+                                        context,
+                                      ).toString(),
+                                    ).format(player.trophies),
                                     style: Theme.of(context)
                                         .textTheme
                                         .titleSmall
@@ -77,326 +81,436 @@ class PlayerLegendCard extends StatelessWidget {
                                 ),
                             ],
                           ),
-                          SizedBox(width: 12),
+                          const SizedBox(width: 12),
                           Expanded(
                             child: currentDay != null
                                 ? Column(
                                     mainAxisAlignment: MainAxisAlignment.center,
                                     children: [
-                                        Wrap(
-                                          spacing: 8,
-                                          runSpacing: -6,
-                                          runAlignment: WrapAlignment.center,
-                                          children: [
-                                            if (player.rankings?.countryCode != null && player.rankings?.countryCode != "")
-                                              ImageChip(
-                                                  context: context,
-                                                  imageUrl: ImageAssets.flag(
-                                                      player.rankings?.countryCode ??
-                                                          ""),
-                                                  label: player.rankings?.localRank != 0
-                                                      ? NumberFormat('#,###', Localizations.localeOf(context).toString())
-                                                          .format(player
-                                                              .rankings
-                                                              ?.localRank)
-                                                      : AppLocalizations.of(context)!
-                                                          .legendsNoRank,
-                                                  description: player.rankings?.localRank != 0
-                                                      ? AppLocalizations.of(context)!
-                                                          .legendsRankLocalDescription(
-                                                              player.rankings?.localRank ?? 0,
-                                                              player.rankings!.countryName ?? "",
-                                                              player.trophies)
-                                                      : AppLocalizations.of(context)!.legendsNoRankLocalDescription(player.rankings!.countryName ?? "", player.trophies)),
-                                            if (player.rankings?.countryCode !=
-                                                    null &&
-                                                player.rankings?.countryCode !=
-                                                    "" &&
-                                                player.rankings?.globalRank !=
-                                                    0)
-                                              ImageChip(
-                                                  context: context,
-                                                  imageUrl: ImageAssets.planet,
-                                                  label: player.rankings?.globalRank != null
-                                                      ? NumberFormat('#,###', Localizations.localeOf(context).toString())
-                                                          .format(player
-                                                              .rankings
-                                                              ?.globalRank)
-                                                      : "N/A",
-                                                  description: player.rankings?.globalRank != null
-                                                      ? AppLocalizations.of(context)!
-                                                          .legendsGlobalRankDescription(
-                                                              player.rankings?.globalRank ?? 0,
-                                                              player.trophies)
-                                                      : AppLocalizations.of(context)!.legendsNoGlobalRankDescription(player.trophies)),
+                                      Wrap(
+                                        spacing: 8,
+                                        runSpacing: -6,
+                                        runAlignment: WrapAlignment.center,
+                                        children: [
+                                          if (player.rankings?.countryCode !=
+                                                  null &&
+                                              player.rankings?.countryCode !=
+                                                  "")
                                             ImageChip(
                                               context: context,
-                                              imageUrl:
-                                                  ImageAssets.legendStartFlag,
-                                              label: NumberFormat(
-                                                      '#,###',
-                                                      Localizations.localeOf(
-                                                              context)
-                                                          .toString())
-                                                  .format(currentDay
-                                                          .startTrophies ??
-                                                      0),
-                                              description: AppLocalizations.of(
-                                                      context)!
-                                                  .legendsStartDescription(
-                                                      "${currentDay.startTrophies ?? 0}"),
-                                            ),
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl: ImageAssets.sword,
-                                              labelWidget: RichText(
-                                                text: TextSpan(
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .labelLarge,
-                                                  children: [
-                                                    TextSpan(
-                                                        text:
-                                                            "${currentDay.totalAttacks}"),
-                                                    WidgetSpan(
-                                                      child:
-                                                          Transform.translate(
-                                                        offset:
-                                                            const Offset(2, -6),
-                                                        child: Text(
-                                                          "(+${currentDay.trophiesGainedTotal})",
-                                                          style:
-                                                              Theme.of(context)
-                                                                  .textTheme
-                                                                  .labelSmall,
-                                                        ),
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
+                                              imageUrl: ImageAssets.flag(
+                                                player.rankings?.countryCode ??
+                                                    "",
                                               ),
-                                              description:
-                                                  AppLocalizations.of(context)!
-                                                      .todoAttacksLeftDescription(
-                                                (8 - currentDay.totalAttacks),
-                                                AppLocalizations.of(context)!
-                                                    .legendsTitle,
-                                              ),
-                                            ),
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl:
-                                                  ImageAssets.shieldWithArrow,
-                                              labelWidget: RichText(
-                                                text: TextSpan(
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .labelLarge,
-                                                  children: [
-                                                    TextSpan(
-                                                        text:
-                                                            "${currentDay.totalDefenses}"),
-                                                    WidgetSpan(
-                                                      child:
-                                                          Transform.translate(
-                                                        offset:
-                                                            const Offset(2, -6),
-                                                        child: Text(
-                                                          "(-${currentDay.trophiesLostTotal})",
-                                                          style:
-                                                              Theme.of(context)
-                                                                  .textTheme
-                                                                  .labelSmall,
-                                                        ),
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                              description:
-                                                  AppLocalizations.of(context)!
-                                                      .todoDefensesLeftDescription(
-                                                (8 - currentDay.totalDefenses),
-                                                AppLocalizations.of(context)!
-                                                    .legendsTitle,
-                                              ),
-                                            ),
-                                            IconChip(
-                                              icon:
-                                                  currentDay.trophiesTotal >= 0
-                                                      ? LucideIcons.chevronUp
-                                                      : LucideIcons.chevronDown,
-                                              color:
-                                                  currentDay.trophiesTotal >= 0
-                                                      ? Colors.green
-                                                      : Colors.red,
-                                              size: 16,
                                               label:
-                                                  "${currentDay.trophiesTotal >= 0 ? '+' : ''}${currentDay.trophiesTotal}",
-                                              description: currentDay
-                                                          .trophiesTotal >=
+                                                  player.rankings?.localRank !=
+                                                      0
+                                                  ? NumberFormat(
+                                                      _numberFormat,
+                                                      Localizations.localeOf(
+                                                        context,
+                                                      ).toString(),
+                                                    ).format(
+                                                      player
+                                                          .rankings
+                                                          ?.localRank,
+                                                    )
+                                                  : AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsNoRank,
+                                              description:
+                                                  player.rankings?.localRank !=
                                                       0
                                                   ? AppLocalizations.of(
-                                                          context)!
-                                                      .legendsGainDescription(
-                                                          currentDay
-                                                              .trophiesTotal)
+                                                      context,
+                                                    )!.legendsRankLocalDescription(
+                                                      player
+                                                              .rankings
+                                                              ?.localRank ??
+                                                          0,
+                                                      player
+                                                              .rankings!
+                                                              .countryName ??
+                                                          "",
+                                                      player.trophies,
+                                                    )
                                                   : AppLocalizations.of(
-                                                          context)!
-                                                      .legendsLossDescription(
-                                                          -currentDay
-                                                              .trophiesTotal),
+                                                      context,
+                                                    )!.legendsNoRankLocalDescription(
+                                                      player
+                                                              .rankings!
+                                                              .countryName ??
+                                                          "",
+                                                      player.trophies,
+                                                    ),
                                             ),
-                                          ],
-                                        )
-                                      ])
+                                          if (player.rankings?.countryCode !=
+                                                  null &&
+                                              player.rankings?.countryCode !=
+                                                  "" &&
+                                              player.rankings?.globalRank != 0)
+                                            ImageChip(
+                                              context: context,
+                                              imageUrl: ImageAssets.planet,
+                                              label:
+                                                  player.rankings?.globalRank !=
+                                                      null
+                                                  ? NumberFormat(
+                                                      _numberFormat,
+                                                      Localizations.localeOf(
+                                                        context,
+                                                      ).toString(),
+                                                    ).format(
+                                                      player
+                                                          .rankings
+                                                          ?.globalRank,
+                                                    )
+                                                  : "N/A",
+                                              description:
+                                                  player.rankings?.globalRank !=
+                                                      null
+                                                  ? AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsGlobalRankDescription(
+                                                      player
+                                                              .rankings
+                                                              ?.globalRank ??
+                                                          0,
+                                                      player.trophies,
+                                                    )
+                                                  : AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsNoGlobalRankDescription(
+                                                      player.trophies,
+                                                    ),
+                                            ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl:
+                                                ImageAssets.legendStartFlag,
+                                            label:
+                                                NumberFormat(
+                                                  _numberFormat,
+                                                  Localizations.localeOf(
+                                                    context,
+                                                  ).toString(),
+                                                ).format(
+                                                  currentDay.startTrophies ?? 0,
+                                                ),
+                                            description:
+                                                AppLocalizations.of(
+                                                  context,
+                                                )!.legendsStartDescription(
+                                                  "${currentDay.startTrophies ?? 0}",
+                                                ),
+                                          ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl: ImageAssets.sword,
+                                            labelWidget: RichText(
+                                              text: TextSpan(
+                                                style: Theme.of(
+                                                  context,
+                                                ).textTheme.labelLarge,
+                                                children: [
+                                                  TextSpan(
+                                                    text:
+                                                        "${currentDay.totalAttacks}",
+                                                  ),
+                                                  WidgetSpan(
+                                                    child: Transform.translate(
+                                                      offset: const Offset(
+                                                        2,
+                                                        -6,
+                                                      ),
+                                                      child: Text(
+                                                        "(+${currentDay.trophiesGainedTotal})",
+                                                        style: Theme.of(
+                                                          context,
+                                                        ).textTheme.labelSmall,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                            description:
+                                                AppLocalizations.of(
+                                                  context,
+                                                )!.todoAttacksLeftDescription(
+                                                  (8 - currentDay.totalAttacks),
+                                                  AppLocalizations.of(
+                                                    context,
+                                                  )!.legendsTitle,
+                                                ),
+                                          ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl:
+                                                ImageAssets.shieldWithArrow,
+                                            labelWidget: RichText(
+                                              text: TextSpan(
+                                                style: Theme.of(
+                                                  context,
+                                                ).textTheme.labelLarge,
+                                                children: [
+                                                  TextSpan(
+                                                    text:
+                                                        "${currentDay.totalDefenses}",
+                                                  ),
+                                                  WidgetSpan(
+                                                    child: Transform.translate(
+                                                      offset: const Offset(
+                                                        2,
+                                                        -6,
+                                                      ),
+                                                      child: Text(
+                                                        "(-${currentDay.trophiesLostTotal})",
+                                                        style: Theme.of(
+                                                          context,
+                                                        ).textTheme.labelSmall,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                            description:
+                                                AppLocalizations.of(
+                                                  context,
+                                                )!.todoDefensesLeftDescription(
+                                                  (8 -
+                                                      currentDay.totalDefenses),
+                                                  AppLocalizations.of(
+                                                    context,
+                                                  )!.legendsTitle,
+                                                ),
+                                          ),
+                                          IconChip(
+                                            icon: currentDay.trophiesTotal >= 0
+                                                ? LucideIcons.chevronUp
+                                                : LucideIcons.chevronDown,
+                                            color: currentDay.trophiesTotal >= 0
+                                                ? Colors.green
+                                                : Colors.red,
+                                            size: 16,
+                                            label:
+                                                "${currentDay.trophiesTotal >= 0 ? '+' : ''}${currentDay.trophiesTotal}",
+                                            description:
+                                                currentDay.trophiesTotal >= 0
+                                                ? AppLocalizations.of(
+                                                    context,
+                                                  )!.legendsGainDescription(
+                                                    currentDay.trophiesTotal,
+                                                  )
+                                                : AppLocalizations.of(
+                                                    context,
+                                                  )!.legendsLossDescription(
+                                                    -currentDay.trophiesTotal,
+                                                  ),
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  )
                                 : isLegend
-                                    ? Column(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.center,
+                                ? Column(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Wrap(
+                                        spacing: 8,
+                                        runSpacing: -6,
+                                        runAlignment: WrapAlignment.center,
                                         children: [
-                                            Wrap(
-                                              spacing: 8,
-                                              runSpacing: -6,
-                                              runAlignment:
-                                                  WrapAlignment.center,
-                                              children: [
-                                                if (player.rankings?.countryCode != null && player.rankings?.countryCode != "")
-                                                  ImageChip(
-                                                      context: context,
-                                                      imageUrl: ImageAssets.flag(
-                                                          player.rankings?.countryCode ??
-                                                              ""),
-                                                      label: player.rankings?.localRank != 0
-                                                          ? NumberFormat('#,###', Localizations.localeOf(context).toString())
-                                                              .format(player
-                                                                  .rankings
-                                                                  ?.localRank)
-                                                          : AppLocalizations.of(context)!
-                                                              .legendsNoRank,
-                                                      description: player.rankings?.localRank != 0
-                                                          ? AppLocalizations.of(context)!
-                                                              .legendsRankLocalDescription(
-                                                                  player.rankings?.localRank ?? 0,
-                                                                  player.rankings!.countryName ?? "",
-                                                                  player.trophies)
-                                                          : AppLocalizations.of(context)!.legendsNoRankLocalDescription(player.rankings!.countryName ?? "", player.trophies)),
-                                                if (player.rankings?.countryCode != null &&
-                                                    player.rankings?.countryCode !=
-                                                        "" &&
-                                                    player.rankings?.globalRank !=
-                                                        0)
-                                                  ImageChip(
-                                                      context: context,
-                                                      imageUrl:
-                                                          ImageAssets.planet,
-                                                      label: player.rankings?.globalRank != null
-                                                          ? NumberFormat('#,###', Localizations.localeOf(context).toString())
-                                                              .format(player
-                                                                  .rankings
-                                                                  ?.globalRank)
-                                                          : "N/A",
-                                                      description: player.rankings?.globalRank != null
-                                                          ? AppLocalizations.of(context)!
-                                                              .legendsGlobalRankDescription(
-                                                                  player.rankings?.globalRank ?? 0,
-                                                                  player.trophies)
-                                                          : AppLocalizations.of(context)!.legendsNoGlobalRankDescription(player.trophies)),
-                                                ImageChip(
-                                                  context: context,
-                                                  imageUrl: ImageAssets
-                                                      .legendStartFlag,
-                                                  label: NumberFormat(
-                                                          '#,###',
-                                                          Localizations
-                                                                  .localeOf(
-                                                                      context)
-                                                              .toString())
-                                                      .format(player.trophies),
-                                                  description: AppLocalizations
-                                                          .of(context)!
-                                                      .legendsStartDescription(
-                                                          "${player.trophies}"),
+                                          if (player.rankings?.countryCode !=
+                                                  null &&
+                                              player.rankings?.countryCode !=
+                                                  "")
+                                            ImageChip(
+                                              context: context,
+                                              imageUrl: ImageAssets.flag(
+                                                player.rankings?.countryCode ??
+                                                    "",
+                                              ),
+                                              label:
+                                                  player.rankings?.localRank !=
+                                                      0
+                                                  ? NumberFormat(
+                                                      _numberFormat,
+                                                      Localizations.localeOf(
+                                                        context,
+                                                      ).toString(),
+                                                    ).format(
+                                                      player
+                                                          .rankings
+                                                          ?.localRank,
+                                                    )
+                                                  : AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsNoRank,
+                                              description:
+                                                  player.rankings?.localRank !=
+                                                      0
+                                                  ? AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsRankLocalDescription(
+                                                      player
+                                                              .rankings
+                                                              ?.localRank ??
+                                                          0,
+                                                      player
+                                                              .rankings!
+                                                              .countryName ??
+                                                          "",
+                                                      player.trophies,
+                                                    )
+                                                  : AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsNoRankLocalDescription(
+                                                      player
+                                                              .rankings!
+                                                              .countryName ??
+                                                          "",
+                                                      player.trophies,
+                                                    ),
+                                            ),
+                                          if (player.rankings?.countryCode !=
+                                                  null &&
+                                              player.rankings?.countryCode !=
+                                                  "" &&
+                                              player.rankings?.globalRank != 0)
+                                            ImageChip(
+                                              context: context,
+                                              imageUrl: ImageAssets.planet,
+                                              label:
+                                                  player.rankings?.globalRank !=
+                                                      null
+                                                  ? NumberFormat(
+                                                      _numberFormat,
+                                                      Localizations.localeOf(
+                                                        context,
+                                                      ).toString(),
+                                                    ).format(
+                                                      player
+                                                          .rankings
+                                                          ?.globalRank,
+                                                    )
+                                                  : "N/A",
+                                              description:
+                                                  player.rankings?.globalRank !=
+                                                      null
+                                                  ? AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsGlobalRankDescription(
+                                                      player
+                                                              .rankings
+                                                              ?.globalRank ??
+                                                          0,
+                                                      player.trophies,
+                                                    )
+                                                  : AppLocalizations.of(
+                                                      context,
+                                                    )!.legendsNoGlobalRankDescription(
+                                                      player.trophies,
+                                                    ),
+                                            ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl:
+                                                ImageAssets.legendStartFlag,
+                                            label: NumberFormat(
+                                              _numberFormat,
+                                              Localizations.localeOf(
+                                                context,
+                                              ).toString(),
+                                            ).format(player.trophies),
+                                            description:
+                                                AppLocalizations.of(
+                                                  context,
+                                                )!.legendsStartDescription(
+                                                  "${player.trophies}",
                                                 ),
-                                                ImageChip(
-                                                  context: context,
-                                                  imageUrl: ImageAssets.sword,
-                                                  labelWidget: RichText(
-                                                    text: TextSpan(
-                                                      style: Theme.of(context)
-                                                          .textTheme
-                                                          .labelLarge,
-                                                      children: [
-                                                        TextSpan(text: "0"),
-                                                        WidgetSpan(
-                                                          child: Transform
-                                                              .translate(
-                                                            offset:
-                                                                const Offset(
-                                                                    2, -6),
-                                                            child: Text(
-                                                              "(+0)",
-                                                              style: Theme.of(
-                                                                      context)
-                                                                  .textTheme
-                                                                  .labelSmall,
-                                                            ),
-                                                          ),
-                                                        ),
-                                                      ],
+                                          ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl: ImageAssets.sword,
+                                            labelWidget: RichText(
+                                              text: TextSpan(
+                                                style: Theme.of(
+                                                  context,
+                                                ).textTheme.labelLarge,
+                                                children: [
+                                                  const TextSpan(text: "0"),
+                                                  WidgetSpan(
+                                                    child: Transform.translate(
+                                                      offset: const Offset(
+                                                        2,
+                                                        -6,
+                                                      ),
+                                                      child: Text(
+                                                        "(+0)",
+                                                        style: Theme.of(
+                                                          context,
+                                                        ).textTheme.labelSmall,
+                                                      ),
                                                     ),
                                                   ),
-                                                  description: "",
-                                                ),
-                                                ImageChip(
-                                                  context: context,
-                                                  imageUrl: ImageAssets
-                                                      .shieldWithArrow,
-                                                  labelWidget: RichText(
-                                                    text: TextSpan(
-                                                      style: Theme.of(context)
-                                                          .textTheme
-                                                          .labelLarge,
-                                                      children: [
-                                                        TextSpan(text: "0"),
-                                                        WidgetSpan(
-                                                          child: Transform
-                                                              .translate(
-                                                            offset:
-                                                                const Offset(
-                                                                    2, -6),
-                                                            child: Text(
-                                                              "(-0)",
-                                                              style: Theme.of(
-                                                                      context)
-                                                                  .textTheme
-                                                                  .labelSmall,
-                                                            ),
-                                                          ),
-                                                        ),
-                                                      ],
+                                                ],
+                                              ),
+                                            ),
+                                            description: "",
+                                          ),
+                                          ImageChip(
+                                            context: context,
+                                            imageUrl:
+                                                ImageAssets.shieldWithArrow,
+                                            labelWidget: RichText(
+                                              text: TextSpan(
+                                                style: Theme.of(
+                                                  context,
+                                                ).textTheme.labelLarge,
+                                                children: [
+                                                  const TextSpan(text: "0"),
+                                                  WidgetSpan(
+                                                    child: Transform.translate(
+                                                      offset: const Offset(
+                                                        2,
+                                                        -6,
+                                                      ),
+                                                      child: Text(
+                                                        "(-0)",
+                                                        style: Theme.of(
+                                                          context,
+                                                        ).textTheme.labelSmall,
+                                                      ),
                                                     ),
                                                   ),
-                                                  description: "",
-                                                ),
-                                                IconChip(
-                                                    icon: LucideIcons.equal,
-                                                    color: Colors.blue,
-                                                    size: 16,
-                                                    label: "0",
-                                                    description: AppLocalizations
-                                                            .of(context)!
-                                                        .legendsGainDescription(
-                                                            0)),
-                                              ],
-                                            )
-                                          ])
-                                    : Text(
-                                        AppLocalizations.of(context)!
-                                            .legendsNoDataToday,
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .labelLarge),
+                                                ],
+                                              ),
+                                            ),
+                                            description: "",
+                                          ),
+                                          IconChip(
+                                            icon: LucideIcons.equal,
+                                            color: Colors.blue,
+                                            size: 16,
+                                            label: "0",
+                                            description: AppLocalizations.of(
+                                              context,
+                                            )!.legendsGainDescription(0),
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  )
+                                : Text(
+                                    AppLocalizations.of(
+                                      context,
+                                    )!.legendsNoDataToday,
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.labelLarge,
+                                  ),
                           ),
                         ],
                       ),
@@ -404,7 +518,7 @@ class PlayerLegendCard extends StatelessWidget {
                   ),
                 ),
               )
-            : SizedBox.shrink()
+            : const SizedBox.shrink(),
       ],
     );
   }

--- a/lib/features/pages/widgets/player_legend_card.dart
+++ b/lib/features/pages/widgets/player_legend_card.dart
@@ -4,6 +4,7 @@ import 'package:clashkingapp/features/coc_accounts/data/coc_account_service.dart
 import 'package:clashkingapp/features/player/data/player_service.dart';
 import 'package:clashkingapp/features/player/models/player_legend_day.dart';
 import 'package:clashkingapp/features/player/models/player_legend_season.dart';
+import 'package:clashkingapp/features/player/models/player_rankings.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -12,6 +13,80 @@ import 'package:clashkingapp/common/widgets/buttons/chip.dart';
 import 'package:provider/provider.dart';
 
 const String _numberFormat = '#,###';
+
+Widget? _buildLocalRankChip(BuildContext context, PlayerRankings? rankings, int trophies) {
+  if (rankings?.countryCode == null || rankings?.countryCode == '') return null;
+
+  final localizations = AppLocalizations.of(context)!;
+  final locale = Localizations.localeOf(context).toString();
+  final localRank = rankings?.localRank ?? 0;
+  final countryName = rankings?.countryName ?? '';
+  late final String label;
+  late final String description;
+
+  if (localRank != 0) {
+    label = NumberFormat(_numberFormat, locale).format(localRank);
+    description = localizations.legendsRankLocalDescription(
+      localRank,
+      countryName,
+      trophies,
+    );
+  } else {
+    label = localizations.legendsNoRank;
+    description = localizations.legendsNoRankLocalDescription(
+      countryName,
+      trophies,
+    );
+  }
+
+  return ImageChip(
+    context: context,
+    imageUrl: ImageAssets.flag(rankings?.countryCode ?? ''),
+    label: label,
+    description: description,
+  );
+}
+
+Widget? _buildGlobalRankChip(BuildContext context, PlayerRankings? rankings, int trophies) {
+  if (rankings?.countryCode == null ||
+      rankings?.countryCode == '' ||
+      rankings?.globalRank == null ||
+      rankings?.globalRank == 0) {
+    return null;
+  }
+
+  final locale = Localizations.localeOf(context).toString();
+  final globalRank = rankings?.globalRank ?? 0;
+
+  return ImageChip(
+    context: context,
+    imageUrl: ImageAssets.planet,
+    label: NumberFormat(_numberFormat, locale).format(globalRank),
+    description: AppLocalizations.of(context)!.legendsGlobalRankDescription(
+      globalRank,
+      trophies,
+    ),
+  );
+}
+
+Widget _buildTrophiesTotalChip(BuildContext context, int trophiesTotal) {
+  final localizations = AppLocalizations.of(context)!;
+  final isGain = trophiesTotal >= 0;
+  final icon = isGain ? LucideIcons.chevronUp : LucideIcons.chevronDown;
+  final color = isGain ? Colors.green : Colors.red;
+  final labelPrefix = isGain ? '+' : '';
+  final description = isGain
+      ? localizations.legendsGainDescription(trophiesTotal)
+      : localizations.legendsLossDescription(-trophiesTotal);
+
+  return IconChip(
+    icon: icon,
+    color: color,
+    size: 16,
+    label: '$labelPrefix$trophiesTotal',
+    description: description,
+  );
+}
 
 class PlayerLegendCard extends StatelessWidget {
   const PlayerLegendCard({super.key});
@@ -29,6 +104,17 @@ class PlayerLegendCard extends StatelessWidget {
       currentSeason = player.currentLegendSeason;
       currentDay = currentSeason?.currentDay;
     }
+
+    final localRankChip = _buildLocalRankChip(
+      context,
+      player.rankings,
+      player.trophies,
+    );
+    final globalRankChip = _buildGlobalRankChip(
+      context,
+      player.rankings,
+      player.trophies,
+    );
 
     return Column(
       children: [
@@ -92,98 +178,10 @@ class PlayerLegendCard extends StatelessWidget {
                                         runSpacing: -6,
                                         runAlignment: WrapAlignment.center,
                                         children: [
-                                          if (player.rankings?.countryCode !=
-                                                  null &&
-                                              player.rankings?.countryCode !=
-                                                  "")
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl: ImageAssets.flag(
-                                                player.rankings?.countryCode ??
-                                                    "",
-                                              ),
-                                              label:
-                                                  player.rankings?.localRank !=
-                                                      0
-                                                  ? NumberFormat(
-                                                      _numberFormat,
-                                                      Localizations.localeOf(
-                                                        context,
-                                                      ).toString(),
-                                                    ).format(
-                                                      player
-                                                          .rankings
-                                                          ?.localRank,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoRank,
-                                              description:
-                                                  player.rankings?.localRank !=
-                                                      0
-                                                  ? AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsRankLocalDescription(
-                                                      player
-                                                              .rankings
-                                                              ?.localRank ??
-                                                          0,
-                                                      player
-                                                              .rankings!
-                                                              .countryName ??
-                                                          "",
-                                                      player.trophies,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoRankLocalDescription(
-                                                      player
-                                                              .rankings!
-                                                              .countryName ??
-                                                          "",
-                                                      player.trophies,
-                                                    ),
-                                            ),
-                                          if (player.rankings?.countryCode !=
-                                                  null &&
-                                              player.rankings?.countryCode !=
-                                                  "" &&
-                                              player.rankings?.globalRank != 0)
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl: ImageAssets.planet,
-                                              label:
-                                                  player.rankings?.globalRank !=
-                                                      null
-                                                  ? NumberFormat(
-                                                      _numberFormat,
-                                                      Localizations.localeOf(
-                                                        context,
-                                                      ).toString(),
-                                                    ).format(
-                                                      player
-                                                          .rankings
-                                                          ?.globalRank,
-                                                    )
-                                                  : "N/A",
-                                              description:
-                                                  player.rankings?.globalRank !=
-                                                      null
-                                                  ? AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsGlobalRankDescription(
-                                                      player
-                                                              .rankings
-                                                              ?.globalRank ??
-                                                          0,
-                                                      player.trophies,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoGlobalRankDescription(
-                                                      player.trophies,
-                                                    ),
-                                            ),
+                                          if (localRankChip != null)
+                                            localRankChip,
+                                          if (globalRankChip != null)
+                                            globalRankChip,
                                           ImageChip(
                                             context: context,
                                             imageUrl:
@@ -286,28 +284,9 @@ class PlayerLegendCard extends StatelessWidget {
                                                   )!.legendsTitle,
                                                 ),
                                           ),
-                                          IconChip(
-                                            icon: currentDay.trophiesTotal >= 0
-                                                ? LucideIcons.chevronUp
-                                                : LucideIcons.chevronDown,
-                                            color: currentDay.trophiesTotal >= 0
-                                                ? Colors.green
-                                                : Colors.red,
-                                            size: 16,
-                                            label:
-                                                "${currentDay.trophiesTotal >= 0 ? '+' : ''}${currentDay.trophiesTotal}",
-                                            description:
-                                                currentDay.trophiesTotal >= 0
-                                                ? AppLocalizations.of(
-                                                    context,
-                                                  )!.legendsGainDescription(
-                                                    currentDay.trophiesTotal,
-                                                  )
-                                                : AppLocalizations.of(
-                                                    context,
-                                                  )!.legendsLossDescription(
-                                                    -currentDay.trophiesTotal,
-                                                  ),
+                                          _buildTrophiesTotalChip(
+                                            context,
+                                            currentDay.trophiesTotal,
                                           ),
                                         ],
                                       ),
@@ -322,98 +301,10 @@ class PlayerLegendCard extends StatelessWidget {
                                         runSpacing: -6,
                                         runAlignment: WrapAlignment.center,
                                         children: [
-                                          if (player.rankings?.countryCode !=
-                                                  null &&
-                                              player.rankings?.countryCode !=
-                                                  "")
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl: ImageAssets.flag(
-                                                player.rankings?.countryCode ??
-                                                    "",
-                                              ),
-                                              label:
-                                                  player.rankings?.localRank !=
-                                                      0
-                                                  ? NumberFormat(
-                                                      _numberFormat,
-                                                      Localizations.localeOf(
-                                                        context,
-                                                      ).toString(),
-                                                    ).format(
-                                                      player
-                                                          .rankings
-                                                          ?.localRank,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoRank,
-                                              description:
-                                                  player.rankings?.localRank !=
-                                                      0
-                                                  ? AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsRankLocalDescription(
-                                                      player
-                                                              .rankings
-                                                              ?.localRank ??
-                                                          0,
-                                                      player
-                                                              .rankings!
-                                                              .countryName ??
-                                                          "",
-                                                      player.trophies,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoRankLocalDescription(
-                                                      player
-                                                              .rankings!
-                                                              .countryName ??
-                                                          "",
-                                                      player.trophies,
-                                                    ),
-                                            ),
-                                          if (player.rankings?.countryCode !=
-                                                  null &&
-                                              player.rankings?.countryCode !=
-                                                  "" &&
-                                              player.rankings?.globalRank != 0)
-                                            ImageChip(
-                                              context: context,
-                                              imageUrl: ImageAssets.planet,
-                                              label:
-                                                  player.rankings?.globalRank !=
-                                                      null
-                                                  ? NumberFormat(
-                                                      _numberFormat,
-                                                      Localizations.localeOf(
-                                                        context,
-                                                      ).toString(),
-                                                    ).format(
-                                                      player
-                                                          .rankings
-                                                          ?.globalRank,
-                                                    )
-                                                  : "N/A",
-                                              description:
-                                                  player.rankings?.globalRank !=
-                                                      null
-                                                  ? AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsGlobalRankDescription(
-                                                      player
-                                                              .rankings
-                                                              ?.globalRank ??
-                                                          0,
-                                                      player.trophies,
-                                                    )
-                                                  : AppLocalizations.of(
-                                                      context,
-                                                    )!.legendsNoGlobalRankDescription(
-                                                      player.trophies,
-                                                    ),
-                                            ),
+                                          if (localRankChip != null)
+                                            localRankChip,
+                                          if (globalRankChip != null)
+                                            globalRankChip,
                                           ImageChip(
                                             context: context,
                                             imageUrl:

--- a/lib/features/pages/widgets/player_search_card.dart
+++ b/lib/features/pages/widgets/player_search_card.dart
@@ -9,13 +9,13 @@ import 'dart:async';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class PlayerSearchCard extends StatefulWidget {
-  PlayerSearchCard({super.key});
+  const PlayerSearchCard({super.key});
   @override
   PlayerSearchCardState createState() => PlayerSearchCardState();
 }
 
 class PlayerSearchCardState extends State<PlayerSearchCard> {
-  TextEditingController _controller = TextEditingController();
+  final TextEditingController _controller = TextEditingController();
   Future<List<dynamic>>? _searchResults;
   bool isSearching = false;
   bool isEmpty = true;
@@ -129,7 +129,7 @@ class PlayerSearchCardState extends State<PlayerSearchCard> {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       isSearching
-                          ? SizedBox(
+                          ? const SizedBox(
                               width: 20.0,
                               height: 20.0,
                               child: CircularProgressIndicator(),
@@ -155,7 +155,7 @@ class PlayerSearchCardState extends State<PlayerSearchCard> {
                                   color:
                                       Theme.of(context).colorScheme.onSurface,
                                 ),
-                      SizedBox(width: 8.0),
+                      const SizedBox(width: 8.0),
                     ],
                   ),
                 ),
@@ -166,9 +166,9 @@ class PlayerSearchCardState extends State<PlayerSearchCard> {
             future: _searchResults,
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return SizedBox.shrink();
+                return const SizedBox.shrink();
               } else if (snapshot.hasError) {
-                return Center(child: Text("No results found."));
+                return const Center(child: Text("No results found."));
               } else if (snapshot.hasData &&
                   snapshot.data != null &&
                   snapshot.data != [] &&
@@ -188,11 +188,11 @@ class PlayerSearchCardState extends State<PlayerSearchCard> {
                           AppLocalizations.of(context)!.searchNoResult,
                         ),
                       ),
-                      SizedBox(height: 8),
+                      const SizedBox(height: 8),
                     ],
                   );
                 } else {
-                  return SizedBox.shrink();
+                  return const SizedBox.shrink();
                 }
               }
             },

--- a/lib/features/pages/widgets/player_search_result_tile.dart
+++ b/lib/features/pages/widgets/player_search_result_tile.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 class PlayerSearchResultTile extends StatefulWidget {
   final dynamic player;
 
-  PlayerSearchResultTile({required this.player});
+  const PlayerSearchResultTile({super.key, required this.player});
 
   @override
   PlayerSearchResultTileState createState() => PlayerSearchResultTileState();
@@ -55,7 +55,7 @@ class PlayerSearchResultTileState extends State<PlayerSearchResultTile> {
             context: context,
             barrierDismissible: false,
             builder: (BuildContext context) {
-              return Center(
+              return const Center(
                 child: CircularProgressIndicator(),
               );
             },
@@ -78,7 +78,7 @@ class PlayerSearchResultTileState extends State<PlayerSearchResultTile> {
           child: Row(
             children: [
               Padding(
-                padding: EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Column(
                   children: [
                     SizedBox(
@@ -92,7 +92,7 @@ class PlayerSearchResultTileState extends State<PlayerSearchResultTile> {
                   ],
                 ),
               ),
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -103,7 +103,7 @@ class PlayerSearchResultTileState extends State<PlayerSearchResultTile> {
                       style: Theme.of(context).textTheme.labelLarge!.copyWith(
                           color: Theme.of(context).colorScheme.tertiary),
                     ),
-                    SizedBox(width: 8),
+                    const SizedBox(width: 8),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [

--- a/lib/features/pages/widgets/player_to_do_card.dart
+++ b/lib/features/pages/widgets/player_to_do_card.dart
@@ -31,7 +31,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
     WarMemberPresence memberCwl = WarMemberPresence.empty();
 
     if (player == null) {
-      return Center(
+      return const Center(
         child: CircularProgressIndicator(),
       );
     }
@@ -69,7 +69,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
       child: Stack(
         children: [
           DefaultTextStyle(
-            style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+            style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
             child: Card(
               child: Padding(
                 padding: const EdgeInsets.only(
@@ -84,8 +84,8 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
                             Text(AppLocalizations.of(context)!.todoTitle,
                                 style:
                                     (Theme.of(context).textTheme.labelLarge)),
-                            SizedBox(height: 12),
-                            SizedBox(
+                            const SizedBox(height: 12),
+                            const SizedBox(
                               height: 90,
                               width: 100,
                               child: MobileWebImage(
@@ -94,7 +94,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
                             ),
                           ],
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Expanded(
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.center,
@@ -102,7 +102,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
                               iconToDo(player, memberCwl),
                               Row(
                                 children: [
-                                  SizedBox(width: 8),
+                                  const SizedBox(width: 8),
                                   Expanded(
                                     child: Container(
                                       height: 8,
@@ -120,13 +120,13 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
                                           backgroundColor: Theme.of(context)
                                               .scaffoldBackgroundColor,
                                           valueColor:
-                                              AlwaysStoppedAnimation<Color>(
+                                              const AlwaysStoppedAnimation<Color>(
                                                   Colors.green),
                                         ),
                                       ),
                                     ),
                                   ),
-                                  SizedBox(width: 8),
+                                  const SizedBox(width: 8),
                                   Text(
                                     '$percent%',
                                     style:
@@ -203,7 +203,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
                               style: Theme.of(context).textTheme.labelLarge,
                               textAlign: TextAlign.center,
                             ),
-                      SizedBox(height: 8),
+                      const SizedBox(height: 8),
                       Wrap(
                         alignment: WrapAlignment.start,
                         spacing: 7.0,
@@ -386,7 +386,7 @@ class PlayerToDoCardState extends State<PlayerToDoCard> {
             ),
           ],
         ),
-        SizedBox(height: 8),
+        const SizedBox(height: 8),
       ],
     );
   }

--- a/lib/features/pages/widgets/player_war_stats_card.dart
+++ b/lib/features/pages/widgets/player_war_stats_card.dart
@@ -20,7 +20,7 @@ class PlayerWarStatsCard extends StatelessWidget {
     final allStats = warStats?.statsByType["all"];
 
     return DefaultTextStyle(
-      style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+      style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
       child: GestureDetector(
         onTap: () {
           Navigator.push(
@@ -53,14 +53,14 @@ class PlayerWarStatsCard extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(height: 12),
-                        SizedBox(
+                        const SizedBox(
                           height: 60,
                           width: 60,
                           child: MobileWebImage(imageUrl: ImageAssets.war),
                         ),
                       ],
                     ),
-                    SizedBox(width: 8),
+                    const SizedBox(width: 8),
                     Expanded(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/features/pages/widgets/utils_creator_code_card.dart
+++ b/lib/features/pages/widgets/utils_creator_code_card.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class CreatorCodeCard extends StatefulWidget {
+  const CreatorCodeCard({super.key});
+
   @override
   CreatorCodeCardState createState() => CreatorCodeCardState();
 }
@@ -27,7 +29,7 @@ class CreatorCodeCardState extends State<CreatorCodeCard> {
             return AlertDialog(
               title: Text(
                 AppLocalizations.of(context)!.gameCreatorCodeDialogTitle,
-                style: TextStyle(fontWeight: FontWeight.bold),
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
               content: Text(
                 AppLocalizations.of(context)!.gameCreatorCodeDialogDescription),
@@ -71,8 +73,8 @@ class CreatorCodeCardState extends State<CreatorCodeCard> {
             children: <Widget>[
               CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),imageUrl: logoUrl, height: 80),
-              SizedBox(width: 16),
+  errorWidget: (context, url, error) => const Icon(Icons.error),imageUrl: logoUrl, height: 80),
+              const SizedBox(width: 16),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.center,
@@ -82,12 +84,12 @@ class CreatorCodeCardState extends State<CreatorCodeCard> {
                       AppLocalizations.of(context)?.gameCreatorCode ??
                           'Creator Code : ClashKing',
                       textAlign: TextAlign.center,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(
                       AppLocalizations.of(context)?.gameCreatorCodeDescription ??
                           'Tap for info • Support us for free!',

--- a/lib/features/pages/widgets/war_access_denied_card.dart
+++ b/lib/features/pages/widgets/war_access_denied_card.dart
@@ -6,7 +6,7 @@ class WarAccessDeniedCard extends StatefulWidget {
   final String clanName;
   final String clanBadgeUrl;
 
-  WarAccessDeniedCard({
+  const WarAccessDeniedCard({
     super.key,
     required this.clanName,
     required this.clanBadgeUrl
@@ -39,7 +39,7 @@ class WarAccessDeniedCardState extends State<WarAccessDeniedCard> {
                     child: Center(
                       child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),imageUrl: 
+  errorWidget: (context, url, error) => const Icon(Icons.error),imageUrl: 
                         widget.clanBadgeUrl,
                         fit: BoxFit.cover),
                     ),

--- a/lib/features/pages/widgets/war_card.dart
+++ b/lib/features/pages/widgets/war_card.dart
@@ -25,7 +25,7 @@ class WarCard extends StatelessWidget {
             case 'warEnded':
               return _warEnded(context, clanTag);
             default:
-              return Text('Clan state unknown');
+              return const Text('Clan state unknown');
           }
         }(),
       ),
@@ -45,7 +45,7 @@ class WarCard extends StatelessWidget {
                 width: 70,
                 height: 70,
                 child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: currentWarInfo.clan!.badgeUrls.large,
                     fit: BoxFit.cover),
               ),
@@ -133,7 +133,7 @@ class WarCard extends StatelessWidget {
                 width: 70,
                 height: 70,
                 child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: currentWarInfo.opponent!.badgeUrls.large,
                     fit: BoxFit.cover),
               ),
@@ -157,7 +157,7 @@ class WarCard extends StatelessWidget {
               width: 70,
               height: 70,
               child: CachedNetworkImage(
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: currentWarInfo.clan!.badgeUrls.large,
                   fit: BoxFit.cover),
             ),
@@ -178,7 +178,7 @@ class WarCard extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
               textAlign: TextAlign.center,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             Text(
               AppLocalizations.of(context)?.warPreparation ?? 'Preparation',
               textAlign: TextAlign.center,
@@ -196,7 +196,7 @@ class WarCard extends StatelessWidget {
               width: 70,
               height: 70,
               child: CachedNetworkImage(
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: currentWarInfo.opponent!.badgeUrls.large,
                   fit: BoxFit.cover),
             ),
@@ -224,7 +224,7 @@ class WarCard extends StatelessWidget {
                 width: 70,
                 height: 70,
                 child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: currentWarInfo.clan!.badgeUrls.large,
                     fit: BoxFit.cover),
               ),
@@ -255,7 +255,7 @@ class WarCard extends StatelessWidget {
                     '${currentWarInfo.clan!.destructionPercentage % 1 == 0 ? currentWarInfo.clan!.destructionPercentage.toInt().toString().padLeft(6, ' ') : currentWarInfo.clan!.destructionPercentage.toStringAsFixed(2).padLeft(5, '0')}%    ${currentWarInfo.opponent!.destructionPercentage % 1 == 0 ? ('${currentWarInfo.opponent!.destructionPercentage.toInt()}%').padRight(7, ' ') : ('${currentWarInfo.opponent!.destructionPercentage.toStringAsFixed(2)}%').padLeft(5, ' ')}',
                     style: Theme.of(context).textTheme.bodySmall),
               ),
-              SizedBox(height: 10),
+              const SizedBox(height: 10),
             ],
           ),
         ),
@@ -268,7 +268,7 @@ class WarCard extends StatelessWidget {
                 width: 70,
                 height: 70,
                 child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: currentWarInfo.opponent!.badgeUrls.large,
                     fit: BoxFit.cover),
               ),

--- a/lib/features/pages/widgets/war_history_card.dart
+++ b/lib/features/pages/widgets/war_history_card.dart
@@ -30,9 +30,9 @@ class WarHistoryCard extends StatelessWidget {
         );
       },
       child: DefaultTextStyle(
-        style: Theme.of(context).textTheme.labelLarge ?? TextStyle(),
+        style: Theme.of(context).textTheme.labelLarge ?? const TextStyle(),
         child: Card(
-          margin: EdgeInsets.only(left: 12, right: 12, top: 4, bottom: 4),
+          margin: const EdgeInsets.only(left: 12, right: 12, top: 4, bottom: 4),
           child: Padding(
             padding:
                 const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -43,11 +43,11 @@ class WarHistoryCard extends StatelessWidget {
                   height: 70,
                   width: 70,
                   child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl: ImageAssets.warClan,
                   ),
                 ),
-                SizedBox(width: 24),
+                const SizedBox(width: 24),
                 Expanded(
                   child: Column(
                     children: [
@@ -62,7 +62,7 @@ class WarHistoryCard extends StatelessWidget {
                             icon: Container(
                               width: 16,
                               height: 16,
-                              decoration: BoxDecoration(
+                              decoration: const BoxDecoration(
                                 color: Colors.green,
                                 shape: BoxShape.circle,
                               ),
@@ -79,7 +79,7 @@ class WarHistoryCard extends StatelessWidget {
                             icon: Container(
                               width: 16,
                               height: 16,
-                              decoration: BoxDecoration(
+                              decoration: const BoxDecoration(
                                 color: Colors.red,
                                 shape: BoxShape.circle,
                               ),
@@ -96,7 +96,7 @@ class WarHistoryCard extends StatelessWidget {
                             icon: Container(
                               width: 16,
                               height: 16,
-                              decoration: BoxDecoration(
+                              decoration: const BoxDecoration(
                                 color: Colors.blue,
                                 shape: BoxShape.circle,
                               ),

--- a/lib/features/pages/widgets/war_not_in_war_card.dart
+++ b/lib/features/pages/widgets/war_not_in_war_card.dart
@@ -6,7 +6,7 @@ class NotInWarCard extends StatefulWidget {
   final String clanName;
   final String clanBadgeUrl;
 
-  NotInWarCard({super.key, required this.clanName, required this.clanBadgeUrl});
+  const NotInWarCard({super.key, required this.clanName, required this.clanBadgeUrl});
 
   @override
   NotInWarCardState createState() => NotInWarCardState();
@@ -30,7 +30,7 @@ class NotInWarCardState extends State<NotInWarCard> {
                     child: Center(
                       child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                           imageUrl: widget.clanBadgeUrl, fit: BoxFit.cover),
                     ),
                   ),

--- a/lib/features/pages/widgets/war_stats_card.dart
+++ b/lib/features/pages/widgets/war_stats_card.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 
 class WarStatsCard extends StatefulWidget {
   final Clan clan;
-  WarStatsCard({super.key, required this.clan});
+  const WarStatsCard({super.key, required this.clan});
 
   @override
   WarStatsCardState createState() => WarStatsCardState();
@@ -31,14 +31,14 @@ class WarStatsCardState extends State<WarStatsCard> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              SizedBox(
+              const SizedBox(
                 height: 70,
                 width: 70,
                 child: MobileWebImage(
                   imageUrl: ImageAssets.warClan,
                 ),
               ),
-              SizedBox(width: 24),
+              const SizedBox(width: 24),
               Expanded(
                 child: Column(
                   children: [

--- a/lib/features/player/data/player_service.dart
+++ b/lib/features/player/data/player_service.dart
@@ -19,7 +19,7 @@ class PlayerService extends ChangeNotifier {
   final ApiService _apiService;
   bool _isLoading = false;
   List<Player> _profiles = [];
-  List<Map<String, dynamic>> _clans = [];
+  final List<Map<String, dynamic>> _clans = [];
 
   bool get isLoading => _isLoading;
   List<Player> get profiles => _profiles;

--- a/lib/features/player/models/player_legend_stats.dart
+++ b/lib/features/player/models/player_legend_stats.dart
@@ -22,7 +22,7 @@ class PlayerLegendStats {
       return seasons.values.cast<PlayerLegendSeason?>().firstWhere((season) =>
           season != null &&
           now.isAfter(season.start) &&
-          now.isBefore(season.end.add(Duration(days: 1))),
+          now.isBefore(season.end.add(const Duration(days: 1))),
           orElse: () => null);
     } catch (_) {
       return null;

--- a/lib/features/player/presentation/legend/player_legend_by_day.dart
+++ b/lib/features/player/presentation/legend/player_legend_by_day.dart
@@ -143,7 +143,7 @@ class _LegendByDayTabState extends State<LegendByDayTab> {
               ),
               CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                 imageUrl: ImageAssets.villager,
                 height: 350,
                 width: 200,

--- a/lib/features/player/presentation/legend/player_legend_header.dart
+++ b/lib/features/player/presentation/legend/player_legend_header.dart
@@ -40,7 +40,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                 Colors.black.withValues(alpha: 0.7),
                 BlendMode.darken,
               ),
-              child: MobileWebImage(
+              child: const MobileWebImage(
                 imageUrl: ImageAssets.legendPageBackground,
                 width: double.infinity,
                 fit: BoxFit.cover,
@@ -69,12 +69,12 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                         style: Theme.of(context).textTheme.labelLarge?.copyWith(
                               color: Colors.grey,
                             )),
-                    SizedBox(height: 10),
+                    const SizedBox(height: 10),
                     if (currentTrophies > 0)
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          MobileWebImage(
+                          const MobileWebImage(
                             imageUrl: ImageAssets.legendBlazon,
                             width: 60,
                           ),
@@ -91,7 +91,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                                     color: Colors.white,
                                     fontSize: 32,
                                   )),
-                          SizedBox(width: 8),
+                          const SizedBox(width: 8),
                           Column(
                             children: [
                               Text(
@@ -104,7 +104,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                                             ? Colors.green
                                             : Colors.red),
                               ),
-                              SizedBox(height: 32),
+                              const SizedBox(height: 32),
                             ],
                           ),
                         ],
@@ -113,7 +113,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          MobileWebImage(
+                          const MobileWebImage(
                             imageUrl: ImageAssets.legendBlazonBorders,
                             width: 60,
                           ),
@@ -126,7 +126,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                           ),
                         ],
                       ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         Expanded(
@@ -156,7 +156,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                                       ),
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(10),
-                                        side: BorderSide(
+                                        side: const BorderSide(
                                             color: Colors.white, width: 1),
                                       ),
                                     ),
@@ -197,12 +197,12 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                                             ),
                                       shape: RoundedRectangleBorder(
                                         borderRadius: BorderRadius.circular(10),
-                                        side: BorderSide(
+                                        side: const BorderSide(
                                             color: Colors.white, width: 1),
                                       ),
                                     ),
                                   Chip(
-                                    avatar: CircleAvatar(
+                                    avatar: const CircleAvatar(
                                       backgroundColor: Colors.transparent,
                                       child: MobileWebImage(
                                           imageUrl: ImageAssets.planet),
@@ -225,7 +225,7 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
                                             ?.copyWith(color: Colors.white)),
                                     shape: RoundedRectangleBorder(
                                       borderRadius: BorderRadius.circular(10),
-                                      side: BorderSide(
+                                      side: const BorderSide(
                                           color: Colors.white, width: 1),
                                     ),
                                   ),
@@ -263,32 +263,32 @@ class _LegendHeaderCardState extends State<LegendHeaderCard> {
               TextSpan(
                   text:
                       "${AppLocalizations.of(context)!.legendsInaccurateApiDelayTitle}\n",
-                  style: TextStyle(fontWeight: FontWeight.bold)),
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(
                   text:
                       "${AppLocalizations.of(context)!.legendsInaccurateApiDelayBody}\n"),
               TextSpan(
                   text: AppLocalizations.of(context)!
                       .legendsInaccurateConcurrentTitle,
-                  style: TextStyle(fontWeight: FontWeight.bold)),
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(
                   text: AppLocalizations.of(context)!
                       .legendsInaccurateMultipleAttacksTitle,
-                  style: TextStyle(fontWeight: FontWeight.bold)),
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(
                   text: AppLocalizations.of(context)!
                       .legendsInaccurateMultipleAttacksBody),
               TextSpan(
                   text: AppLocalizations.of(context)!
                       .legendsInaccurateSimultaneousTitle,
-                  style: TextStyle(fontWeight: FontWeight.bold)),
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(
                   text:
                       "${AppLocalizations.of(context)!.legendsInaccurateSimultaneousBody}\n"),
               TextSpan(
                   text:
                       "${AppLocalizations.of(context)!.legendsInaccurateNetGainTitle}\n",
-                  style: TextStyle(fontWeight: FontWeight.bold)),
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(
                   text:
                       "${AppLocalizations.of(context)!.legendsInaccurateNetGainBody}\n\n"),

--- a/lib/features/player/presentation/legend/player_legend_history.dart
+++ b/lib/features/player/presentation/legend/player_legend_history.dart
@@ -19,7 +19,7 @@ class PlayerLegendHistory extends StatelessWidget {
   Widget buildSeasonInfo(
       PlayerLegendRanking? season, BuildContext context, String title) {
     if (season == null) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -52,7 +52,7 @@ class PlayerLegendHistory extends StatelessWidget {
                 children: <Widget>[
                   Center(
                     child: CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: ImageAssets.legendBlazonBordersNoPadding,
                       height: 80,
                     ),
@@ -80,7 +80,7 @@ class PlayerLegendHistory extends StatelessWidget {
                 Row(
                   children: [
                     CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: ImageAssets.bestTrophies,
                       height: 20,
                     ),
@@ -96,7 +96,7 @@ class PlayerLegendHistory extends StatelessWidget {
                 Row(
                   children: [
                     CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: ImageAssets.sword,
                       height: 20,
                     ),

--- a/lib/features/player/presentation/legend/player_legend_season.dart
+++ b/lib/features/player/presentation/legend/player_legend_season.dart
@@ -60,7 +60,7 @@ class LegendSeason extends StatelessWidget {
                         children: [
                           CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                             imageUrl: ImageAssets.legendBlazon,
                             width: 40,
                           ),
@@ -132,7 +132,7 @@ class LegendSeason extends StatelessWidget {
                     style: Theme.of(context).textTheme.bodyMedium),
                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl:
                       'https://assets.clashk.ing/stickers/Villager_HV_Villager_12.png',
                   height: 300,
@@ -165,7 +165,7 @@ class LegendSeason extends StatelessWidget {
           children: [
             CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),imageUrl: icon, width: 15, height: 15),
+  errorWidget: (context, url, error) => const Icon(Icons.error),imageUrl: icon, width: 15, height: 15),
             const SizedBox(width: 4),
             Text(
                 "${NumberFormat('#,###', locale).format(count)}/$attacksPossible",
@@ -176,7 +176,7 @@ class LegendSeason extends StatelessWidget {
           children: [
             CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
               imageUrl: ImageAssets.trophies,
               width: 15,
               height: 15,
@@ -195,7 +195,7 @@ class LegendSeason extends StatelessWidget {
               children: [
                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: ImageAssets.trophies,
                   width: 16,
                   height: 16,
@@ -203,7 +203,7 @@ class LegendSeason extends StatelessWidget {
                 ),
                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: ImageAssets.builderBaseStar,
                   width: 8,
                   height: 8,

--- a/lib/features/player/presentation/legend/widgets/player_legend_day_offense_defense_card.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_day_offense_defense_card.dart
@@ -60,7 +60,7 @@ class LegendOffenseDefenseCard extends StatelessWidget {
                               padding: const EdgeInsets.only(left: 8.0),
                               child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                 imageUrl: icon,
                                 width: 20,
                               ),

--- a/lib/features/player/presentation/legend/widgets/player_legend_day_trophies_start_end_card.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_day_trophies_start_end_card.dart
@@ -18,7 +18,7 @@ class LegendTrophiesStartEndCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: EdgeInsets.only(left: 8, right: 8, bottom: 4),
+      margin: const EdgeInsets.only(left: 8, right: 8, bottom: 4),
       child: Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
         Column(
           children: [
@@ -33,7 +33,7 @@ class LegendTrophiesStartEndCard extends StatelessWidget {
         ),
         CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
           imageUrl:
               "https://assets.clashk.ing/icons/Icon_HV_League_Legend_3_Border.png",
           width: 80,

--- a/lib/features/player/presentation/legend/widgets/player_legend_day_used_gear_card.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_day_used_gear_card.dart
@@ -45,7 +45,7 @@ class LegendUsedGearCard extends StatelessWidget {
                         children: [
                           CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                             imageUrl: gear.imageUrl,
                             width: 40,
                             height: 40,

--- a/lib/features/player/presentation/legend/widgets/player_legend_history_eos_chart.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_history_eos_chart.dart
@@ -42,7 +42,7 @@ class PlayerLegendHistoryEosChart extends StatelessWidget {
                 Expanded(
                   child: LineChart(
                     LineChartData(
-                      gridData: FlGridData(
+                      gridData: const FlGridData(
                         show: true,
                         drawHorizontalLine: true,
                         horizontalInterval: 30,
@@ -85,10 +85,10 @@ class PlayerLegendHistoryEosChart extends StatelessWidget {
                             },
                           ),
                         ),
-                        rightTitles: AxisTitles(
+                        rightTitles: const AxisTitles(
                           sideTitles: SideTitles(showTitles: false),
                         ),
-                        topTitles: AxisTitles(
+                        topTitles: const AxisTitles(
                           sideTitles: SideTitles(showTitles: false),
                         ),
                       ),
@@ -106,7 +106,7 @@ class PlayerLegendHistoryEosChart extends StatelessWidget {
                           isCurved: false,
                           barWidth: 2,
                           isStrokeCapRound: true,
-                          dotData: FlDotData(show: true),
+                          dotData: const FlDotData(show: true),
                           belowBarData: BarAreaData(
                             show: true,
                             color: Theme.of(context)

--- a/lib/features/player/presentation/legend/widgets/player_legend_history_eos_list.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_history_eos_list.dart
@@ -43,7 +43,7 @@ class PlayerLegendHistoryEosList extends StatelessWidget {
                                 Center(
                                   child: CachedNetworkImage(
 
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                     imageUrl: ImageAssets.legendBlazonBordersNoPadding,
                                     height: 80,
                                   ),
@@ -95,7 +95,7 @@ class PlayerLegendHistoryEosList extends StatelessWidget {
                                     backgroundColor: Colors.transparent,
                                     child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                       imageUrl: ImageAssets.bestTrophies,
                                     ),
                                   ),
@@ -112,7 +112,7 @@ class PlayerLegendHistoryEosList extends StatelessWidget {
                                     backgroundColor: Colors.transparent,
                                     child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                         imageUrl: ImageAssets.planet),
                                   ),
                                   label: Text(
@@ -128,7 +128,7 @@ class PlayerLegendHistoryEosList extends StatelessWidget {
                                     backgroundColor: Colors.transparent,
                                     child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                       imageUrl: ImageAssets.sword,
                                     ),
                                   ),
@@ -145,7 +145,7 @@ class PlayerLegendHistoryEosList extends StatelessWidget {
                                     backgroundColor: Colors.transparent,
                                     child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                       imageUrl: ImageAssets.shieldWithArrow,
                                     ),
                                   ),

--- a/lib/features/player/presentation/legend/widgets/player_legend_season_chart.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_season_chart.dart
@@ -67,7 +67,7 @@ class LegendSeasonChart extends StatelessWidget {
         barWidth: 2,
         isStrokeCapRound: true,
         color: Theme.of(context).colorScheme.primary,
-        dotData: FlDotData(show: true),
+        dotData: const FlDotData(show: true),
         belowBarData: BarAreaData(
           show: true,
           color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
@@ -129,10 +129,10 @@ class LegendSeasonChart extends StatelessWidget {
                         },
                       ),
                     ),
-                    topTitles: AxisTitles(
+                    topTitles: const AxisTitles(
                       sideTitles: SideTitles(showTitles: false),
                     ),
-                    rightTitles: AxisTitles(
+                    rightTitles: const AxisTitles(
                       sideTitles: SideTitles(showTitles: false),
                     ),
                   ),

--- a/lib/features/player/presentation/legend/widgets/player_legend_season_list.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_season_list.dart
@@ -114,7 +114,7 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
           else if (icon is String)
             CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),imageUrl: icon, height: 20),
+  errorWidget: (context, url, error) => const Icon(Icons.error),imageUrl: icon, height: 20),
           const SizedBox(width: 4),
           Icon(
             _sortCriterion == criterion
@@ -159,7 +159,7 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
                         child: Transform.translate(
                           offset: const Offset(2, -6),
                           child: Text("(${day.totalAttacks})",
-                              textScaler: TextScaler.linear(0.7),
+                              textScaler: const TextScaler.linear(0.7),
                               style: Theme.of(context).textTheme.labelSmall),
                         ),
                       ),
@@ -175,7 +175,7 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
                         child: Transform.translate(
                           offset: const Offset(2, -6),
                           child: Text("(${day.totalDefenses})",
-                              textScaler: TextScaler.linear(0.7),
+                              textScaler: const TextScaler.linear(0.7),
                               style: Theme.of(context).textTheme.labelSmall),
                         ),
                       ),
@@ -197,7 +197,7 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
                             day.trophiesTotal > 0
                                 ? "(+${day.trophiesTotal})"
                                 : "(${day.trophiesTotal})",
-                            textScaler: TextScaler.linear(0.7),
+                            textScaler: const TextScaler.linear(0.7),
                             style: Theme.of(context)
                                 .textTheme
                                 .labelSmall
@@ -222,12 +222,12 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
           crossFadeState:
               isSelected ? CrossFadeState.showSecond : CrossFadeState.showFirst,
           duration: const Duration(milliseconds: 300),
-          firstChild: Divider(height: 1, indent: 16, endIndent: 16),
+          firstChild: const Divider(height: 1, indent: 16, endIndent: 16),
           secondChild: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Column(
               children: [
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -263,9 +263,9 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
                   ],
                 ),
                 if (day.usageCount.isNotEmpty) ...[
-                  SizedBox(height: 12),
-                  Divider(height: 1, indent: 32, endIndent: 32),
-                  SizedBox(height: 12),
+                  const SizedBox(height: 12),
+                  const Divider(height: 1, indent: 32, endIndent: 32),
+                  const SizedBox(height: 12),
                   PlayerLegendSeasonUsedGear(
                       context: context,
                       gears: day
@@ -274,8 +274,8 @@ class _PlayerLegendSeasonListState extends State<PlayerLegendSeasonList> {
                           .toList(),
                       usageCount: day.usageCount),
                 ],
-                SizedBox(height: 16),
-                Divider(height: 1, indent: 16, endIndent: 16),
+                const SizedBox(height: 16),
+                const Divider(height: 1, indent: 16, endIndent: 16),
               ],
             ),
           ),

--- a/lib/features/player/presentation/legend/widgets/player_legend_season_offense_defense.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_season_offense_defense.dart
@@ -47,7 +47,7 @@ class PlayerLegendOffenseDefense extends StatelessWidget {
               children: [
                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl:
                       "https://assets.clashk.ing/icons/Icon_HV_Trophy.png",
                   width: 16,
@@ -56,7 +56,7 @@ class PlayerLegendOffenseDefense extends StatelessWidget {
                 ),
                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: "https://assets.clashk.ing/icons/Icon_BB_Star.png",
                   width: 8,
                   height: 8,
@@ -93,7 +93,7 @@ class PlayerLegendOffenseDefense extends StatelessWidget {
                             padding: const EdgeInsets.only(left: 8.0),
                             child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                               imageUrl: icon,
                               width: 20,
                             ),

--- a/lib/features/player/presentation/legend/widgets/player_legend_season_used_gear.dart
+++ b/lib/features/player/presentation/legend/widgets/player_legend_season_used_gear.dart
@@ -26,7 +26,7 @@ class PlayerLegendSeasonUsedGear extends StatelessWidget {
         children: [
           Text(localizations?.gameHeroesEquipments ?? "Heroes Equipments",
               style: Theme.of(context).textTheme.bodyMedium),
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
           Wrap(
             spacing: 12,
             runSpacing: 12,
@@ -41,7 +41,7 @@ class PlayerLegendSeasonUsedGear extends StatelessWidget {
                     children: [
                       CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                         imageUrl: gear.imageUrl,
                         width: 35,
                         height: 35,

--- a/lib/features/player/presentation/player/player_achievement_page.dart
+++ b/lib/features/player/presentation/player/player_achievement_page.dart
@@ -13,7 +13,7 @@ import 'package:scrollable_tab_view/scrollable_tab_view.dart';
 class PlayerAchievementScreen extends StatefulWidget {
   final Player player;
 
-  PlayerAchievementScreen({super.key, required this.player});
+  const PlayerAchievementScreen({super.key, required this.player});
 
   @override
   PlayerAchievementScreenState createState() => PlayerAchievementScreenState();
@@ -21,11 +21,15 @@ class PlayerAchievementScreen extends StatefulWidget {
 
 class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
     with SingleTickerProviderStateMixin {
+  static const String _keepYourAccountSafe = 'Keep Your Account Safe!';
+  static const String _dragonSlayer = 'Dragon Slayer';
+  static const String _ungratefulChild = 'Ungrateful Child';
+
   String currentFilter = 'All';
   int achievementCompleted = 0;
   int achievementTotal = 0;
   String achievementStringRatio = '';
-  
+
   // Progress per village
   int homeCompleted = 0;
   int homeTotal = 0;
@@ -38,18 +42,18 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
   void initState() {
     super.initState();
     var filteredAchievements = widget.player.achievements
-        .where((achievement) => achievement.name != "Keep Your Account Safe!")
+        .where((achievement) => achievement.name != _keepYourAccountSafe)
         .toList();
     achievementTotal = filteredAchievements.length;
-    
+
     // Calculate progress per village
     _calculateProgressPerVillage(filteredAchievements);
-    
+
     for (var achievement in filteredAchievements) {
       if (achievement.value >= achievement.target && achievement.stars == 3) {
         achievementCompleted++;
-      } else if ((achievement.name == 'Dragon Slayer' ||
-              achievement.name == 'Ungrateful Child') &&
+      } else if ((achievement.name == _dragonSlayer ||
+              achievement.name == _ungratefulChild) &&
           achievement.value >= 1) {
         achievementCompleted++;
       }
@@ -68,13 +72,15 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
       currentFilter = newFilter;
     });
   }
-  
+
   void _calculateProgressPerVillage(List<dynamic> achievements) {
     for (var achievement in achievements) {
-      bool isCompleted = (achievement.value >= achievement.target && achievement.stars == 3) ||
-          ((achievement.name == 'Dragon Slayer' || achievement.name == 'Ungrateful Child') &&
+      bool isCompleted =
+          (achievement.value >= achievement.target && achievement.stars == 3) ||
+          ((achievement.name == _dragonSlayer ||
+                  achievement.name == _ungratefulChild) &&
               achievement.value >= 1);
-      
+
       switch (achievement.village) {
         case 'home':
           homeTotal++;
@@ -108,13 +114,16 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
               labelStyle: Theme.of(context).textTheme.bodyLarge,
               unselectedLabelColor: Theme.of(context).colorScheme.onSurface,
               tabs: [
-                Tab(text: AppLocalizations.of(context)?.gameBaseHome ?? 'Home Village'),
-                Tab(text: AppLocalizations.of(context)?.generalOthers ?? 'Others'),
+                Tab(
+                  text:
+                      AppLocalizations.of(context)?.gameBaseHome ??
+                      'Home Village',
+                ),
+                Tab(
+                  text: AppLocalizations.of(context)?.generalOthers ?? 'Others',
+                ),
               ],
-              children: [
-                _buildTabContent('home'),
-                _buildTabContent('others'),
-              ],
+              children: [_buildTabContent('home'), _buildTabContent('others')],
             ),
           ],
         ),
@@ -136,7 +145,7 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
                 Colors.black.withValues(alpha: 0.7),
                 BlendMode.darken,
               ),
-              child: MobileWebImage(
+              child: const MobileWebImage(
                 imageUrl: ImageAssets.playerAchievementPageBackground,
                 width: double.infinity,
                 fit: BoxFit.cover,
@@ -148,9 +157,11 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
           top: 40,
           left: 10,
           child: IconButton(
-            icon: Icon(Icons.arrow_back,
-                color: Theme.of(context).colorScheme.onPrimary,
-                size: 32),
+            icon: Icon(
+              Icons.arrow_back,
+              color: Theme.of(context).colorScheme.onPrimary,
+              size: 32,
+            ),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),
@@ -166,16 +177,19 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
                 child: Column(
                   children: [
                     Text(
-                      AppLocalizations.of(context)?.gameAchievements ?? 'Achievements',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headlineMedium
-                          ?.copyWith(color: Colors.white),
+                      AppLocalizations.of(context)?.gameAchievements ??
+                          'Achievements',
+                      style: Theme.of(
+                        context,
+                      ).textTheme.headlineMedium?.copyWith(color: Colors.white),
                     ),
-                    SizedBox(height: 16),
+                    const SizedBox(height: 16),
                     Container(
                       width: 250,
-                      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 12,
+                      ),
                       child: Column(
                         children: [
                           Container(
@@ -188,8 +202,8 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(4),
                               child: LinearProgressIndicator(
-                                value: achievementTotal > 0 
-                                    ? achievementCompleted / achievementTotal 
+                                value: achievementTotal > 0
+                                    ? achievementCompleted / achievementTotal
                                     : 0.0,
                                 minHeight: 8,
                                 backgroundColor: Colors.transparent,
@@ -199,10 +213,10 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
                               ),
                             ),
                           ),
-                          SizedBox(height: 8),
+                          const SizedBox(height: 8),
                           Text(
                             '${achievementCompleted.toString()}/${achievementTotal.toString()} ${AppLocalizations.of(context)?.generalCompleted ?? 'completed'} • $achievementStringRatio%',
-                            style: TextStyle(
+                            style: const TextStyle(
                               fontSize: 14,
                               color: Colors.white,
                               fontWeight: FontWeight.w600,
@@ -225,128 +239,140 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
   Widget _buildTabContent(String category) {
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: Column(
-        children: _buildAchievementsForCategory(category),
-      ),
+      child: Column(children: _buildAchievementsForCategory(category)),
     );
   }
 
   List<Widget> _buildAchievementsForCategory(String category) {
     List<dynamic> filteredAchievements;
-    
+
     if (category == 'home') {
       filteredAchievements = widget.player.achievements
-          .where((achievement) =>
-              achievement.name != "Keep Your Account Safe!" &&
-              achievement.village == 'home')
+          .where(
+            (achievement) =>
+                achievement.name != _keepYourAccountSafe &&
+                achievement.village == 'home',
+          )
           .toList();
     } else {
       // Others = Builder Base + Clan Capital
       filteredAchievements = widget.player.achievements
-          .where((achievement) =>
-              achievement.name != "Keep Your Account Safe!" &&
-              (achievement.village == 'builderBase' || achievement.village == 'clanCapital'))
+          .where(
+            (achievement) =>
+                achievement.name != _keepYourAccountSafe &&
+                (achievement.village == 'builderBase' ||
+                    achievement.village == 'clanCapital'),
+          )
           .toList();
     }
-    
-    return filteredAchievements.map((achievement) {
-          int stars = achievement.stars;
-          if ((achievement.name == 'Dragon Slayer' ||
-                  achievement.name == 'Ungrateful Child') &&
-              achievement.value >= 1) {
-            stars += 2;
-          }
-          double progress = min<double>(
-              (achievement.value.toDouble() / max<double>(achievement.target.toDouble(), 1.0)) * 100, 
-              100.0
-          );
-          String progressStr = progress == progress.toInt()
-              ? progress.toInt().toString()
-              : progress.toStringAsFixed(2);
-          String progressStringRatio =
-              '${formatNumber(achievement.value)}/${achievement.target.toString().replaceAll(RegExp('000000\$'), 'M')} - $progressStr%';
 
-          return Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(12),
-                    color: progress >= 100 
-                        ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-                        : Theme.of(context).colorScheme.surface,
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                achievement.name,
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold, 
-                                  fontSize: 16,
-                                  color: Theme.of(context).colorScheme.onSurface,
-                                ),
-                              ),
-                            ),
-                            SizedBox(width: 8),
-                            Row(
-                              children: generateStars(stars, 20).map((star) {
-                                return Container(
-                                  margin: EdgeInsets.only(left: 2),
-                                  child: star,
-                                );
-                              }).toList(),
-                            ),
-                          ],
-                        ),
-                        SizedBox(height: 8),
-                        Text(
-                          achievement.info.replaceAll(RegExp('000000 '), 'M '),
+    return filteredAchievements.map((achievement) {
+      int stars = achievement.stars;
+      if ((achievement.name == _dragonSlayer ||
+              achievement.name == _ungratefulChild) &&
+          achievement.value >= 1) {
+        stars += 2;
+      }
+      double progress = min<double>(
+        (achievement.value.toDouble() /
+                max<double>(achievement.target.toDouble(), 1.0)) *
+            100,
+        100.0,
+      );
+      String progressStr = progress == progress.toInt()
+          ? progress.toInt().toString()
+          : progress.toStringAsFixed(2);
+      String progressStringRatio =
+          '${formatNumber(achievement.value)}/${achievement.target.toString().replaceAll(RegExp('000000\$'), 'M')} - $progressStr%';
+
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Card(
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: progress >= 100
+                  ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
+                  : Theme.of(context).colorScheme.surface,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          achievement.name,
                           style: TextStyle(
-                            fontSize: 13, 
-                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color: Theme.of(context).colorScheme.onSurface,
                           ),
                         ),
-                        SizedBox(height: 12),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              progressStringRatio,
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.8),
-                              ),
-                            ),
-                          ],
-                        ),
-                        SizedBox(height: 8),
-                        LinearProgressIndicator(
-                          value: progress / 100,
-                          minHeight: 6,
-                          backgroundColor: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
-                          valueColor: AlwaysStoppedAnimation<Color>(
-                            progress >= 100 
-                                ? Theme.of(context).colorScheme.primary
-                                : Theme.of(context).colorScheme.primary,
-                          ),
-                        ),
-                      ],
+                      ),
+                      const SizedBox(width: 8),
+                      Row(
+                        children: generateStars(stars, 20).map((star) {
+                          return Container(
+                            margin: const EdgeInsets.only(left: 2),
+                            child: star,
+                          );
+                        }).toList(),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    achievement.info.replaceAll(RegExp('000000 '), 'M '),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
-                ),
-              ));
-        }).toList();
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        progressStringRatio,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onSurface.withValues(alpha: 0.8),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    value: progress / 100,
+                    minHeight: 6,
+                    backgroundColor: Theme.of(
+                      context,
+                    ).colorScheme.outline.withValues(alpha: 0.2),
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      progress >= 100
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }).toList();
   }
 
   Widget _buildAchievementChips(BuildContext context) {
@@ -382,10 +408,9 @@ class PlayerAchievementScreenState extends State<PlayerAchievementScreen>
     if (numberStr.endsWith('000000')) {
       return numberStr.replaceAll(RegExp('000000\$'), 'M');
     } else {
-      return NumberFormat("#,###")
-          .format(number)
-          .toString()
-          .replaceAll(',', ' ');
+      return NumberFormat(
+        "#,###",
+      ).format(number).toString().replaceAll(',', ' ');
     }
   }
 }

--- a/lib/features/player/presentation/player/player_header.dart
+++ b/lib/features/player/presentation/player/player_header.dart
@@ -70,15 +70,15 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
               _buildPlayerMainInfo(hallImageUrl),
             ],
           ),
-          SizedBox(height: 46),
+          const SizedBox(height: 46),
           _buildPlayerDetails(context, stars),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child: hallChips,
           ),
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
           _buildWarButtons(context),
-          SizedBox(height: 16),
+          const SizedBox(height: 16),
         ],
       ),
     );
@@ -97,7 +97,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
             BlendMode.darken,
           ),
           child: CachedNetworkImage(
-            errorWidget: (context, url, error) => Icon(Icons.error),
+            errorWidget: (context, url, error) => const Icon(Icons.error),
             imageUrl: imageUrl,
             width: double.infinity,
             fit: BoxFit.cover,
@@ -128,7 +128,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
       child: Row(
         children: [
           IconButton(
-            icon: Icon(Icons.sports_esports_rounded,
+            icon: const Icon(Icons.sports_esports_rounded,
                 color: Colors.white, size: 32),
             onPressed: () {
               final languageCode =
@@ -152,7 +152,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
             onPressed: () {
               showMenu(
                 context: context,
-                position: RelativeRect.fromLTRB(100, 100, 0, 0),
+                position: const RelativeRect.fromLTRB(100, 100, 0, 0),
                 items: [
                   PopupMenuItem(
                     value: 'achievements',
@@ -162,7 +162,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
                             imageUrl:
                                 widget.player.clanOverview.badgeUrls.small,
                             width: 20),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.gameAchievements),
                       ],
                     ),
@@ -180,8 +180,8 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
                     value: 'war_stats',
                     child: Row(
                       children: [
-                        MobileWebImage(imageUrl: ImageAssets.war, width: 20),
-                        SizedBox(width: 8),
+                        const MobileWebImage(imageUrl: ImageAssets.war, width: 20),
+                        const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.warStats),
                       ],
                     ),
@@ -198,9 +198,9 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
                     value: 'todolist',
                     child: Row(
                       children: [
-                        MobileWebImage(
+                        const MobileWebImage(
                             imageUrl: ImageAssets.iconBuilderPotion, width: 20),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!.todoTitle),
                       ],
                     ),
@@ -210,7 +210,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
                           context: context,
                           builder: (context) => Dialog(
                             backgroundColor: Colors.transparent,
-                            insetPadding: EdgeInsets.all(8),
+                            insetPadding: const EdgeInsets.all(8),
                             child: IntrinsicHeight(
                               child: PlayerToDoBodyCard(
                                 player: widget.player,
@@ -237,12 +237,12 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
       bottom: -72,
       child: Row(
         children: [
-          SizedBox(width: 16),
+          const SizedBox(width: 16),
           CachedNetworkImage(
-              errorWidget: (context, url, error) => Icon(Icons.error),
+              errorWidget: (context, url, error) => const Icon(Icons.error),
               imageUrl: hallImageUrl,
               width: 190),
-          SizedBox(width: 16),
+          const SizedBox(width: 16),
         ],
       ),
     );
@@ -256,14 +256,14 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              SizedBox(height: 22),
+              const SizedBox(height: 22),
               stars.isNotEmpty
                   ? Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: stars,
                     )
-                  : SizedBox(height: 22),
-              SizedBox(height: 8),
+                  : const SizedBox(height: 22),
+              const SizedBox(height: 8),
               Text(
                 widget.player.name,
                 style: Theme.of(context).textTheme.titleLarge,
@@ -290,7 +290,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
         });
       },
       child: Container(
-        padding: EdgeInsets.only(top: 2.0, bottom: 10.0),
+        padding: const EdgeInsets.only(top: 2.0, bottom: 10.0),
         child: Text(
           widget.player.tag,
           style: TextStyle(color: Theme.of(context).colorScheme.tertiary),
@@ -304,7 +304,7 @@ class PlayerInfoHeaderState extends State<PlayerInfoHeader>
     return List<Widget>.generate(
       count,
       (index) => CachedNetworkImage(
-        errorWidget: (context, url, error) => Icon(Icons.error),
+        errorWidget: (context, url, error) => const Icon(Icons.error),
         imageUrl: ImageAssets.builderBaseStar,
         width: 22.0,
         height: 22.0,

--- a/lib/features/player/presentation/player/player_page.dart
+++ b/lib/features/player/presentation/player/player_page.dart
@@ -75,7 +75,7 @@ class PlayerScreenState extends State<PlayerScreen>
   Widget _buildPlayerContent(Player player) {
     return Column(
       children: [
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
         PlayerSuperTroopSection(superTroops: player.superTroops),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameHeroes,
@@ -101,7 +101,7 @@ class PlayerScreenState extends State<PlayerScreen>
             title: AppLocalizations.of(context)!.gamePets,
             items: player.pets,
             townHallLevel: player.townHallLevel),
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
       ],
     );
   }
@@ -109,7 +109,7 @@ class PlayerScreenState extends State<PlayerScreen>
   Widget _buildBuilderContent(Player player) {
     return Column(
       children: [
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
         PlayerItemSection(
             title: AppLocalizations.of(context)!.gameHeroes,
             items: player.bbHeroes,
@@ -118,7 +118,7 @@ class PlayerScreenState extends State<PlayerScreen>
             title: AppLocalizations.of(context)!.gameTroops,
             items: player.bbTroops,
             townHallLevel: player.builderHallLevel),
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
       ],
     );
   }

--- a/lib/features/player/presentation/player/player_super_troop_section.dart
+++ b/lib/features/player/presentation/player/player_super_troop_section.dart
@@ -37,9 +37,9 @@ class PlayerSuperTroopSection extends StatelessWidget {
                           borderRadius: BorderRadius.circular(6),
                           child: CachedNetworkImage(
                             placeholder: (context, url) =>
-                                CircularProgressIndicator(),
+                                const CircularProgressIndicator(),
                             errorWidget: (context, url, error) =>
-                                Icon(Icons.error),
+                                const Icon(Icons.error),
                             imageUrl: troop.imageUrl,
                             width: 50,
                             height: 50,

--- a/lib/features/player/presentation/to_do/player_to_do_page.dart
+++ b/lib/features/player/presentation/to_do/player_to_do_page.dart
@@ -10,7 +10,7 @@ class PlayerToDoScreen extends StatefulWidget {
   final List<Player> players;
   final Map<String, WarMemberPresence> memberPresenceMap;
 
-  PlayerToDoScreen(
+  const PlayerToDoScreen(
       {super.key, required this.players, required this.memberPresenceMap});
 
   @override
@@ -81,7 +81,7 @@ class PlayerToDoScreenState extends State<PlayerToDoScreen>
                     active: false,
                   ),
                 ]),
-            SizedBox(height: 8),
+            const SizedBox(height: 8),
           ],
         ),
       ),

--- a/lib/features/player/presentation/to_do/widget/player_to_do_body.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_body.dart
@@ -11,7 +11,7 @@ class PlayerToDoBody extends StatefulWidget {
   final Map<String, String> filterOptions;
   final bool active;
 
-  PlayerToDoBody({
+  const PlayerToDoBody({
     super.key,
     required this.filterOptions,
     required this.active,

--- a/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
@@ -13,7 +13,7 @@ class PlayerToDoHeader extends StatefulWidget {
   final List<Player> players;
   final Map<String, WarMemberPresence> memberPresenceMap;
 
-  PlayerToDoHeader({super.key, required this.players, required this.memberPresenceMap});
+  const PlayerToDoHeader({super.key, required this.players, required this.memberPresenceMap});
 
   @override
   PlayerToDoHeaderState createState() => PlayerToDoHeaderState();
@@ -84,7 +84,7 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
                 BlendMode.darken,
               ),
               child: CachedNetworkImage(
-                errorWidget: (context, url, error) => Icon(Icons.error),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
                 imageUrl: "https://assets.clashk.ing/landscape/todo-landscape.png",
                 width: double.infinity,
                 fit: BoxFit.cover,
@@ -100,7 +100,7 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
                 style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white)),
             Text(loc.todoAccountsNumberInactive(inactive),
                 style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white)),
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
             Wrap(
               alignment: WrapAlignment.start,
               spacing: 7.0,
@@ -125,7 +125,7 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
           right: 20,
           child: Row(
             children: [
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Expanded(
                 child: Container(
                   height: 8,
@@ -138,12 +138,12 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
                     child: LinearProgressIndicator(
                       value: progressRatio,
                       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
+                      valueColor: const AlwaysStoppedAnimation<Color>(Colors.green),
                     ),
                   ),
                 ),
               ),
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Text('${(progressRatio * 100).toInt()}%',
                   style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white)),
             ],
@@ -163,15 +163,15 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
             style: Theme.of(context).textTheme.bodyMedium!.copyWith(color: Theme.of(context).colorScheme.onSurface),
             children: [
               TextSpan(text: "${loc.todoExplanationIntro}\n\n"),
-              TextSpan(text: "${loc.todoExplanationLegendsTitle}\n", style: TextStyle(fontWeight: FontWeight.bold)),
+              TextSpan(text: "${loc.todoExplanationLegendsTitle}\n", style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(text: "${loc.todoExplanationLegends}\n\n"),
-              TextSpan(text: "${loc.todoExplanationRaidsTitle}\n", style: TextStyle(fontWeight: FontWeight.bold)),
+              TextSpan(text: "${loc.todoExplanationRaidsTitle}\n", style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(text: "${loc.todoExplanationRaids}\n\n"),
-              TextSpan(text: "${loc.todoExplanationClanWarsTitle}\n", style: TextStyle(fontWeight: FontWeight.bold)),
+              TextSpan(text: "${loc.todoExplanationClanWarsTitle}\n", style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(text: "${loc.todoExplanationClanWars}\n\n"),
-              TextSpan(text: "${loc.todoExplanationCwlTitle}\n", style: TextStyle(fontWeight: FontWeight.bold)),
+              TextSpan(text: "${loc.todoExplanationCwlTitle}\n", style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(text: "${loc.todoExplanationCwl}\n\n"),
-              TextSpan(text: "${loc.todoExplanationPassAndGamesTitle}\n", style: TextStyle(fontWeight: FontWeight.bold)),
+              TextSpan(text: "${loc.todoExplanationPassAndGamesTitle}\n", style: const TextStyle(fontWeight: FontWeight.bold)),
               TextSpan(text: "${loc.todoExplanationPassAndGames}\n\n"),
               TextSpan(text: loc.todoExplanationConclusion),
             ],
@@ -186,11 +186,11 @@ class PlayerToDoHeaderState extends State<PlayerToDoHeader> {
       avatar: CircleAvatar(
         backgroundColor: Colors.transparent,
         child: CachedNetworkImage(
-          errorWidget: (context, url, error) => Icon(Icons.error),
+          errorWidget: (context, url, error) => const Icon(Icons.error),
           imageUrl: imageUrl,
         ),
       ),
-      labelPadding: EdgeInsets.symmetric(horizontal: 4.0),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 4.0),
       label: Text('$value/$max', style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white)),
       shape: RoundedRectangleBorder(
         side: BorderSide(color: value >= max ? Colors.green : Colors.red, width: 1.0),

--- a/lib/features/player/presentation/war_stats/player_war_attacks_card.dart
+++ b/lib/features/player/presentation/war_stats/player_war_attacks_card.dart
@@ -206,7 +206,7 @@ class PlayerWarAttacksCard extends StatelessWidget {
                           children: [
                             buildStarsIcon(attack.stars.round()),
                             const SizedBox(width: 4),
-                            Text(
+                            const Text(
                               "-"
                             ),
                             const SizedBox(width: 4),

--- a/lib/features/player/presentation/war_stats/player_war_attacks_tab.dart
+++ b/lib/features/player/presentation/war_stats/player_war_attacks_tab.dart
@@ -39,7 +39,7 @@ class _PlayerWarAttacksTabState extends State<PlayerWarAttacksTab> {
                 color: Colors.black.withValues(alpha: 0.3),
                 blurRadius: 4.0,
                 spreadRadius: 1.0,
-                offset: Offset(0.0, 2.0),
+                offset: const Offset(0.0, 2.0),
               ),
             ],
           ),

--- a/lib/features/player/presentation/war_stats/player_war_stats_header.dart
+++ b/lib/features/player/presentation/war_stats/player_war_stats_header.dart
@@ -20,7 +20,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
   final VoidCallback onExport;
   final bool hasActiveFilters;
 
-  PlayerWarStatsHeader({
+  const PlayerWarStatsHeader({
     super.key,
     required this.name,
     required this.tag,
@@ -52,7 +52,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
                   Colors.black.withValues(alpha: 0.7),
                   BlendMode.darken,
                 ),
-                child: MobileWebImage(
+                child: const MobileWebImage(
                   imageUrl: ImageAssets.playerWarStatsPageBackground,
                   width: double.infinity,
                   fit: BoxFit.cover,
@@ -77,12 +77,12 @@ class PlayerWarStatsHeader extends StatelessWidget {
                           .titleSmall
                           ?.copyWith(color: Colors.white),
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     MobileWebImage(
                       imageUrl: picture,
                       width: 50,
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(
                       name,
                       style: Theme.of(context)
@@ -97,7 +97,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
                           .labelLarge
                           ?.copyWith(color: Colors.grey),
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Wrap(
                       spacing: 0,
                       runSpacing: 0,
@@ -114,7 +114,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
                           selected: isCWLChecked,
                           onSelected: (bool selected) => onCWLChanged(),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         FilterChip(
                           visualDensity: VisualDensity.compact,
                           selectedColor: Theme.of(context).colorScheme.primary,
@@ -128,7 +128,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
                           selected: isRandomChecked,
                           onSelected: (bool selected) => onRandomChanged(),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         FilterChip(
                           visualDensity: VisualDensity.compact,
                           selectedColor: Theme.of(context).colorScheme.primary,
@@ -144,7 +144,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 ),
               ),
@@ -168,7 +168,7 @@ class PlayerWarStatsHeader extends StatelessWidget {
             children: [
               // Export button
               IconButton(
-                icon: Icon(Icons.download_outlined, color: Colors.white),
+                icon: const Icon(Icons.download_outlined, color: Colors.white),
                 onPressed: onExport,
                 tooltip:
                     AppLocalizations.of(context)?.generalExport ?? 'Export',

--- a/lib/features/player/presentation/war_stats/player_war_stats_page.dart
+++ b/lib/features/player/presentation/war_stats/player_war_stats_page.dart
@@ -144,11 +144,11 @@ class _PlayerWarStatsScreenState extends State<PlayerWarStatsScreen> {
                       children: [
                         const SizedBox(height: 16),
                         // Skeleton loading for stat cards
-                        Row(
+                        const Row(
                           children: [
-                            Expanded(child: const StatCardSkeleton()),
-                            const SizedBox(width: 8),
-                            Expanded(child: const StatCardSkeleton()),
+                            Expanded(child: StatCardSkeleton()),
+                            SizedBox(width: 8),
+                            Expanded(child: StatCardSkeleton()),
                           ],
                         ),
                         const SizedBox(height: 16),
@@ -560,7 +560,7 @@ class _PlayerWarStatsScreenState extends State<PlayerWarStatsScreen> {
           SnackBar(
             content: Row(
               children: [
-                Icon(Icons.error, color: Colors.white, size: 20),
+                const Icon(Icons.error, color: Colors.white, size: 20),
                 const SizedBox(width: 12),
                 Expanded(child: Text('Failed to load filtered data: $e')),
               ],

--- a/lib/features/player/presentation/war_stats/player_war_stats_tab.dart
+++ b/lib/features/player/presentation/war_stats/player_war_stats_tab.dart
@@ -139,12 +139,12 @@ class WarStatsView extends StatelessWidget {
                           width: 30,
                           height: 30,
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         Text(AppLocalizations.of(context)!
                             .gameTownHallLevelNumber(defTh ?? 1)),
                       ],
                     ),
-                    SizedBox(height: 12),
+                    const SizedBox(height: 12),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: Row(

--- a/lib/features/player/presentation/war_stats/war_stats_filter_dialog.dart
+++ b/lib/features/player/presentation/war_stats/war_stats_filter_dialog.dart
@@ -29,6 +29,8 @@ class WarStatsFilterDialog extends StatefulWidget {
 }
 
 class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
+  static const String _allTimeFallback = 'All Time';
+
   late WarStatsFilter _filter;
   late TextEditingController _minMapPositionController;
   late TextEditingController _maxMapPositionController;
@@ -72,7 +74,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
     super.initState();
     // Default the dialog to show "All" (10000) limit, even if initial filter uses 50
     _filter = widget.initialFilter.copyWith(
-      limit: widget.initialFilter.limit == 50 ? 1000 : widget.initialFilter.limit,
+      limit: widget.initialFilter.limit == 50
+          ? 1000
+          : widget.initialFilter.limit,
     );
     _minMapPositionController = TextEditingController(
       text: _filter.minMapPosition?.toString() ?? '',
@@ -98,7 +102,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       'random':
           _filter.warTypes?.contains('random') ?? (_filter.warType == 'random'),
       'cwl': _filter.warTypes?.contains('cwl') ?? (_filter.warType == 'cwl'),
-      'friendly': _filter.warTypes?.contains('friendly') ??
+      'friendly':
+          _filter.warTypes?.contains('friendly') ??
           (_filter.warType == 'friendly'),
     };
 
@@ -121,7 +126,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
     // Performance suggestions will be generated in didChangeDependencies
 
     // Initialize All Time state based on current filter
-    _isAllTimeSelected = _filter.startDate == null &&
+    _isAllTimeSelected =
+        _filter.startDate == null &&
         _filter.endDate == null &&
         _filter.season == null;
   }
@@ -129,7 +135,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    
+
     // Generate performance analysis suggestions
     if (widget.warStats != null && _performanceSuggestions.isEmpty) {
       _performanceSuggestions = PerformanceAnalysisService.analyzePerformance(
@@ -217,14 +223,14 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
     final result = await showDialog<String>(
       context: context,
-      builder: (context) => _SavePresetDialog(
-        filter: _filter,
-      ),
+      builder: (context) => _SavePresetDialog(filter: _filter),
     );
-    
+
     // Only show success message and reload if preset was actually saved
     if (result != null && mounted) {
-      _showInlineSuccess(AppLocalizations.of(context)!.presetsSaveSuccess(result));
+      _showInlineSuccess(
+        AppLocalizations.of(context)!.presetsSaveSuccess(result),
+      );
       await _loadSavedPresets();
     }
   }
@@ -320,8 +326,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
       // Reset destruction range and limit
       _filter = _filter.copyWith(
-        minDestruction: null, 
-        maxDestruction: null, 
+        minDestruction: null,
+        maxDestruction: null,
         limit: null,
         startDate: null,
         endDate: null,
@@ -354,10 +360,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 ),
                 border: Border(
                   bottom: BorderSide(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .outline
-                        .withValues(alpha: 0.2),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.outline.withValues(alpha: 0.2),
                   ),
                 ),
               ),
@@ -373,9 +378,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                     AppLocalizations.of(context)?.generalFilters ??
                         'War Stats Filters',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurface,
-                          fontWeight: FontWeight.bold,
-                        ),
+                      color: Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const Spacer(),
                   IconButton(
@@ -397,28 +402,38 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // Inline message display
-                    if (_inlineMessage != null) 
+                    if (_inlineMessage != null)
                       Container(
                         width: double.infinity,
                         margin: const EdgeInsets.only(bottom: 16),
                         padding: const EdgeInsets.all(12),
                         decoration: BoxDecoration(
-                          color: _isInlineError 
-                              ? Theme.of(context).colorScheme.errorContainer.withValues(alpha: 0.8)
-                              : Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.8),
+                          color: _isInlineError
+                              ? Theme.of(context).colorScheme.errorContainer
+                                    .withValues(alpha: 0.8)
+                              : Theme.of(context)
+                                    .colorScheme
+                                    .surfaceContainerHighest
+                                    .withValues(alpha: 0.8),
                           borderRadius: BorderRadius.circular(8),
                           border: Border.all(
-                            color: _isInlineError 
-                                ? Theme.of(context).colorScheme.error.withValues(alpha: 0.5)
-                                : Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                            color: _isInlineError
+                                ? Theme.of(
+                                    context,
+                                  ).colorScheme.error.withValues(alpha: 0.5)
+                                : Theme.of(
+                                    context,
+                                  ).colorScheme.primary.withValues(alpha: 0.5),
                             width: 1,
                           ),
                         ),
                         child: Row(
                           children: [
                             Icon(
-                              _isInlineError ? Icons.error_outline : Icons.check_circle_outline,
-                              color: _isInlineError 
+                              _isInlineError
+                                  ? Icons.error_outline
+                                  : Icons.check_circle_outline,
+                              color: _isInlineError
                                   ? Theme.of(context).colorScheme.error
                                   : Theme.of(context).colorScheme.primary,
                               size: 20,
@@ -427,19 +442,24 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                             Expanded(
                               child: Text(
                                 _inlineMessage!,
-                                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                  color: _isInlineError 
-                                      ? Theme.of(context).colorScheme.onErrorContainer
-                                      : Theme.of(context).colorScheme.onSurface,
-                                  fontWeight: FontWeight.w500,
-                                ),
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(
+                                      color: _isInlineError
+                                          ? Theme.of(
+                                              context,
+                                            ).colorScheme.onErrorContainer
+                                          : Theme.of(
+                                              context,
+                                            ).colorScheme.onSurface,
+                                      fontWeight: FontWeight.w500,
+                                    ),
                               ),
                             ),
                             IconButton(
                               onPressed: _clearInlineMessage,
                               icon: Icon(
                                 Icons.close,
-                                color: _isInlineError 
+                                color: _isInlineError
                                     ? Theme.of(context).colorScheme.error
                                     : Theme.of(context).colorScheme.primary,
                                 size: 18,
@@ -458,7 +478,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
                     // Time Filters Card (Collapsible)
                     _buildCollapsibleSectionCard(
-                      title: AppLocalizations.of(context)?.filtersTimeFilters ??
+                      title:
+                          AppLocalizations.of(context)?.filtersTimeFilters ??
                           'Time Filters',
                       icon: Icons.schedule,
                       isExpanded: _isTimeFiltersExpanded,
@@ -470,13 +491,15 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       child: Column(
                         children: [
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.filtersSeason ??
-                                  'Season'),
+                            AppLocalizations.of(context)?.filtersSeason ??
+                                'Season',
+                          ),
                           _buildSeasonSelector(),
                           const SizedBox(height: 16),
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.filtersDateRange ??
-                                  'Date Range'),
+                            AppLocalizations.of(context)?.filtersDateRange ??
+                                'Date Range',
+                          ),
                           _buildDateRangePicker(),
                         ],
                       ),
@@ -484,7 +507,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
                     // War Settings Card (Collapsible)
                     _buildCollapsibleSectionCard(
-                      title: AppLocalizations.of(context)?.filtersWarSettings ??
+                      title:
+                          AppLocalizations.of(context)?.filtersWarSettings ??
                           'War Settings',
                       icon: Icons.military_tech,
                       isExpanded: _isWarSettingsExpanded,
@@ -496,13 +520,15 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       child: Column(
                         children: [
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.filtersWarType ??
-                                  'War Type'),
+                            AppLocalizations.of(context)?.filtersWarType ??
+                                'War Type',
+                          ),
                           _buildWarTypeDropdown(),
                           const SizedBox(height: 16),
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.filtersTownHall ??
-                                  'Town Hall'),
+                            AppLocalizations.of(context)?.filtersTownHall ??
+                                'Town Hall',
+                          ),
                           _buildTownHallFilters(),
                         ],
                       ),
@@ -510,7 +536,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
                     // Performance Card (Collapsible)
                     _buildCollapsibleSectionCard(
-                      title: AppLocalizations.of(context)?.filtersPerformance ??
+                      title:
+                          AppLocalizations.of(context)?.filtersPerformance ??
                           'Performance',
                       icon: Icons.star,
                       isExpanded: _isPerformanceExpanded,
@@ -524,7 +551,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
 
                     // Advanced Card (Collapsible)
                     _buildCollapsibleSectionCard(
-                      title: AppLocalizations.of(context)?.filtersAdvanced ??
+                      title:
+                          AppLocalizations.of(context)?.filtersAdvanced ??
                           'Advanced',
                       icon: Icons.settings,
                       isExpanded: _isAdvancedExpanded,
@@ -536,13 +564,15 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       child: Column(
                         children: [
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.warPositionMap ??
-                                  'Map Position'),
+                            AppLocalizations.of(context)?.warPositionMap ??
+                                'Map Position',
+                          ),
                           _buildMapPositionFilters(),
                           const SizedBox(height: 16),
                           _buildSubsectionTitle(
-                              AppLocalizations.of(context)?.filtersOptions ??
-                                  'Options'),
+                            AppLocalizations.of(context)?.filtersOptions ??
+                                'Options',
+                          ),
                           _buildAdvancedOptions(),
                         ],
                       ),
@@ -559,11 +589,10 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                           ),
                           const SizedBox(width: 4),
                           Text(
-                            AppLocalizations.of(context)!
-                                .performanceAnalysisSuggestions,
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelMedium
+                            AppLocalizations.of(
+                              context,
+                            )!.performanceAnalysisSuggestions,
+                            style: Theme.of(context).textTheme.labelMedium
                                 ?.copyWith(
                                   color: Theme.of(context).colorScheme.tertiary,
                                 ),
@@ -575,17 +604,26 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                 context: context,
                                 builder: (BuildContext context) {
                                   return AlertDialog(
-                                    title: Text(AppLocalizations.of(context)!
-                                        .performanceAnalysisSuggestions),
-                                    content: Text(AppLocalizations.of(context)!
-                                        .performanceAnalysisTooltip),
+                                    title: Text(
+                                      AppLocalizations.of(
+                                        context,
+                                      )!.performanceAnalysisSuggestions,
+                                    ),
+                                    content: Text(
+                                      AppLocalizations.of(
+                                        context,
+                                      )!.performanceAnalysisTooltip,
+                                    ),
                                     actions: [
                                       TextButton(
                                         onPressed: () =>
                                             Navigator.of(context).pop(),
-                                        child: Text(AppLocalizations.of(context)
-                                                ?.generalOk ??
-                                            'OK'),
+                                        child: Text(
+                                          AppLocalizations.of(
+                                                context,
+                                              )?.generalOk ??
+                                              'OK',
+                                        ),
                                       ),
                                     ],
                                   );
@@ -598,10 +636,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                               child: Icon(
                                 Icons.info_outline,
                                 size: 14,
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurface
-                                    .withValues(alpha: 0.6),
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withValues(alpha: 0.6),
                               ),
                             ),
                           ),
@@ -612,8 +649,10 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         spacing: 8,
                         runSpacing: 8,
                         children: _performanceSuggestions
-                            .map((suggestion) =>
-                                _buildPerformanceSuggestionChip(suggestion))
+                            .map(
+                              (suggestion) =>
+                                  _buildPerformanceSuggestionChip(suggestion),
+                            )
                             .toList(),
                       ),
                     ],
@@ -629,10 +668,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 color: Theme.of(context).colorScheme.surface,
                 border: Border(
                   top: BorderSide(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .outline
-                        .withValues(alpha: 0.2),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.outline.withValues(alpha: 0.2),
                   ),
                 ),
               ),
@@ -646,8 +684,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         onPressed: _resetFilters,
                         icon: const Icon(Icons.refresh, size: 18),
                         label: Text(
-                            AppLocalizations.of(context)?.generalReset ??
-                                'Reset'),
+                          AppLocalizations.of(context)?.generalReset ?? 'Reset',
+                        ),
                       ),
                       const Spacer(),
                     ],
@@ -660,8 +698,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       TextButton(
                         onPressed: () => Navigator.pop(context),
                         child: Text(
-                            AppLocalizations.of(context)?.generalCancel ??
-                                'Cancel'),
+                          AppLocalizations.of(context)?.generalCancel ??
+                              'Cancel',
+                        ),
                       ),
                       const SizedBox(width: 8),
                       ElevatedButton.icon(
@@ -689,10 +728,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                               .toList();
 
                           // Update filter with all selections
-                          final DateTime? finalStartDate = _isAllTimeSelected ? null : _filter.startDate;
-                          final DateTime? finalEndDate = _isAllTimeSelected ? null : _filter.endDate;
-                          final String? finalSeason = _isAllTimeSelected ? null : selectedSeason;
-                          
+                          final DateTime? finalStartDate = _isAllTimeSelected
+                              ? null
+                              : _filter.startDate;
+                          final DateTime? finalEndDate = _isAllTimeSelected
+                              ? null
+                              : _filter.endDate;
+                          final String? finalSeason = _isAllTimeSelected
+                              ? null
+                              : selectedSeason;
+
                           final updatedFilter = _filter.copyWith(
                             season: finalSeason,
                             startDate: finalStartDate,
@@ -706,20 +751,22 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                             enemyTownHalls: selectedDefenderTH.isNotEmpty
                                 ? selectedDefenderTH
                                 : null,
-                            warTypes: selectedWarTypes.isNotEmpty &&
+                            warTypes:
+                                selectedWarTypes.isNotEmpty &&
                                     !selectedWarTypes.contains('all')
                                 ? selectedWarTypes
                                 : null,
-                            allowedStars:
-                                selectedStars.isNotEmpty ? selectedStars : null,
+                            allowedStars: selectedStars.isNotEmpty
+                                ? selectedStars
+                                : null,
                             minDestruction: _filter.minDestruction,
                             maxDestruction: _filter.maxDestruction,
-                            minMapPosition: _minMapPositionController
-                                    .text.isNotEmpty
+                            minMapPosition:
+                                _minMapPositionController.text.isNotEmpty
                                 ? int.tryParse(_minMapPositionController.text)
                                 : null,
-                            maxMapPosition: _maxMapPositionController
-                                    .text.isNotEmpty
+                            maxMapPosition:
+                                _maxMapPositionController.text.isNotEmpty
                                 ? int.tryParse(_maxMapPositionController.text)
                                 : null,
                             limit: _filter.limit,
@@ -730,9 +777,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         },
                         icon: const Icon(Icons.check, size: 18),
                         label: Text(
-                            AppLocalizations.of(context)?.generalApply ??
-                                'Apply',
-                            style: Theme.of(context).textTheme.labelLarge),
+                          AppLocalizations.of(context)?.generalApply ?? 'Apply',
+                          style: Theme.of(context).textTheme.labelLarge,
+                        ),
                       ),
                     ],
                   ),
@@ -760,9 +807,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                     : () async {
                         final picked = await showDatePicker(
                           context: context,
-                          initialDate: _filter.startDate ??
-                              DateTime.now()
-                                  .subtract(const Duration(days: 180)),
+                          initialDate:
+                              _filter.startDate ??
+                              DateTime.now().subtract(
+                                const Duration(days: 180),
+                              ),
                           firstDate: DateTime(2020),
                           lastDate: DateTime.now(),
                         );
@@ -781,10 +830,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
                     border: Border.all(
-                        color: Theme.of(context).colorScheme.outline.withValues(
-                            alpha: (isAllTime || selectedSeason != null)
-                                ? 0.1
-                                : 0.3)),
+                      color: Theme.of(context).colorScheme.outline.withValues(
+                        alpha: (isAllTime || selectedSeason != null)
+                            ? 0.1
+                            : 0.3,
+                      ),
+                    ),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Column(
@@ -795,10 +846,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                           Icon(
                             Icons.event,
                             color: isAllTime
-                                ? Theme.of(context)
-                                    .colorScheme
-                                    .primary
-                                    .withValues(alpha: 0.5)
+                                ? Theme.of(
+                                    context,
+                                  ).colorScheme.primary.withValues(alpha: 0.5)
                                 : Theme.of(context).colorScheme.primary,
                             size: 16,
                           ),
@@ -806,18 +856,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                           Text(
                             AppLocalizations.of(context)?.filtersStartDate ??
                                 'Start Date',
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelSmall
+                            style: Theme.of(context).textTheme.labelSmall
                                 ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
+                                  color: Theme.of(context).colorScheme.onSurface
                                       .withValues(
-                                          alpha: (isAllTime ||
-                                                  selectedSeason != null)
-                                              ? 0.4
-                                              : 0.8),
+                                        alpha:
+                                            (isAllTime ||
+                                                selectedSeason != null)
+                                            ? 0.4
+                                            : 0.8,
+                                      ),
                                 ),
                             overflow: TextOverflow.ellipsis,
                           ),
@@ -827,25 +875,26 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       Text(
                         isAllTime
                             ? (AppLocalizations.of(context)?.generalAll ??
-                                'All Time')
+                                  _allTimeFallback)
                             : (selectedSeason != null
-                                ? (AppLocalizations.of(context)
-                                        ?.filtersSeason ??
-                                    'Season Selected')
-                                : (_filter.startDate != null
-                                        ? _formatDate(_filter.startDate!) :
-                                    (AppLocalizations.of(context)
-                                            ?.generalNotSet ??
-                                        'Not set'))),
+                                  ? (AppLocalizations.of(
+                                          context,
+                                        )?.filtersSeason ??
+                                        'Season Selected')
+                                  : (_filter.startDate != null
+                                        ? _formatDate(_filter.startDate!)
+                                        : (AppLocalizations.of(
+                                                context,
+                                              )?.generalNotSet ??
+                                              'Not set'))),
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              fontWeight: FontWeight.w500,
-                              color: isAllTime
-                                  ? Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withValues(alpha: 0.6)
-                                  : null,
-                            ),
+                          fontWeight: FontWeight.w500,
+                          color: isAllTime
+                              ? Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withValues(alpha: 0.6)
+                              : null,
+                        ),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ],
@@ -880,10 +929,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   padding: const EdgeInsets.all(10),
                   decoration: BoxDecoration(
                     border: Border.all(
-                        color: Theme.of(context).colorScheme.outline.withValues(
-                            alpha: (isAllTime || selectedSeason != null)
-                                ? 0.1
-                                : 0.3)),
+                      color: Theme.of(context).colorScheme.outline.withValues(
+                        alpha: (isAllTime || selectedSeason != null)
+                            ? 0.1
+                            : 0.3,
+                      ),
+                    ),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Column(
@@ -894,10 +945,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                           Icon(
                             Icons.event,
                             color: isAllTime
-                                ? Theme.of(context)
-                                    .colorScheme
-                                    .primary
-                                    .withValues(alpha: 0.5)
+                                ? Theme.of(
+                                    context,
+                                  ).colorScheme.primary.withValues(alpha: 0.5)
                                 : Theme.of(context).colorScheme.primary,
                             size: 16,
                           ),
@@ -905,18 +955,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                           Text(
                             AppLocalizations.of(context)?.filtersEndDate ??
                                 'End Date',
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelSmall
+                            style: Theme.of(context).textTheme.labelSmall
                                 ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
+                                  color: Theme.of(context).colorScheme.onSurface
                                       .withValues(
-                                          alpha: (isAllTime ||
-                                                  selectedSeason != null)
-                                              ? 0.4
-                                              : 0.8),
+                                        alpha:
+                                            (isAllTime ||
+                                                selectedSeason != null)
+                                            ? 0.4
+                                            : 0.8,
+                                      ),
                                 ),
                             overflow: TextOverflow.ellipsis,
                           ),
@@ -926,25 +974,26 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       Text(
                         isAllTime
                             ? (AppLocalizations.of(context)?.generalAll ??
-                                'All Time')
+                                  _allTimeFallback)
                             : (selectedSeason != null
-                                ? (AppLocalizations.of(context)
-                                        ?.filtersSeason ??
-                                    'Season Selected')
-                                : (_filter.endDate != null
-                                        ? _formatDate(_filter.endDate!) :
-                                    (AppLocalizations.of(context)
-                                            ?.generalNotSet ??
-                                        'Not set'))),
+                                  ? (AppLocalizations.of(
+                                          context,
+                                        )?.filtersSeason ??
+                                        'Season Selected')
+                                  : (_filter.endDate != null
+                                        ? _formatDate(_filter.endDate!)
+                                        : (AppLocalizations.of(
+                                                context,
+                                              )?.generalNotSet ??
+                                              'Not set'))),
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              fontWeight: FontWeight.w500,
-                              color: isAllTime
-                                  ? Theme.of(context)
-                                      .colorScheme
-                                      .onSurface
-                                      .withValues(alpha: 0.6)
-                                  : null,
-                            ),
+                          fontWeight: FontWeight.w500,
+                          color: isAllTime
+                              ? Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withValues(alpha: 0.6)
+                              : null,
+                        ),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ],
@@ -986,12 +1035,14 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 selectedMonth = null;
               });
               _limitController.text = '1000';
-              _updateFilter(_filter.copyWith(
-                startDate: DateTime.now().subtract(const Duration(days: 180)),
-                endDate: DateTime.now(),
-                season: null,
-                limit: 1000, // Set back to default limit
-              ));
+              _updateFilter(
+                _filter.copyWith(
+                  startDate: DateTime.now().subtract(const Duration(days: 180)),
+                  endDate: DateTime.now(),
+                  season: null,
+                  limit: 1000, // Set back to default limit
+                ),
+              );
             }
           },
           child: Row(
@@ -999,7 +1050,6 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               Checkbox(
                 value: isAllTime,
                 onChanged: (value) {
-
                   if (value == true) {
                     // When checking, clear dates and season for all time
                     setState(() {
@@ -1009,15 +1059,17 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       selectedMonth = null;
                     });
                     _limitController.text = '';
-                    _updateFilter(_filter.copyWith(
-                      startDate: null,
-                      endDate: null,
-                      season: null,
-                      limit: 10000, // Set to "All" when All Time is selected
-                      clearStartDate: true,
-                      clearEndDate: true,
-                      clearSeason: true,
-                    ));
+                    _updateFilter(
+                      _filter.copyWith(
+                        startDate: null,
+                        endDate: null,
+                        season: null,
+                        limit: 10000, // Set to "All" when All Time is selected
+                        clearStartDate: true,
+                        clearEndDate: true,
+                        clearSeason: true,
+                      ),
+                    );
                   } else if (value == false) {
                     // When unchecking, set to default date range (last 180 days)
                     setState(() {
@@ -1027,23 +1079,27 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                       selectedMonth = null;
                     });
                     _limitController.text = '1000';
-                    _updateFilter(_filter.copyWith(
-                      startDate:
-                          DateTime.now().subtract(const Duration(days: 180)),
-                      endDate: DateTime.now(),
-                      season: null,
-                      limit: 1000, // Set back to default limit
-                    ));
+                    _updateFilter(
+                      _filter.copyWith(
+                        startDate: DateTime.now().subtract(
+                          const Duration(days: 180),
+                        ),
+                        endDate: DateTime.now(),
+                        season: null,
+                        limit: 1000, // Set back to default limit
+                      ),
+                    );
                   }
                 },
               ),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  AppLocalizations.of(context)?.generalAllTime ?? 'All Time',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
+                  AppLocalizations.of(context)?.generalAllTime ??
+                      _allTimeFallback,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
                   softWrap: true,
                 ),
               ),
@@ -1059,22 +1115,22 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       {
         'value': 'all',
         'label': AppLocalizations.of(context)!.filtersAllWars,
-        'icon': Icons.all_inclusive
+        'icon': Icons.all_inclusive,
       },
       {
         'value': 'random',
         'label': AppLocalizations.of(context)!.warFiltersRandom,
-        'icon': Icons.shuffle
+        'icon': Icons.shuffle,
       },
       {
         'value': 'cwl',
         'label': AppLocalizations.of(context)!.cwlTitle,
-        'icon': Icons.emoji_events
+        'icon': Icons.emoji_events,
       },
       {
         'value': 'friendly',
         'label': AppLocalizations.of(context)!.warFiltersFriendly,
-        'icon': Icons.handshake
+        'icon': Icons.handshake,
       },
     ];
 
@@ -1133,9 +1189,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       children: [
         Text(
           AppLocalizations.of(context)?.filtersAttackerTh ?? 'Attacker TH',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
           overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 8),
@@ -1145,8 +1201,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           children: attackerThSelection.keys.map((thLevel) {
             return FilterChip(
               showCheckmark: false,
-              selectedColor:
-                  Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+              selectedColor: Theme.of(
+                context,
+              ).colorScheme.primary.withValues(alpha: 0.6),
               labelPadding: const EdgeInsets.all(0),
               label: MobileWebImage(
                 imageUrl: ImageAssets.townHall(thLevel),
@@ -1164,9 +1221,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         const SizedBox(height: 16),
         Text(
           AppLocalizations.of(context)?.filtersDefenderTh ?? 'Defender TH',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
           overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 8),
@@ -1176,8 +1233,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           children: defenderThSelection.keys.map((thLevel) {
             return FilterChip(
               showCheckmark: false,
-              selectedColor:
-                  Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+              selectedColor: Theme.of(
+                context,
+              ).colorScheme.primary.withValues(alpha: 0.6),
               labelPadding: const EdgeInsets.all(0),
               label: MobileWebImage(
                 imageUrl: ImageAssets.townHall(thLevel),
@@ -1206,9 +1264,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               child: Text(
                 AppLocalizations.of(context)?.filtersSameTownHallOnly ??
                     'Same Town Hall Only',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
                 overflow: TextOverflow.ellipsis,
               ),
             ),
@@ -1224,9 +1282,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         // Stars filter with chips
         Text(
           AppLocalizations.of(context)?.warStarsTitle ?? 'Stars',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
         ),
         const SizedBox(height: 8),
         Wrap(
@@ -1259,9 +1317,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         Text(
           AppLocalizations.of(context)?.filtersDestructionPercentage ??
               'Destruction Percentage',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
         ),
         const SizedBox(height: 8),
         RangeSlider(
@@ -1278,10 +1336,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           ),
           onChanged: (RangeValues values) {
             setState(() {
-              _updateFilter(_filter.copyWith(
-                minDestruction: values.start,
-                maxDestruction: values.end,
-              ));
+              _updateFilter(
+                _filter.copyWith(
+                  minDestruction: values.start,
+                  maxDestruction: values.end,
+                ),
+              );
             });
           },
         ),
@@ -1312,12 +1372,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               Text(
                 'Min',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w500,
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withValues(alpha: 0.7),
-                    ),
+                  fontWeight: FontWeight.w500,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
               ),
               const SizedBox(height: 4),
               TextField(
@@ -1325,9 +1384,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 keyboardType: TextInputType.number,
                 decoration: InputDecoration(
                   border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8)),
-                  contentPadding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                 ),
               ),
             ],
@@ -1341,12 +1403,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               Text(
                 'Max',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.w500,
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withValues(alpha: 0.7),
-                    ),
+                  fontWeight: FontWeight.w500,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
               ),
               const SizedBox(height: 4),
               TextField(
@@ -1354,9 +1415,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 keyboardType: TextInputType.number,
                 decoration: InputDecoration(
                   border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8)),
-                  contentPadding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                 ),
               ),
             ],
@@ -1392,14 +1456,17 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
           border: Border.all(
-              color: Theme.of(context).colorScheme.outline.withValues(alpha: isDisabled ? 0.1 : 0.3)),
+            color: Theme.of(
+              context,
+            ).colorScheme.outline.withValues(alpha: isDisabled ? 0.1 : 0.3),
+          ),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
           children: [
             Icon(
               Icons.calendar_today,
-              color: isDisabled 
+              color: isDisabled
                   ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.5)
                   : Theme.of(context).colorScheme.primary,
               size: 20,
@@ -1412,22 +1479,23 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   Text(
                     AppLocalizations.of(context)?.filtersSeason ?? 'Season',
                     style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .onSurface
-                              .withValues(alpha: isDisabled ? 0.4 : 0.8),
-                        ),
+                      color: Theme.of(context).colorScheme.onSurface.withValues(
+                        alpha: isDisabled ? 0.4 : 0.8,
+                      ),
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 4),
                   Text(
                     displayText,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w500,
-                          color: isDisabled 
-                              ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)
-                              : null,
-                        ),
+                      fontWeight: FontWeight.w500,
+                      color: isDisabled
+                          ? Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withValues(alpha: 0.6)
+                          : null,
+                    ),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ],
@@ -1435,10 +1503,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             ),
             Icon(
               Icons.arrow_drop_down,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: isDisabled ? 0.3 : 0.7),
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: isDisabled ? 0.3 : 0.7),
             ),
           ],
         ),
@@ -1487,8 +1554,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                 child: ListView(
                                   children: [
                                     ListTile(
-                                      title: Text(AppLocalizations.of(context)!
-                                          .generalAll),
+                                      title: Text(
+                                        AppLocalizations.of(
+                                          context,
+                                        )!.generalAll,
+                                      ),
                                       selected: selectedYear == null,
                                       onTap: () {
                                         setState(() {
@@ -1496,28 +1566,37 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                           selectedYear = null;
                                           _updateSeasonString();
                                           // Clear date range when selecting season
-                                          _updateFilter(_filter.copyWith(
-                                              startDate: null, endDate: null));
+                                          _updateFilter(
+                                            _filter.copyWith(
+                                              startDate: null,
+                                              endDate: null,
+                                            ),
+                                          );
                                         });
                                         setModalState(() {});
                                       },
                                     ),
-                                    ...years.map((year) => ListTile(
-                                          title: Text(year.toString()),
-                                          selected: selectedYear == year,
-                                          onTap: () {
-                                            setState(() {
-                                              _isAllTimeSelected = false;
-                                              selectedYear = year;
-                                              _updateSeasonString();
-                                              // Clear date range when selecting season
-                                              _updateFilter(_filter.copyWith(
-                                                  startDate: null,
-                                                  endDate: null));
-                                            });
-                                            setModalState(() {});
-                                          },
-                                        )),
+                                    ...years.map(
+                                      (year) => ListTile(
+                                        title: Text(year.toString()),
+                                        selected: selectedYear == year,
+                                        onTap: () {
+                                          setState(() {
+                                            _isAllTimeSelected = false;
+                                            selectedYear = year;
+                                            _updateSeasonString();
+                                            // Clear date range when selecting season
+                                            _updateFilter(
+                                              _filter.copyWith(
+                                                startDate: null,
+                                                endDate: null,
+                                              ),
+                                            );
+                                          });
+                                          setModalState(() {});
+                                        },
+                                      ),
+                                    ),
                                   ],
                                 ),
                               ),
@@ -1526,10 +1605,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         ),
                         Container(
                           width: 1,
-                          color: Theme.of(context)
-                              .colorScheme
-                              .outline
-                              .withValues(alpha: 0.3),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.outline.withValues(alpha: 0.3),
                         ),
                         // Month Selection
                         Expanded(
@@ -1547,8 +1625,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                 child: ListView(
                                   children: [
                                     ListTile(
-                                      title: Text(AppLocalizations.of(context)!
-                                          .generalAll),
+                                      title: Text(
+                                        AppLocalizations.of(
+                                          context,
+                                        )!.generalAll,
+                                      ),
                                       selected: selectedMonth == null,
                                       onTap: () {
                                         setState(() {
@@ -1556,28 +1637,37 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                           selectedMonth = null;
                                           _updateSeasonString();
                                           // Clear date range when selecting season
-                                          _updateFilter(_filter.copyWith(
-                                              startDate: null, endDate: null));
+                                          _updateFilter(
+                                            _filter.copyWith(
+                                              startDate: null,
+                                              endDate: null,
+                                            ),
+                                          );
                                         });
                                         setModalState(() {});
                                       },
                                     ),
-                                    ...months.entries.map((entry) => ListTile(
-                                          title: Text(entry.value),
-                                          selected: selectedMonth == entry.key,
-                                          onTap: () {
-                                            setState(() {
-                                              _isAllTimeSelected = false;
-                                              selectedMonth = entry.key;
-                                              _updateSeasonString();
-                                              // Clear date range when selecting season
-                                              _updateFilter(_filter.copyWith(
-                                                  startDate: null,
-                                                  endDate: null));
-                                            });
-                                            setModalState(() {});
-                                          },
-                                        )),
+                                    ...months.entries.map(
+                                      (entry) => ListTile(
+                                        title: Text(entry.value),
+                                        selected: selectedMonth == entry.key,
+                                        onTap: () {
+                                          setState(() {
+                                            _isAllTimeSelected = false;
+                                            selectedMonth = entry.key;
+                                            _updateSeasonString();
+                                            // Clear date range when selecting season
+                                            _updateFilter(
+                                              _filter.copyWith(
+                                                startDate: null,
+                                                endDate: null,
+                                              ),
+                                            );
+                                          });
+                                          setModalState(() {});
+                                        },
+                                      ),
+                                    ),
                                   ],
                                 ),
                               ),
@@ -1595,14 +1685,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         TextButton(
                           onPressed: () => Navigator.pop(context),
                           child: Text(
-                              AppLocalizations.of(context)?.generalCancel ??
-                                  'Cancel'),
+                            AppLocalizations.of(context)?.generalCancel ??
+                                'Cancel',
+                          ),
                         ),
                         const SizedBox(width: 8),
                         ElevatedButton(
                           onPressed: () => Navigator.pop(context),
                           child: Text(
-                              AppLocalizations.of(context)?.generalOk ?? 'OK'),
+                            AppLocalizations.of(context)?.generalOk ?? 'OK',
+                          ),
                         ),
                       ],
                     ),
@@ -1644,8 +1736,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
   }
 
   Map<int, String> _generateMonths() {
-    final dateFormat =
-        DateFormat.MMMM(Localizations.localeOf(context).languageCode);
+    final dateFormat = DateFormat.MMMM(
+      Localizations.localeOf(context).languageCode,
+    );
     return {
       1: dateFormat.format(DateTime(2024, 1, 1)),
       2: dateFormat.format(DateTime(2024, 2, 1)),
@@ -1680,9 +1773,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               child: Text(
                 AppLocalizations.of(context)?.filtersFreshAttacksOnly ??
                     'Fresh Attacks Only',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
                 softWrap: true,
               ),
             ),
@@ -1698,15 +1791,17 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 Text(
                   AppLocalizations.of(context)?.filtersResultLimit ??
                       'Result Limit',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(width: 8),
                 Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.primary,
                     borderRadius: BorderRadius.circular(12),
@@ -1714,9 +1809,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   child: Text(
                     '${_filter.limit}',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onPrimary,
-                          fontWeight: FontWeight.bold,
-                        ),
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
               ],
@@ -1754,8 +1849,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                     child: Text(
                       AppLocalizations.of(context)?.generalAll ?? 'All Results',
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w500,
-                          ),
+                        fontWeight: FontWeight.w500,
+                      ),
                       softWrap: true,
                     ),
                   ),
@@ -1772,21 +1867,26 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                     child: TextField(
                       controller: _limitController,
                       decoration: InputDecoration(
-                        labelText: AppLocalizations.of(context)?.filtersResultLimit ?? 'Result Limit',
+                        labelText:
+                            AppLocalizations.of(context)?.filtersResultLimit ??
+                            'Result Limit',
                         hintText: '1000',
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
                       ),
                       keyboardType: TextInputType.number,
-                      inputFormatters: [
-                        FilteringTextInputFormatter.digitsOnly,
-                      ],
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                       onChanged: (value) {
                         if (value.isNotEmpty) {
                           final intValue = int.tryParse(value);
-                          if (intValue != null && intValue >= 1 && intValue <= 9999) {
+                          if (intValue != null &&
+                              intValue >= 1 &&
+                              intValue <= 9999) {
                             _updateFilter(_filter.copyWith(limit: intValue));
                           }
                         }
@@ -1822,32 +1922,32 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       {
         'label': AppLocalizations.of(context)!.filtersLast30Days,
         'icon': Icons.schedule,
-        'preset': 'last30days'
+        'preset': 'last30days',
       },
       {
         'label': AppLocalizations.of(context)!.filters3StarOnly,
         'icon': Icons.star,
-        'preset': '3star'
+        'preset': '3star',
       },
       {
         'label': AppLocalizations.of(context)!.cwlTitle,
         'icon': Icons.emoji_events,
-        'preset': 'cwl'
+        'preset': 'cwl',
       },
       {
         'label': AppLocalizations.of(context)!.warFiltersRandom,
         'icon': Icons.shuffle,
-        'preset': 'random'
+        'preset': 'random',
       },
       {
         'label': AppLocalizations.of(context)!.warFiltersFriendly,
         'icon': Icons.handshake,
-        'preset': 'friendly'
+        'preset': 'friendly',
       },
       {
         'label': AppLocalizations.of(context)!.filtersFreshAttacks,
         'icon': Icons.new_releases,
-        'preset': 'fresh'
+        'preset': 'fresh',
       },
     ];
 
@@ -1867,22 +1967,27 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               AppLocalizations.of(context)?.filtersQuickFilters ??
                   'Quick Filters',
               style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                fontWeight: FontWeight.w600,
+                color: Theme.of(context).colorScheme.primary,
+              ),
             ),
             const Spacer(),
             // Save Current Filter Button
             if (_filter.hasActiveFilters())
               TextButton.icon(
                 onPressed: _showSavePresetDialog,
-                icon: Icon(Icons.bookmark_add,
-                    size: 16, color: Theme.of(context).colorScheme.primary),
+                icon: Icon(
+                  Icons.bookmark_add,
+                  size: 16,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
                 label: Text(AppLocalizations.of(context)!.presetsSave),
                 style: TextButton.styleFrom(
                   foregroundColor: Theme.of(context).colorScheme.primary,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
                   minimumSize: Size.zero,
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
@@ -1895,8 +2000,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         Wrap(
           spacing: 8,
           runSpacing: 8,
-          children:
-              builtInPresets.map((preset) => _buildPresetChip(preset)).toList(),
+          children: builtInPresets
+              .map((preset) => _buildPresetChip(preset))
+              .toList(),
         ),
 
         // Saved Presets Section
@@ -1913,16 +2019,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               Text(
                 AppLocalizations.of(context)!.presetsSaved,
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
+                  fontWeight: FontWeight.w600,
+                  color: Theme.of(context).colorScheme.secondary,
+                ),
               ),
             ],
           ),
           const SizedBox(height: 8),
           if (_isLoadingPresets)
             Padding(
-              padding: EdgeInsets.all(8.0),
+              padding: const EdgeInsets.all(8.0),
               child: Center(
                 child: SizedBox(
                   height: 20,
@@ -1958,34 +2064,41 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       case 'last30days':
         // Check if we have a 30-day range ending around today
         if (_filter.startDate != null && _filter.endDate != null) {
-          final daysDiff =
-              _filter.endDate!.difference(_filter.startDate!).inDays;
-          final daysFromToday =
-              DateTime.now().difference(_filter.endDate!).inDays.abs();
+          final daysDiff = _filter.endDate!
+              .difference(_filter.startDate!)
+              .inDays;
+          final daysFromToday = DateTime.now()
+              .difference(_filter.endDate!)
+              .inDays
+              .abs();
           // Consider active if it's approximately 30 days range and ends within 2 days of today
           isActive = daysDiff >= 28 && daysDiff <= 32 && daysFromToday <= 2;
         }
         break;
       case '3star':
-        isActive = starSelection[3] == true &&
+        isActive =
+            starSelection[3] == true &&
             starSelection[0] == false &&
             starSelection[1] == false &&
             starSelection[2] == false;
         break;
       case 'cwl':
-        isActive = warTypeSelection['cwl'] == true &&
+        isActive =
+            warTypeSelection['cwl'] == true &&
             warTypeSelection['all'] == false &&
             warTypeSelection['random'] == false &&
             warTypeSelection['friendly'] == false;
         break;
       case 'random':
-        isActive = warTypeSelection['random'] == true &&
+        isActive =
+            warTypeSelection['random'] == true &&
             warTypeSelection['all'] == false &&
             warTypeSelection['cwl'] == false &&
             warTypeSelection['friendly'] == false;
         break;
       case 'friendly':
-        isActive = warTypeSelection['friendly'] == true &&
+        isActive =
+            warTypeSelection['friendly'] == true &&
             warTypeSelection['all'] == false &&
             warTypeSelection['random'] == false &&
             warTypeSelection['cwl'] == false;
@@ -2030,11 +2143,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             Text(
               preset['label'],
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
-                    color: isActive
-                        ? Theme.of(context).colorScheme.onPrimary
-                        : null,
-                  ),
+                fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
+                color: isActive
+                    ? Theme.of(context).colorScheme.onPrimary
+                    : null,
+              ),
             ),
           ],
         ),
@@ -2089,11 +2202,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 child: Text(
                   preset.name,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
-                        color: isActive
-                            ? Theme.of(context).colorScheme.onSecondary
-                            : Theme.of(context).colorScheme.onSecondaryContainer,
-                      ),
+                    fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
+                    color: isActive
+                        ? Theme.of(context).colorScheme.onSecondary
+                        : Theme.of(context).colorScheme.onSecondaryContainer,
+                  ),
                   maxLines: null,
                   softWrap: true,
                 ),
@@ -2133,10 +2246,9 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             border: Border.all(
               color: isActive
                   ? Theme.of(context).colorScheme.tertiary
-                  : Theme.of(context)
-                      .colorScheme
-                      .tertiary
-                      .withValues(alpha: 0.4),
+                  : Theme.of(
+                      context,
+                    ).colorScheme.tertiary.withValues(alpha: 0.4),
               width: isActive ? 2 : 1,
             ),
           ),
@@ -2157,12 +2269,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                   child: Text(
                     suggestion.name,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          fontWeight:
-                              isActive ? FontWeight.bold : FontWeight.w500,
-                          color: isActive
-                              ? Theme.of(context).colorScheme.onTertiary
-                              : Theme.of(context).colorScheme.onTertiaryContainer,
-                        ),
+                      fontWeight: isActive ? FontWeight.bold : FontWeight.w500,
+                      color: isActive
+                          ? Theme.of(context).colorScheme.onTertiary
+                          : Theme.of(context).colorScheme.onTertiaryContainer,
+                    ),
                     maxLines: null,
                     softWrap: true,
                   ),
@@ -2185,8 +2296,10 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
-              leading: Icon(Icons.play_arrow,
-                  color: Theme.of(context).colorScheme.primary),
+              leading: Icon(
+                Icons.play_arrow,
+                color: Theme.of(context).colorScheme.primary,
+              ),
               title: Text(AppLocalizations.of(context)!.presetsApply),
               onTap: () {
                 Navigator.pop(context);
@@ -2199,8 +2312,10 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               },
             ),
             ListTile(
-              leading: Icon(Icons.edit,
-                  color: Theme.of(context).colorScheme.secondary),
+              leading: Icon(
+                Icons.edit,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
               title: Text(AppLocalizations.of(context)!.presetsRename),
               onTap: () {
                 Navigator.pop(context);
@@ -2208,10 +2323,14 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
               },
             ),
             ListTile(
-              leading: Icon(Icons.delete,
-                  color: Theme.of(context).colorScheme.error),
-              title: Text(AppLocalizations.of(context)!.presetsDelete,
-                  style: TextStyle(color: Theme.of(context).colorScheme.error)),
+              leading: Icon(
+                Icons.delete,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: Text(
+                AppLocalizations.of(context)!.presetsDelete,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
               onTap: () {
                 Navigator.pop(context);
                 _showDeletePresetDialog(preset);
@@ -2251,27 +2370,36 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 return;
               }
 
-              if (await FilterPresetService.instance
-                      .presetNameExists(newName, excludeId: preset.id) &&
+              if (await FilterPresetService.instance.presetNameExists(
+                    newName,
+                    excludeId: preset.id,
+                  ) &&
                   context.mounted) {
-                _showInlineError(AppLocalizations.of(context)!.presetsNameExists);
+                _showInlineError(
+                  AppLocalizations.of(context)!.presetsNameExists,
+                );
                 return;
               }
 
               final updatedPreset = preset.copyWith(name: newName);
-              final success = await FilterPresetService.instance
-                  .updatePreset(updatedPreset);
+              final success = await FilterPresetService.instance.updatePreset(
+                updatedPreset,
+              );
 
               if (context.mounted) {
                 Navigator.pop(context);
               }
 
               if (success && context.mounted) {
-                _showInlineSuccess(AppLocalizations.of(context)!.presetsRenameSuccess(newName));
+                _showInlineSuccess(
+                  AppLocalizations.of(context)!.presetsRenameSuccess(newName),
+                );
                 await _loadSavedPresets();
               } else {
                 if (context.mounted) {
-                  _showInlineError(AppLocalizations.of(context)!.presetsRenameError);
+                  _showInlineError(
+                    AppLocalizations.of(context)!.presetsRenameError,
+                  );
                 }
               }
             },
@@ -2289,7 +2417,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       builder: (context) => AlertDialog(
         title: Text(AppLocalizations.of(context)!.presetsDeleteTitle),
         content: Text(
-            AppLocalizations.of(context)!.presetsDeleteConfirm(preset.name)),
+          AppLocalizations.of(context)!.presetsDeleteConfirm(preset.name),
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
@@ -2297,19 +2426,26 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           ),
           ElevatedButton(
             onPressed: () async {
-              final success =
-                  await FilterPresetService.instance.deletePreset(preset.id);
+              final success = await FilterPresetService.instance.deletePreset(
+                preset.id,
+              );
 
               if (context.mounted) {
                 Navigator.pop(context);
               }
 
               if (success && context.mounted) {
-                _showInlineSuccess(AppLocalizations.of(context)!.presetsDeleteSuccess(preset.name));
+                _showInlineSuccess(
+                  AppLocalizations.of(
+                    context,
+                  )!.presetsDeleteSuccess(preset.name),
+                );
                 await _loadSavedPresets();
               } else {
                 if (context.mounted) {
-                  _showInlineError(AppLocalizations.of(context)!.presetsDeleteError);
+                  _showInlineError(
+                    AppLocalizations.of(context)!.presetsDeleteError,
+                  );
                 }
               }
             },
@@ -2348,7 +2484,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             'all': true,
             'random': false,
             'cwl': false,
-            'friendly': false
+            'friendly': false,
           };
           break;
         case 'stars':
@@ -2356,7 +2492,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           break;
         case 'destruction':
           _updateFilter(
-              _filter.copyWith(minDestruction: null, maxDestruction: null));
+            _filter.copyWith(minDestruction: null, maxDestruction: null),
+          );
           break;
         case 'fresh':
           _updateFilter(_filter.copyWith(freshAttacksOnly: null));
@@ -2372,10 +2509,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
     setState(() {
       switch (preset) {
         case 'last30days':
-          _updateFilter(_filter.copyWith(
-            startDate: DateTime.now().subtract(const Duration(days: 30)),
-            endDate: DateTime.now(),
-          ));
+          _updateFilter(
+            _filter.copyWith(
+              startDate: DateTime.now().subtract(const Duration(days: 30)),
+              endDate: DateTime.now(),
+            ),
+          );
           break;
         case '3star':
           starSelection = {0: false, 1: false, 2: false, 3: true};
@@ -2385,7 +2524,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             'all': false,
             'random': false,
             'cwl': true,
-            'friendly': false
+            'friendly': false,
           };
           break;
         case 'random':
@@ -2393,7 +2532,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             'all': false,
             'random': true,
             'cwl': false,
-            'friendly': false
+            'friendly': false,
           };
           break;
         case 'friendly':
@@ -2401,7 +2540,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             'all': false,
             'random': false,
             'cwl': false,
-            'friendly': true
+            'friendly': true,
           };
           break;
         case 'fresh':
@@ -2415,9 +2554,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
     setState(() {
       switch (preset) {
         case 'last30days':
-          _updateFilter(_filter.copyWith(
+          _updateFilter(
+            _filter.copyWith(
               startDate: DateTime.now().subtract(const Duration(days: 180)),
-              endDate: DateTime.now()));
+              endDate: DateTime.now(),
+            ),
+          );
           break;
         case '3star':
           starSelection = {0: false, 1: false, 2: false, 3: false};
@@ -2429,7 +2571,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
             'all': true,
             'random': false,
             'cwl': false,
-            'friendly': false
+            'friendly': false,
           };
           break;
         case 'fresh':
@@ -2463,8 +2605,11 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                 padding: const EdgeInsets.all(16),
                 child: Row(
                   children: [
-                    Icon(icon,
-                        size: 20, color: Theme.of(context).colorScheme.primary),
+                    Icon(
+                      icon,
+                      size: 20,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Column(
@@ -2472,27 +2617,23 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                         children: [
                           Text(
                             title,
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleSmall
-                                ?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                ),
+                            style: Theme.of(context).textTheme.titleSmall
+                                ?.copyWith(fontWeight: FontWeight.bold),
                           ),
                           if (!isExpanded) ...[
                             const SizedBox(height: 4),
                             Builder(
                               builder: (context) {
-                                final sectionFilters =
-                                    _getSectionActiveFilters(title);
+                                final sectionFilters = _getSectionActiveFilters(
+                                  title,
+                                );
                                 if (sectionFilters.isEmpty) {
                                   return Text(
-                                    AppLocalizations.of(context)
-                                            ?.filtersNoFiltersActive ??
+                                    AppLocalizations.of(
+                                          context,
+                                        )?.filtersNoFiltersActive ??
                                         'No filters active',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodySmall
+                                    style: Theme.of(context).textTheme.bodySmall
                                         ?.copyWith(
                                           color: Theme.of(context)
                                               .colorScheme
@@ -2507,13 +2648,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
                                     children: sectionFilters.map((filter) {
                                       return Container(
                                         padding: const EdgeInsets.symmetric(
-                                            horizontal: 6, vertical: 2),
+                                          horizontal: 6,
+                                          vertical: 2,
+                                        ),
                                         decoration: BoxDecoration(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .secondaryContainer,
-                                          borderRadius:
-                                              BorderRadius.circular(12),
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.secondaryContainer,
+                                          borderRadius: BorderRadius.circular(
+                                            12,
+                                          ),
                                         ),
                                         child: Row(
                                           mainAxisSize: MainAxisSize.min,
@@ -2588,11 +2732,8 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
       child: Text(
         title,
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.8),
-            ),
+          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.8),
+        ),
       ),
     );
   }
@@ -2632,14 +2773,14 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'startDate',
           'text':
-              '${AppLocalizations.of(context)?.filtersStartDate ?? 'From'} $start'
+              '${AppLocalizations.of(context)?.filtersStartDate ?? 'From'} $start',
         });
       } else if (_filter.endDate != null) {
         final end = _formatDate(_filter.endDate!);
         filters.add({
           'type': 'endDate',
           'text':
-              '${AppLocalizations.of(context)?.filtersEndDate ?? 'Until'} $end'
+              '${AppLocalizations.of(context)?.filtersEndDate ?? 'Until'} $end',
         });
       }
     } else if (sectionTitle == warSettings) {
@@ -2653,7 +2794,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           filters.add({
             'type': 'warType',
             'text':
-                '$selectedTypes ${AppLocalizations.of(context)?.filtersWarType ?? 'wars'}'
+                '$selectedTypes ${AppLocalizations.of(context)?.filtersWarType ?? 'wars'}',
           });
         }
       }
@@ -2665,7 +2806,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'attackerTH',
           'text':
-              '${AppLocalizations.of(context)?.filtersAttackerTh ?? 'Attacker TH'}$selectedTH'
+              '${AppLocalizations.of(context)?.filtersAttackerTh ?? 'Attacker TH'}$selectedTH',
         });
       }
       if (defenderThSelection.values.any((selected) => selected)) {
@@ -2676,14 +2817,15 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'defenderTH',
           'text':
-              '${AppLocalizations.of(context)?.filtersDefenderTh ?? 'Defender TH'}$selectedTH'
+              '${AppLocalizations.of(context)?.filtersDefenderTh ?? 'Defender TH'}$selectedTH',
         });
       }
       if (_filter.sameTownHall == true) {
         filters.add({
           'type': 'sameTH',
-          'text': AppLocalizations.of(context)?.filtersSameTownHallOnly ??
-              'Same TH only'
+          'text':
+              AppLocalizations.of(context)?.filtersSameTownHallOnly ??
+              'Same TH only',
         });
       }
     } else if (sectionTitle == performance) {
@@ -2695,7 +2837,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'stars',
           'text':
-              '$selectedStars ${AppLocalizations.of(context)?.warStarsTitle ?? '⭐'}'
+              '$selectedStars ${AppLocalizations.of(context)?.warStarsTitle ?? '⭐'}',
         });
       }
       if ((_filter.minDestruction != null && _filter.minDestruction! > 0) ||
@@ -2705,15 +2847,16 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'destruction',
           'text':
-              '${min.toInt()}-${max.toInt()}% ${AppLocalizations.of(context)?.filtersDestructionPercentage ?? 'destruction'}'
+              '${min.toInt()}-${max.toInt()}% ${AppLocalizations.of(context)?.filtersDestructionPercentage ?? 'destruction'}',
         });
       }
     } else if (sectionTitle == advanced) {
       if (_filter.freshAttacksOnly == true) {
         filters.add({
           'type': 'fresh',
-          'text': AppLocalizations.of(context)?.filtersFreshAttacksOnly ??
-              'Fresh attacks only'
+          'text':
+              AppLocalizations.of(context)?.filtersFreshAttacksOnly ??
+              'Fresh attacks only',
         });
       }
       if (_minMapPositionController.text.isNotEmpty ||
@@ -2727,7 +2870,7 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
         filters.add({
           'type': 'mapPosition',
           'text':
-              '${AppLocalizations.of(context)?.warPositionMap ?? 'Position'} $min-$max'
+              '${AppLocalizations.of(context)?.warPositionMap ?? 'Position'} $min-$max',
         });
       }
     }
@@ -2931,10 +3074,7 @@ class StarFilterChip extends StatelessWidget {
       },
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        constraints: const BoxConstraints(
-          minWidth: 48,
-          minHeight: 48,
-        ),
+        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
         decoration: BoxDecoration(
           color: isSelected
               ? Theme.of(context).colorScheme.secondaryContainer
@@ -2971,9 +3111,7 @@ class StarFilterChip extends StatelessWidget {
 class _SavePresetDialog extends StatefulWidget {
   final WarStatsFilter filter;
 
-  const _SavePresetDialog({
-    required this.filter,
-  });
+  const _SavePresetDialog({required this.filter});
 
   @override
   State<_SavePresetDialog> createState() => _SavePresetDialogState();
@@ -3003,14 +3141,14 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
 
   Future<void> _savePreset() async {
     final name = _nameController.text.trim();
-    
+
     _clearError();
-    
+
     if (name.isEmpty) {
       _showError(AppLocalizations.of(context)!.presetsNameRequired);
       return;
     }
-    
+
     if (await FilterPresetService.instance.presetNameExists(name) && mounted) {
       if (!context.mounted) return;
       _showError(AppLocalizations.of(context)!.presetsNameExists);
@@ -3021,7 +3159,7 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
       name: name,
       filter: widget.filter,
     );
-    
+
     if (success && mounted) {
       Navigator.pop(context, name); // Return the preset name
     } else {
@@ -3032,7 +3170,9 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final suggestions = FilterPresetService.getPresetNameSuggestions(widget.filter);
+    final suggestions = FilterPresetService.getPresetNameSuggestions(
+      widget.filter,
+    );
 
     return AlertDialog(
       title: Text(AppLocalizations.of(context)!.presetsSaveTitle),
@@ -3067,10 +3207,9 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
                 alignment: Alignment.centerLeft,
                 child: Text(
                   AppLocalizations.of(context)!.presetsSuggestions,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
                 ),
               ),
               const SizedBox(height: 8),
@@ -3085,18 +3224,19 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
                           suggestion,
                           style: Theme.of(context).textTheme.bodySmall,
                         ),
-                        backgroundColor:
-                            Theme.of(context).colorScheme.secondaryContainer,
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.secondaryContainer,
                         side: BorderSide(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .outline
-                              .withValues(alpha: 0.2),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.outline.withValues(alpha: 0.2),
                         ),
-                        labelStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onSecondaryContainer,
+                        labelStyle: Theme.of(context).textTheme.bodySmall
+                            ?.copyWith(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSecondaryContainer,
                             ),
                         onPressed: () {
                           _nameController.text = suggestion;
@@ -3128,9 +3268,7 @@ class _SavePresetDialogState extends State<_SavePresetDialog> {
 class _RenamePresetDialog extends StatefulWidget {
   final FilterPreset preset;
 
-  const _RenamePresetDialog({
-    required this.preset,
-  });
+  const _RenamePresetDialog({required this.preset});
 
   @override
   State<_RenamePresetDialog> createState() => _RenamePresetDialogState();
@@ -3183,14 +3321,19 @@ class _RenamePresetDialogState extends State<_RenamePresetDialog> {
       return;
     }
 
-    if (await FilterPresetService.instance.presetNameExists(newName, excludeId: widget.preset.id) &&
+    if (await FilterPresetService.instance.presetNameExists(
+          newName,
+          excludeId: widget.preset.id,
+        ) &&
         mounted) {
       _showInlineError(AppLocalizations.of(context)!.presetsNameExists);
       return;
     }
 
     final updatedPreset = widget.preset.copyWith(name: newName);
-    final success = await FilterPresetService.instance.updatePreset(updatedPreset);
+    final success = await FilterPresetService.instance.updatePreset(
+      updatedPreset,
+    );
 
     if (mounted) {
       if (success) {
@@ -3209,28 +3352,37 @@ class _RenamePresetDialogState extends State<_RenamePresetDialog> {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Inline message display
-          if (_inlineMessage != null) 
+          if (_inlineMessage != null)
             Container(
               width: double.infinity,
               margin: const EdgeInsets.only(bottom: 16),
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: _isInlineError 
-                    ? Theme.of(context).colorScheme.errorContainer.withValues(alpha: 0.8)
-                    : Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.8),
+                color: _isInlineError
+                    ? Theme.of(
+                        context,
+                      ).colorScheme.errorContainer.withValues(alpha: 0.8)
+                    : Theme.of(context).colorScheme.surfaceContainerHighest
+                          .withValues(alpha: 0.8),
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
-                  color: _isInlineError 
-                      ? Theme.of(context).colorScheme.error.withValues(alpha: 0.5)
-                      : Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                  color: _isInlineError
+                      ? Theme.of(
+                          context,
+                        ).colorScheme.error.withValues(alpha: 0.5)
+                      : Theme.of(
+                          context,
+                        ).colorScheme.primary.withValues(alpha: 0.5),
                   width: 1,
                 ),
               ),
               child: Row(
                 children: [
                   Icon(
-                    _isInlineError ? Icons.error_outline : Icons.check_circle_outline,
-                    color: _isInlineError 
+                    _isInlineError
+                        ? Icons.error_outline
+                        : Icons.check_circle_outline,
+                    color: _isInlineError
                         ? Theme.of(context).colorScheme.error
                         : Theme.of(context).colorScheme.primary,
                     size: 20,
@@ -3240,7 +3392,7 @@ class _RenamePresetDialogState extends State<_RenamePresetDialog> {
                     child: Text(
                       _inlineMessage!,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: _isInlineError 
+                        color: _isInlineError
                             ? Theme.of(context).colorScheme.onErrorContainer
                             : Theme.of(context).colorScheme.onSurface,
                         fontWeight: FontWeight.w500,
@@ -3251,7 +3403,7 @@ class _RenamePresetDialogState extends State<_RenamePresetDialog> {
                     onPressed: _clearInlineMessage,
                     icon: Icon(
                       Icons.close,
-                      color: _isInlineError 
+                      color: _isInlineError
                           ? Theme.of(context).colorScheme.error
                           : Theme.of(context).colorScheme.primary,
                       size: 18,

--- a/lib/features/player/presentation/war_stats/widgets/enhanced_stat_card.dart
+++ b/lib/features/player/presentation/war_stats/widgets/enhanced_stat_card.dart
@@ -186,7 +186,7 @@ class EnhancedStatCard extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  MobileWebImage(
+                  const MobileWebImage(
                       imageUrl: ImageAssets.brokenSword, width: 16, height: 16),
                   const SizedBox(width: 4),
                   Text(

--- a/lib/features/player/presentation/war_stats/widgets/th_heatmap_chart.dart
+++ b/lib/features/player/presentation/war_stats/widgets/th_heatmap_chart.dart
@@ -58,9 +58,9 @@ class THHeatmapChart extends StatelessWidget {
               // Header row
               Container(
                 padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
+                decoration: const BoxDecoration(
                   color: Colors.transparent,
-                  borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(8)),
                 ),
                 child: Row(
                   children: [

--- a/lib/features/player/services/performance_analysis_service.dart
+++ b/lib/features/player/services/performance_analysis_service.dart
@@ -26,7 +26,7 @@ class PerformanceAnalysisService {
         'failed-attacks',
         localizations?.performanceAnalysisFailedAttacks ?? 'Failed Attacks (0-1 Stars)',
         localizations?.performanceAnalysisFailedAttacksDesc ?? 'Shows attacks that failed to get 2+ stars',
-        WarStatsFilter(
+        const WarStatsFilter(
           allowedStars: [0, 1],
         ),
       ));
@@ -40,7 +40,7 @@ class PerformanceAnalysisService {
         'missed-perfects',
         localizations?.performanceAnalysisMissedPerfects ?? 'Missed Perfect Attacks',
         localizations?.performanceAnalysisMissedPerfectsDesc ?? 'Shows attacks that got 2 stars - potential perfect opportunities',
-        WarStatsFilter(
+        const WarStatsFilter(
           allowedStars: [2],
         ),
       ));
@@ -106,7 +106,7 @@ class PerformanceAnalysisService {
           'cwl-issues',
           localizations?.performanceAnalysisCwlIssues ?? 'CWL Performance Issues',
           localizations?.performanceAnalysisCwlIssuesDesc ?? 'Shows CWL attacks - lower success than regular wars',
-          WarStatsFilter(
+          const WarStatsFilter(
             warTypes: ['cwl'],
           ),
         ));
@@ -118,7 +118,7 @@ class PerformanceAnalysisService {
           'random-war-issues',
           localizations?.performanceAnalysisRandomWarIssues ?? 'Random War Issues',
           localizations?.performanceAnalysisRandomWarIssuesDesc ?? 'Shows random war attacks - lower success than CWL',
-          WarStatsFilter(
+          const WarStatsFilter(
             warTypes: ['random'],
           ),
         ));
@@ -130,7 +130,7 @@ class PerformanceAnalysisService {
       'fresh-only',
       localizations?.performanceAnalysisFreshOnly ?? 'Fresh Attack Analysis',
       localizations?.performanceAnalysisFreshOnlyDesc ?? 'Analyzes performance on fresh bases only',
-      WarStatsFilter(
+      const WarStatsFilter(
         freshAttacksOnly: true,
       ),
     ));
@@ -151,7 +151,7 @@ class PerformanceAnalysisService {
       'high-stakes',
       localizations?.performanceAnalysisHighStakes ?? 'High-Stakes Attacks',
       localizations?.performanceAnalysisHighStakesDesc ?? 'Shows attacks from top 5 war positions',
-      WarStatsFilter(
+      const WarStatsFilter(
         maxMapPosition: 5,
       ),
     ));
@@ -161,7 +161,7 @@ class PerformanceAnalysisService {
       'cleanup-crew',
       localizations?.performanceAnalysisCleanupCrew ?? 'Cleanup Attacks',
       localizations?.performanceAnalysisCleanupCrewDesc ?? 'Shows attacks from lower war positions',
-      WarStatsFilter(
+      const WarStatsFilter(
         minMapPosition: 6,
       ),
     ));

--- a/lib/features/player/services/player_war_export_service.dart
+++ b/lib/features/player/services/player_war_export_service.dart
@@ -15,7 +15,7 @@ class PlayerWarExportService {
     String? playerName,
   }) async {
     // Build API URL for new export endpoint
-    final baseUrl = ApiService.apiUrlV2;
+    const baseUrl = ApiService.apiUrlV2;
     final uri = Uri.parse('$baseUrl/exports/war/player-stats');
     
     // Build request body as PlayerWarhitsFilter

--- a/lib/features/settings/presentation/faq_page.dart
+++ b/lib/features/settings/presentation/faq_page.dart
@@ -9,6 +9,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class FaqScreen extends StatefulWidget {
+  const FaqScreen({super.key});
+
   @override
   State<FaqScreen> createState() => _FaqScreenState();
 }
@@ -23,7 +25,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     _animationController = AnimationController(
-      duration: Duration(milliseconds: 300),
+      duration: const Duration(milliseconds: 300),
       vsync: this,
     );
     _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
@@ -41,7 +43,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
           children: [
             // Search bar
             Container(
-              padding: EdgeInsets.all(16),
+              padding: const EdgeInsets.all(16),
               child: Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surfaceContainer,
@@ -81,7 +83,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                           )
                         : null,
                     border: InputBorder.none,
-                    contentPadding: EdgeInsets.symmetric(
+                    contentPadding: const EdgeInsets.symmetric(
                       horizontal: 16,
                       vertical: 16,
                     ),
@@ -99,7 +101,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
               child: FadeTransition(
                 opacity: _fadeAnimation,
                 child: ListView(
-                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
                   children: _buildFilteredFAQItems(),
                 ),
               ),
@@ -121,7 +123,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.info,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -129,7 +131,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqWhatIsClashKingProjectAnswer,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   children: [
                     _buildActionButton(
@@ -153,7 +155,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.phone_android,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -161,7 +163,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqFeaturesGuideDescription,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 _buildFeatureItem(
                   context: context,
                   icon: Icons.person,
@@ -202,9 +204,9 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                     context,
                   )!.faqFeaturesCwlDescription,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Container(
-                  padding: EdgeInsets.all(12),
+                  padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: Theme.of(
                       context,
@@ -224,7 +226,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                         color: Theme.of(context).colorScheme.primary,
                         size: 20,
                       ),
-                      SizedBox(width: 8),
+                      const SizedBox(width: 8),
                       Expanded(
                         child: Text(
                           AppLocalizations.of(context)!.faqAppDevelopmentNotice,
@@ -248,7 +250,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.smart_toy,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -256,7 +258,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqWhatCanBotDoAnswer,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 _buildFeatureItem(
                   context: context,
                   icon: Icons.track_changes,
@@ -291,14 +293,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                     context,
                   )!.faqBotFeatureCommandsDesc,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   children: [
                     _buildActionButton(
                       context: context,
                       label: AppLocalizations.of(context)!.faqInviteBotToServer,
                       icon: LucideIcons.bot,
-                      color: Color(0xFF5865F2),
+                      color: const Color(0xFF5865F2),
                       onPressed: () async {
                         launchUrl(
                           Uri.parse(
@@ -320,7 +322,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.info,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -328,14 +330,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqFanContentPolicy,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   children: [
                     _buildActionButton(
                       context: context,
                       label: "Supercell Fan Content Policy",
                       icon: Icons.policy,
-                      color: Color(0xFF4CAF50),
+                      color: const Color(0xFF4CAF50),
                       onPressed: () async {
                         launchUrl(
                           Uri.parse(
@@ -361,7 +363,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.favorite,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -369,14 +371,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqSupportWorkAnswer,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Text(
                   AppLocalizations.of(context)!.faqWaysToSupport,
                   style: Theme.of(
                     context,
                   ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 12),
+                const SizedBox(height: 12),
                 Column(
                   children: [
                     Row(
@@ -425,14 +427,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Row(
                       children: [
                         _buildActionButton(
                           context: context,
                           label: AppLocalizations.of(context)!.faqJoinDiscord,
                           icon: Icons.discord,
-                          color: Color(0xFF5865F2),
+                          color: const Color(0xFF5865F2),
                           onPressed: () async {
                             launchUrl(
                               Uri.parse('https://discord.gg/clashking'),
@@ -472,7 +474,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.help,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -480,7 +482,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqNeedHelpAnswer,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   children: [
                     _buildActionButton(
@@ -545,7 +547,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                       context: context,
                       label: AppLocalizations.of(context)!.faqJoinDiscord,
                       icon: Icons.discord,
-                      color: Color(0xFF5865F2),
+                      color: const Color(0xFF5865F2),
                       onPressed: () async {
                         launchUrl(Uri.parse('https://discord.gg/clashking'));
                       },
@@ -565,43 +567,43 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.warning,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: RichText(
               text: TextSpan(
                 style: Theme.of(context).textTheme.bodyMedium,
                 children: <TextSpan>[
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqClanNotTracked,
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       decoration: TextDecoration.underline,
                     ),
                   ),
-                  TextSpan(text: '\n'),
+                  const TextSpan(text: '\n'),
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqClanNotTrackedAnswer,
                   ),
-                  TextSpan(text: '\n\n'),
+                  const TextSpan(text: '\n\n'),
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqTrackingDown,
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       decoration: TextDecoration.underline,
                     ),
                   ),
-                  TextSpan(text: '\n'),
+                  const TextSpan(text: '\n'),
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqTrackingDownAnswer,
                   ),
-                  TextSpan(text: '\n\n'),
+                  const TextSpan(text: '\n\n'),
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqApiLimitation,
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       decoration: TextDecoration.underline,
                     ),
                   ),
-                  TextSpan(text: '\n'),
+                  const TextSpan(text: '\n'),
                   TextSpan(
                     text: AppLocalizations.of(context)!.faqApiLimitationAnswer,
                   ),
@@ -616,7 +618,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.translate,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -624,7 +626,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   AppLocalizations.of(context)!.faqTranslationIssueAnswer,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Row(
                   children: [
                     _buildActionButton(
@@ -633,7 +635,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                         context,
                       )!.translationHelpUsTranslate,
                       icon: Icons.language,
-                      color: Color(0xFF2196F3),
+                      color: const Color(0xFF2196F3),
                       onPressed: () async {
                         launchUrl(
                           Uri.parse('https://crowdin.com/project/clashkingapp'),
@@ -652,7 +654,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.cloud_off,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -662,14 +664,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   )!.faqTroubleshootingDataDescription,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Text(
                   AppLocalizations.of(context)!.faqTroubleshootingSolutions,
                   style: Theme.of(
                     context,
                   ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 8),
+                const SizedBox(height: 8),
                 ...AppLocalizations.of(
                       context,
                     )!.faqTroubleshootingDataSolution1.isNotEmpty
@@ -714,7 +716,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.bug_report,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -724,14 +726,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   )!.faqTroubleshootingCrashDescription,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Text(
                   AppLocalizations.of(context)!.faqTroubleshootingSolutions,
                   style: Theme.of(
                     context,
                   ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 8),
+                const SizedBox(height: 8),
                 ...AppLocalizations.of(
                       context,
                     )!.faqTroubleshootingCrashSolution1.isNotEmpty
@@ -794,7 +796,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         icon: Icons.account_circle,
         content: [
           Padding(
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -804,14 +806,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   )!.faqTroubleshootingAccountDescription,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
-                SizedBox(height: 16),
+                const SizedBox(height: 16),
                 Text(
                   AppLocalizations.of(context)!.faqTroubleshootingSolutions,
                   style: Theme.of(
                     context,
                   ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                 ),
-                SizedBox(height: 8),
+                const SizedBox(height: 8),
                 ...AppLocalizations.of(
                       context,
                     )!.faqTroubleshootingAccountSolution1.isNotEmpty
@@ -859,7 +861,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
 
   Widget _buildSectionHeader(String title) {
     return Container(
-      margin: EdgeInsets.only(top: 24, bottom: 16),
+      margin: const EdgeInsets.only(top: 24, bottom: 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -871,7 +873,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
               color: Theme.of(context).colorScheme.primary,
             ),
           ),
-          SizedBox(height: 8),
+          const SizedBox(height: 8),
           Container(
             height: 3,
             width: 50,
@@ -897,11 +899,11 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
   }) {
     if (_searchQuery.isNotEmpty &&
         !question.toLowerCase().contains(_searchQuery)) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     return Container(
-      margin: EdgeInsets.only(bottom: 16),
+      margin: const EdgeInsets.only(bottom: 16),
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [
@@ -920,14 +922,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
           BoxShadow(
             color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.08),
             blurRadius: 12,
-            offset: Offset(0, 4),
+            offset: const Offset(0, 4),
           ),
           BoxShadow(
             color: Theme.of(
               context,
             ).colorScheme.primary.withValues(alpha: 0.02),
             blurRadius: 6,
-            offset: Offset(0, 2),
+            offset: const Offset(0, 2),
           ),
         ],
       ),
@@ -938,7 +940,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
           collapsedIconColor: Theme.of(
             context,
           ).colorScheme.primary.withValues(alpha: 0.7),
-          tilePadding: EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
           childrenPadding: EdgeInsets.zero,
           title: Row(
             children: [
@@ -948,7 +950,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                   size: 20,
                   color: Theme.of(context).colorScheme.primary,
                 ),
-                SizedBox(width: 8),
+                const SizedBox(width: 8),
               ],
               Expanded(
                 child: Text(
@@ -979,8 +981,8 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
       child: GestureDetector(
         onTap: onPressed,
         child: Container(
-          margin: EdgeInsets.all(4),
-          padding: EdgeInsets.all(16),
+          margin: const EdgeInsets.all(4),
+          padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
             gradient: LinearGradient(
               colors: [
@@ -998,14 +1000,14 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
               BoxShadow(
                 color: color.withValues(alpha: 0.1),
                 blurRadius: 8,
-                offset: Offset(0, 3),
+                offset: const Offset(0, 3),
               ),
               BoxShadow(
                 color: Theme.of(
                   context,
                 ).colorScheme.shadow.withValues(alpha: 0.05),
                 blurRadius: 4,
-                offset: Offset(0, 2),
+                offset: const Offset(0, 2),
               ),
             ],
           ),
@@ -1013,7 +1015,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(icon, size: 32, color: color),
-              SizedBox(height: 8),
+              const SizedBox(height: 8),
               Text(
                 label,
                 textAlign: TextAlign.center,
@@ -1037,8 +1039,8 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
     required String description,
   }) {
     return Container(
-      margin: EdgeInsets.only(bottom: 12),
-      padding: EdgeInsets.all(16),
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainer,
         borderRadius: BorderRadius.circular(12),
@@ -1051,7 +1053,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            padding: EdgeInsets.all(12),
+            padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 colors: [
@@ -1075,7 +1077,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
               size: 24,
             ),
           ),
-          SizedBox(width: 16),
+          const SizedBox(width: 16),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -1087,7 +1089,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
                     color: Theme.of(context).colorScheme.onSurface,
                   ),
                 ),
-                SizedBox(height: 4),
+                const SizedBox(height: 4),
                 Text(
                   description,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -1104,12 +1106,12 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
 
   Widget _buildSolutionItem(String solution) {
     return Padding(
-      padding: EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(bottom: 8),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            margin: EdgeInsets.only(top: 6),
+            margin: const EdgeInsets.only(top: 6),
             width: 6,
             height: 6,
             decoration: BoxDecoration(
@@ -1117,7 +1119,7 @@ class _FaqScreenState extends State<FaqScreen> with TickerProviderStateMixin {
               shape: BoxShape.circle,
             ),
           ),
-          SizedBox(width: 12),
+          const SizedBox(width: 12),
           Expanded(
             child: Text(
               solution,

--- a/lib/features/settings/presentation/features_vote.dart
+++ b/lib/features/settings/presentation/features_vote.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -6,21 +5,24 @@ import 'package:webview_flutter/webview_flutter.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class FeatureRequests extends StatelessWidget {
-  const FeatureRequests({
-    super.key,
-  });
+  const FeatureRequests({super.key});
 
   @override
   Widget build(BuildContext context) {
-    const url = 'https://clashkingapp.features.vote/board?api_key=ec52d587-cb17-4e63-898c-351f592f6454&is_embed=true&user_id=<Optional>&user_email=<Optional>&user_name=<Optional>&img_url=<Optional>&user_spend=<Optional>';
+    const url =
+        'https://clashkingapp.features.vote/board?api_key=ec52d587-cb17-4e63-898c-351f592f6454&is_embed=true&user_id=<Optional>&user_email=<Optional>&user_name=<Optional>&img_url=<Optional>&user_spend=<Optional>';
 
     if (kIsWeb) {
       return Scaffold(
-        appBar: AppBar(title: Text(AppLocalizations.of(context)!.translationSuggestFeatures)),
+        appBar: AppBar(
+          title: Text(AppLocalizations.of(context)!.translationSuggestFeatures),
+        ),
         body: Center(
           child: ElevatedButton(
             onPressed: () => launchUrl(Uri.parse(url)),
-            child: Text(AppLocalizations.of(context)!.featureRequestsOpenButton),
+            child: Text(
+              AppLocalizations.of(context)!.featureRequestsOpenButton,
+            ),
           ),
         ),
       );
@@ -31,12 +33,17 @@ class FeatureRequests extends StatelessWidget {
       ..setBackgroundColor(const Color(0x00000000))
       ..setNavigationDelegate(
         NavigationDelegate(
+          onNavigationRequest: (NavigationRequest request) {
+            final uri = Uri.tryParse(request.url);
+            final host = uri?.host.toLowerCase();
+            if (host == 'features.vote' ||
+                (host != null && host.endsWith('.features.vote'))) {
+              return NavigationDecision.navigate;
+            }
+            return NavigationDecision.prevent;
+          },
           onProgress: (int progress) {
-            Center(
-              child: CircularProgressIndicator(
-                value: progress / 100,
-              )
-            );
+            Center(child: CircularProgressIndicator(value: progress / 100));
           },
           onPageStarted: (String url) {},
           onPageFinished: (String url) {},
@@ -46,9 +53,10 @@ class FeatureRequests extends StatelessWidget {
       ..loadRequest(Uri.parse(url));
 
     return Scaffold(
-      appBar: AppBar(title: Text(AppLocalizations.of(context)!.translationSuggestFeatures)),
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.translationSuggestFeatures),
+      ),
       body: WebViewWidget(controller: controller),
     );
   }
 }
-

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -25,7 +25,7 @@ import 'package:clashkingapp/core/utils/debug_utils.dart';
 class SettingsInfoScreen extends StatefulWidget {
   final User user;
 
-  SettingsInfoScreen({required this.user});
+  const SettingsInfoScreen({super.key, required this.user});
 
   @override
   State<SettingsInfoScreen> createState() => _SettingsInfoScreenState();
@@ -38,7 +38,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.generalSettings),
-        actions: [],
+        actions: const [],
       ),
       body: ResponsiveLayoutWrapper(
         child: ListView(
@@ -52,7 +52,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
               await _showLanguageSelection(context);
             },
           ),
-          Divider(),
+          const Divider(),
           Consumer<ThemeNotifier>(
             builder: (context, themeNotifier, child) {
               return _buildListTile(
@@ -65,7 +65,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.faqTitle,
@@ -74,22 +74,22 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
             onTap: () async {
               // Open FAQ page
               Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => FaqScreen()),
+                MaterialPageRoute(builder: (context) => const FaqScreen()),
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.translationHelpUsTranslate,
             leadingIcon: Icons.language,
             onTap: () async {
               Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => TranslationScreen()),
+                MaterialPageRoute(builder: (context) => const TranslationScreen()),
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.translationSuggestFeatures,
@@ -97,11 +97,11 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
             onTap: () async {
               // Open Features vote
               Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => FeatureRequests()),
+                MaterialPageRoute(builder: (context) => const FeatureRequests()),
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.faqJoinDiscord,
@@ -110,7 +110,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
               launchUrl(Uri.parse('https://discord.gg/clashking'));
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.settingsLicenses,
@@ -128,14 +128,14 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
                     imageUrl: Theme.of(context).brightness == Brightness.dark
                         ? "https://assets.clashk.ing/logos/crown-arrow-dark-bg/ClashKing-1.png"
                         : "https://assets.clashk.ing/logos/crown-arrow-white-bg/ClashKing-2.png",
-                    errorWidget: (context, url, error) => Icon(Icons.apps),
+                    errorWidget: (context, url, error) => const Icon(Icons.apps),
                   ),
                 ),
                 applicationLegalese: '© ${DateTime.now().year} ClashKing',
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.settingsPrivacyPolicy,
@@ -149,7 +149,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildListTile(
             context,
             title: AppLocalizations.of(context)!.authLogout,
@@ -165,7 +165,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
               );
             },
           ),
-          Divider(),
+          const Divider(),
           _buildVersionInfoTile(context),
         ],
       ),
@@ -210,8 +210,8 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
                       width: 32,
                       height: 32,
                       placeholder: (context, url) =>
-                          CircularProgressIndicator(),
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                          const CircularProgressIndicator(),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                     ),
                     title: Text(locale.languageName),
                     onTap: () {
@@ -255,7 +255,7 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
 
       // Navigate to login page
       globalNavigatorKey.currentState?.pushReplacement(
-        MaterialPageRoute(builder: (context) => LoginPage()),
+        MaterialPageRoute(builder: (context) => const LoginPage()),
       );
       DebugUtils.debugSuccess("SettingsInfoScreen: All service data cleared successfully.");
     } else {

--- a/lib/features/settings/presentation/translation_page.dart
+++ b/lib/features/settings/presentation/translation_page.dart
@@ -5,6 +5,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
 class TranslationScreen extends StatelessWidget {
+  const TranslationScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -24,17 +26,17 @@ class TranslationScreen extends StatelessWidget {
                     color: Theme.of(context).colorScheme.primary,
                     fontWeight: FontWeight.bold),
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Text(
                 AppLocalizations.of(context)!.translationThankYouContent,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Center(
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(16.0),
                   child: CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl:
                         "https://www.icegif.com/wp-content/uploads/2023/06/icegif-202.gif", // remplacez par votre URL d'image
                     height: 200,
@@ -43,7 +45,7 @@ class TranslationScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              SizedBox(height: 24),
+              const SizedBox(height: 24),
               Text(
                 AppLocalizations.of(context)!.translationHelpUsTranslate,
                 style: Theme.of(context).textTheme.bodyLarge!.copyWith(
@@ -51,11 +53,11 @@ class TranslationScreen extends StatelessWidget {
                       color: Theme.of(context).colorScheme.primary,
                     ),
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Text(
                   AppLocalizations.of(context)!.translationHelpTranslateContent,
                   style: Theme.of(context).textTheme.bodyMedium),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Center(
                 child: ElevatedButton.icon(
                   onPressed: () async {
@@ -65,7 +67,7 @@ class TranslationScreen extends StatelessWidget {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Theme.of(context).colorScheme.primary,
                   ),
-                  icon: Icon(Icons.language),
+                  icon: const Icon(Icons.language),
                   label: Text(
                     AppLocalizations.of(context)!
                         .translationHelpTranslateButton,
@@ -76,16 +78,16 @@ class TranslationScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              SizedBox(height: 8),
+              const SizedBox(height: 8),
               Center(
                 child: ElevatedButton.icon(
                   onPressed: () async {
                     await launchUrl(Uri.parse("https://discord.gg/clashking"));
                   },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Color(0xFF5865F2),
+                    backgroundColor: const Color(0xFF5865F2),
                   ),
-                  icon: Icon(Icons.discord),
+                  icon: const Icon(Icons.discord),
                   label: Text(
                     AppLocalizations.of(context)!.faqJoinDiscord,
                     style: Theme.of(context)
@@ -95,7 +97,7 @@ class TranslationScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Text(
                 AppLocalizations.of(context)!.translationCurrentTranslators,
                 style: Theme.of(context).textTheme.bodyLarge!.copyWith(
@@ -103,7 +105,7 @@ class TranslationScreen extends StatelessWidget {
                       color: Theme.of(context).colorScheme.primary,
                     ),
               ),
-              SizedBox(height: 16),
+              const SizedBox(height: 16),
               Text(
                 '''
   • AlejandroMoc

--- a/lib/features/war_cwl/presentation/cwl/cwl.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl.dart
@@ -19,7 +19,7 @@ class CwlScreen extends StatefulWidget {
   final String clanTag;
   final CwlClan clanInfo;
 
-  CwlScreen({
+  const CwlScreen({
     super.key,
     required this.warCwl,
     required this.clanTag,
@@ -49,7 +49,7 @@ class CwlScreenState extends State<CwlScreen> {
                     child: ColorFiltered(
                       colorFilter: ColorFilter.mode(
                           Colors.black.withAlpha(128), BlendMode.darken),
-                      child: MobileWebImage(
+                      child: const MobileWebImage(
                         imageUrl: ImageAssets.cwlPageBackground,
                         width: double.infinity,
                         fit: BoxFit.cover,
@@ -80,7 +80,7 @@ class CwlScreenState extends State<CwlScreen> {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      SizedBox(height: 36),
+                      const SizedBox(height: 36),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -109,7 +109,7 @@ class CwlScreenState extends State<CwlScreen> {
                           ),
                         ],
                       ),
-                      SizedBox(height: 16),
+                      const SizedBox(height: 16),
                       Wrap(
                         alignment: WrapAlignment.center,
                         spacing: 7.0,

--- a/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
@@ -58,7 +58,7 @@ class _CwlMembersTabState extends State<CwlMembersTab> {
     
     final clanDetails = widget.warCwl.leagueInfo?.getClanDetails(widget.clanTag);
     final warsPlayed = clanDetails?.warsPlayed ?? 0;
-    final attacksPerWar = 1; // Standard CWL attacks per war
+    const attacksPerWar = 1; // Standard CWL attacks per war
 
     return Column(
       children: [

--- a/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
@@ -36,12 +36,12 @@ class _CwlMembersTabState extends State<CwlMembersTab> {
   void toggleShowStats(GlobalKey<State<StatefulWidget>> key) {
     setState(() {
       showFullStats = !showFullStats;
-      Future.delayed(Duration(milliseconds: 200), () {
+      Future.delayed(const Duration(milliseconds: 200), () {
         final context = key.currentContext;
         if (context != null && context.mounted) {
           Scrollable.ensureVisible(
             context,
-            duration: Duration(milliseconds: 300),
+            duration: const Duration(milliseconds: 300),
             alignment: 0.1,
             curve: Curves.easeInOut,
           );

--- a/lib/features/war_cwl/presentation/cwl/cwl_rounds_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_rounds_tab.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 class CwlRoundsTab extends StatefulWidget {
   final WarCwl warCwl;
 
-  CwlRoundsTab({
+  const CwlRoundsTab({
     super.key,
     required this.warCwl,
   });
@@ -22,7 +22,7 @@ class CwlRoundsTabState extends State<CwlRoundsTab> {
     final currentRound = widget.warCwl.leagueInfo?.getCurrentRounds();
 
     if (rounds == null || currentRound == null) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     return Column(

--- a/lib/features/war_cwl/presentation/cwl/cwl_teams_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_teams_tab.dart
@@ -25,12 +25,12 @@ class CwlTeamsTabState extends State<CwlTeamsTab> {
   void toggleShowStats(GlobalKey<State<StatefulWidget>> key) {
     setState(() {
       showFullStats = !showFullStats;
-      Future.delayed(Duration(milliseconds: 200), () {
+      Future.delayed(const Duration(milliseconds: 200), () {
         final context = key.currentContext;
         if (context != null && context.mounted) {
           Scrollable.ensureVisible(
             context,
-            duration: Duration(milliseconds: 300),
+            duration: const Duration(milliseconds: 300),
             alignment: 0.1,
             curve: Curves.easeInOut,
           );

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
@@ -40,7 +40,7 @@ class MembersCard extends StatelessWidget {
                 offset: const Offset(2, -8),
                 child: Text(
                   "($average)",
-                  textScaler: TextScaler.linear(0.8),
+                  textScaler: const TextScaler.linear(0.8),
                   style: Theme.of(context).textTheme.labelSmall,
                 ),
               ),
@@ -228,7 +228,7 @@ class MembersCard extends StatelessWidget {
 
       case 'opponentPosition':
         return withIcon(member.avgOpponentPosition?.toStringAsFixed(1) ?? "-",
-            Icon(Icons.location_pin), "Opponent Position");
+            const Icon(Icons.location_pin), "Opponent Position");
 
       case 'opponentTH':
         return withImageIcon(
@@ -242,7 +242,7 @@ class MembersCard extends StatelessWidget {
 
       case 'attackerPosition':
         return withIcon(member.avgAttackerPosition?.toStringAsFixed(1) ?? "-",
-            Icon(Icons.location_pin), "Attacker Position");
+            const Icon(Icons.location_pin), "Attacker Position");
 
       case 'attackerTH':
         return withImageIcon(
@@ -297,7 +297,7 @@ class MembersCard extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        Icon(Icons.location_pin,
+                        const Icon(Icons.location_pin,
                             size: 16, color: Colors.redAccent),
                         Text(
                             member.avgOpponentPosition?.toStringAsFixed(1) ??
@@ -414,19 +414,19 @@ class MembersCard extends StatelessWidget {
                   StatTile(
                       label: AppLocalizations.of(context)!.warAttacksTitle,
                       value: '${attack.attackCount}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.sword, width: 16, height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.warStatusMissed,
                       value: '${attack.missedAttacks}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.brokenSword,
                           width: 16,
                           height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.generalTotal,
                       value: '${attack.stars}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.attackStar,
                           width: 16,
                           height: 16)),
@@ -434,7 +434,7 @@ class MembersCard extends StatelessWidget {
                       label: AppLocalizations.of(context)!.warAbbreviationAvg,
                       value:
                           attack.averageStars.toStringAsFixed(1),
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.attackStar,
                           width: 16,
                           height: 16)),
@@ -457,7 +457,7 @@ class MembersCard extends StatelessWidget {
                   StatTile(
                       label: AppLocalizations.of(context)!.warDestructionTitle,
                       value: '${attack.totalDestruction.toStringAsFixed(1)}%',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.hitrate,
                           width: 16,
                           height: 16)),
@@ -465,14 +465,14 @@ class MembersCard extends StatelessWidget {
                       label: AppLocalizations.of(context)!.warAbbreviationAvgPercentage,
                       value:
                           attack.averageDestruction.toStringAsFixed(1),
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.hitrate,
                           width: 16,
                           height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.warPositionOrder,
                       value: member.avgAttackOrder?.toStringAsFixed(1) ?? "-",
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.iconClock,
                           width: 16,
                           height: 16)),
@@ -525,19 +525,19 @@ class MembersCard extends StatelessWidget {
                   StatTile(
                       label: AppLocalizations.of(context)!.warDefensesTitle,
                       value: '${defense.defenseCount}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.shieldWithArrow,
                           width: 16,
                           height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.warStatusMissed,
                       value: '${defense.missedDefenses}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.shield, width: 16, height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.generalTotal,
                       value: '${defense.stars}',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.attackStar,
                           width: 16,
                           height: 16)),
@@ -545,7 +545,7 @@ class MembersCard extends StatelessWidget {
                       label: AppLocalizations.of(context)!.warAbbreviationAvg,
                       value:
                           defense.averageStars.toStringAsFixed(1),
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.attackStar,
                           width: 16,
                           height: 16)),
@@ -568,7 +568,7 @@ class MembersCard extends StatelessWidget {
                   StatTile(
                       label: AppLocalizations.of(context)!.warDestructionTitle,
                       value: '${defense.totalDestruction.toStringAsFixed(1)}%',
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.hitrate,
                           width: 16,
                           height: 16)),
@@ -576,14 +576,14 @@ class MembersCard extends StatelessWidget {
                       label: AppLocalizations.of(context)!.warAbbreviationAvgPercentage,
                       value:
                           defense.averageDestruction.toStringAsFixed(1),
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.hitrate,
                           width: 16,
                           height: 16)),
                   StatTile(
                       label: AppLocalizations.of(context)!.warPositionOrder,
                       value: member.avgDefenseOrder?.toStringAsFixed(1) ?? "-",
-                      icon: MobileWebImage(
+                      icon: const MobileWebImage(
                           imageUrl: ImageAssets.iconClock,
                           width: 16,
                           height: 16)),

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_round_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_round_card.dart
@@ -44,7 +44,7 @@ class RoundClanCard extends StatelessWidget {
                               width: 50,
                               child: CachedNetworkImage(
                                   errorWidget: (context, url, error) =>
-                                      Icon(Icons.error),
+                                      const Icon(Icons.error),
                                   imageUrl: warInfo.clan!.badgeUrls.small),
                             ),
                             Column(
@@ -53,7 +53,7 @@ class RoundClanCard extends StatelessWidget {
                                   SizedBox(
                                     child: CachedNetworkImage(
                                       errorWidget: (context, url, error) =>
-                                          Icon(Icons.error),
+                                          const Icon(Icons.error),
                                       imageUrl: ImageAssets.sword,
                                       width: 12,
                                       height: 12,
@@ -69,7 +69,7 @@ class RoundClanCard extends StatelessWidget {
                                   SizedBox(
                                     child: CachedNetworkImage(
                                       errorWidget: (context, url, error) =>
-                                          Icon(Icons.error),
+                                          const Icon(Icons.error),
                                       imageUrl: ImageAssets.hitrate,
                                       width: 12,
                                       height: 12,
@@ -125,7 +125,7 @@ class RoundClanCard extends StatelessWidget {
                                           : null,
                                     ),
                           ),
-                          Text(" - "),
+                          const Text(" - "),
                           Text(
                             "${warInfo.opponent!.stars}",
                             style:
@@ -167,7 +167,7 @@ class RoundClanCard extends StatelessWidget {
                                     SizedBox(
                                       child: CachedNetworkImage(
                                         errorWidget: (context, url, error) =>
-                                            Icon(Icons.error),
+                                            const Icon(Icons.error),
                                         imageUrl:
                                             "https://assets.clashk.ing/icons/Icon_HV_Sword.png",
                                         width: 12,
@@ -186,7 +186,7 @@ class RoundClanCard extends StatelessWidget {
                                     SizedBox(
                                       child: CachedNetworkImage(
                                         errorWidget: (context, url, error) =>
-                                            Icon(Icons.error),
+                                            const Icon(Icons.error),
                                         imageUrl:
                                             "https://assets.clashk.ing/icons/Icon_DC_Hitrate.png",
                                         width: 12,
@@ -201,7 +201,7 @@ class RoundClanCard extends StatelessWidget {
                             width: 50,
                             child: CachedNetworkImage(
                                 errorWidget: (context, url, error) =>
-                                    Icon(Icons.error),
+                                    const Icon(Icons.error),
                                 imageUrl: warInfo.opponent!.badgeUrls.small),
                           ),
                         ],

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
@@ -67,9 +67,9 @@ class CwlTeamCard extends StatelessWidget {
                     imageUrl: clan.badgeUrls.medium,
                     width: 40,
                     height: 40,
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                   ),
-                  SizedBox(width: 10),
+                  const SizedBox(width: 10),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -90,7 +90,7 @@ class CwlTeamCard extends StatelessWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Text("${clan.stars}  "),
-                          SizedBox(
+                          const SizedBox(
                             child: MobileWebImage(
                               imageUrl: ImageAssets.attackStar,
                               width: 15,
@@ -104,7 +104,7 @@ class CwlTeamCard extends StatelessWidget {
                         children: [
                           Text(
                               "${NumberFormat('#,###', Localizations.localeOf(context).toString()).format(clan.destructionPercentageInflicted)}  "),
-                          SizedBox(
+                          const SizedBox(
                             child: MobileWebImage(
                               imageUrl: ImageAssets.hitrate,
                               width: 15,
@@ -118,7 +118,7 @@ class CwlTeamCard extends StatelessWidget {
                 ],
               ),
             ),
-            SizedBox(height: 8),
+            const SizedBox(height: 8),
             Wrap(
               alignment: WrapAlignment.center,
               children: sortedTownHalls.map((entry) {
@@ -184,28 +184,28 @@ class CwlTeamCard extends StatelessWidget {
                             StatTile(
                                 label: AppLocalizations.of(context)!.warAttacksTitle,
                                 value: '${clan.attackCount}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.sword,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.warStatusMissed,
                                 value: '${clan.missedAttacks}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.brokenSword,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.generalTotal,
                                 value: '${clan.stars}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.attackStar,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.warAbbreviationAvg,
                                 value: clan.averageStars.toStringAsFixed(1),
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.attackStar,
                                     width: 16,
                                     height: 16)),
@@ -230,7 +230,7 @@ class CwlTeamCard extends StatelessWidget {
                                     AppLocalizations.of(context)!.warDestructionTitle,
                                 value:
                                     '${clan.destructionPercentageInflicted.toStringAsFixed(1)}%',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.hitrate,
                                     width: 16,
                                     height: 16)),
@@ -239,7 +239,7 @@ class CwlTeamCard extends StatelessWidget {
                                     AppLocalizations.of(context)!.warAbbreviationAvgPercentage,
                                 value:
                                     clan.averageDestruction.toStringAsFixed(1),
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.hitrate,
                                     width: 16,
                                     height: 16)),
@@ -261,28 +261,28 @@ class CwlTeamCard extends StatelessWidget {
                             StatTile(
                                 label: AppLocalizations.of(context)!.warDefensesTitle,
                                 value: '${clan.defenseCount}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.shieldWithArrow,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.warStatusMissed,
                                 value: '${clan.missedDefenses}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.shield,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.generalTotal,
                                 value: '${clan.defStars}',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.attackStar,
                                     width: 16,
                                     height: 16)),
                             StatTile(
                                 label: AppLocalizations.of(context)!.warAbbreviationAvg,
                                 value: clan.defAverageStars.toStringAsFixed(1),
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.attackStar,
                                     width: 16,
                                     height: 16)),
@@ -307,7 +307,7 @@ class CwlTeamCard extends StatelessWidget {
                                     AppLocalizations.of(context)!.warDestructionTitle,
                                 value:
                                     '${clan.destructionPercentage.toStringAsFixed(1)}%',
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.hitrate,
                                     width: 16,
                                     height: 16)),
@@ -315,7 +315,7 @@ class CwlTeamCard extends StatelessWidget {
                                 label:
                                     AppLocalizations.of(context)!.warAbbreviationAvgPercentage,
                                 value: clan.defAverageDestruction.toStringAsFixed(1),
-                                icon: MobileWebImage(
+                                icon: const MobileWebImage(
                                     imageUrl: ImageAssets.hitrate,
                                     width: 16,
                                     height: 16)),

--- a/lib/features/war_cwl/presentation/war/war.dart
+++ b/lib/features/war_cwl/presentation/war/war.dart
@@ -334,7 +334,7 @@ class _WarScreenState extends State<WarScreen> with TickerProviderStateMixin {
                               color: Colors.black.withValues(alpha: 0.3),
                               blurRadius: 4,
                               spreadRadius: 1,
-                              offset: Offset(0, 2),
+                              offset: const Offset(0, 2),
                             ),
                           ],
                         ),

--- a/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
+++ b/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
@@ -208,7 +208,7 @@ class WarStatisticsTab extends StatelessWidget {
         SizedBox(
           width: 25,
           child: imageUrl != null
-              ? CachedNetworkImage(imageUrl: imageUrl, errorWidget: (c, u, e) => Icon(Icons.error))
+              ? CachedNetworkImage(imageUrl: imageUrl, errorWidget: (c, u, e) => const Icon(Icons.error))
               : Icon(icon, size: 25),
         ),
         Expanded(
@@ -249,7 +249,7 @@ class WarStatisticsTab extends StatelessWidget {
                     : "https://assets.clashk.ing/icons/Icon_BB_Empty_Star.png";
                 return SizedBox(
                   width: 25,
-                  child: CachedNetworkImage(imageUrl: image, errorWidget: (c, u, e) => Icon(Icons.error)),
+                  child: CachedNetworkImage(imageUrl: image, errorWidget: (c, u, e) => const Icon(Icons.error)),
                 );
               }),
             ),

--- a/lib/features/war_cwl/presentation/war/widgets/war_calculator_card.dart
+++ b/lib/features/war_cwl/presentation/war/widgets/war_calculator_card.dart
@@ -55,14 +55,14 @@ class WarCalculatorCardState extends State<WarCalculatorCard> {
           children: [
             Container(
               height: 60,
-              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Icon(Icons.calculate,
                       color: Theme.of(context).colorScheme.onSurface),
                   Padding(
-                    padding: EdgeInsets.only(left: 4.0),
+                    padding: const EdgeInsets.only(left: 4.0),
                     child: Text(
                         AppLocalizations.of(context)?.warCalculatorFast ??
                             'Fast calculator'),

--- a/lib/features/war_cwl/presentation/war/widgets/war_header.dart
+++ b/lib/features/war_cwl/presentation/war/widgets/war_header.dart
@@ -51,7 +51,7 @@ class _WarHeaderState extends State<WarHeader> {
                 Colors.black.withValues(alpha: 0.5),
                 BlendMode.darken,
               ),
-              child: MobileWebImage(
+              child: const MobileWebImage(
                 imageUrl: ImageAssets.warPageBackground,
                 width: double.infinity,
                 fit: BoxFit.cover

--- a/lib/features/war_cwl/presentation/war_history/component/war_history_header.dart
+++ b/lib/features/war_cwl/presentation/war_history/component/war_history_header.dart
@@ -31,7 +31,7 @@ class WarHistoryHeader extends StatelessWidget {
                 BlendMode.darken,
               ),
               child: CachedNetworkImage(
-                errorWidget: (context, url, error) => Icon(Icons.error),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
                 imageUrl: ImageAssets.warPageBackground,
                 width: double.infinity,
                 fit: BoxFit.cover,
@@ -48,7 +48,7 @@ class WarHistoryHeader extends StatelessWidget {
                   height: 60,
                   width: 60,
                   child: CachedNetworkImage(
-                      errorWidget: (context, url, error) => Icon(Icons.error),
+                      errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: clan.badgeUrls.medium),
                 ),
                 Column(
@@ -72,7 +72,7 @@ class WarHistoryHeader extends StatelessWidget {
                 ),
               ],
             ),
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
             Wrap(
               alignment: WrapAlignment.start,
               spacing: 7.0,
@@ -119,7 +119,7 @@ class WarHistoryHeader extends StatelessWidget {
                             warLogStats.totalTies, warLogStats.tiePercentage)),
               ],
             ),
-            SizedBox(height: 24),
+            const SizedBox(height: 24),
           ],
         ),
         Positioned(

--- a/lib/features/war_cwl/presentation/war_history/component/war_history_players_header.dart
+++ b/lib/features/war_cwl/presentation/war_history/component/war_history_players_header.dart
@@ -15,7 +15,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
   final VoidCallback onBack;
   final VoidCallback onFilter;
 
-  WarHistoryPlayersStatsHeader({
+  const WarHistoryPlayersStatsHeader({
     super.key,
     required this.clan,
     required this.isCWLChecked,
@@ -45,7 +45,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                 ),
                 child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                   imageUrl: "https://assets.clashk.ing/landscape/war-stats.png",
                   width: double.infinity,
                   fit: BoxFit.cover,
@@ -70,14 +70,14 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                           .titleSmall
                           ?.copyWith(color: Colors.white),
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                       imageUrl: clan.badgeUrls.medium,
                       width: 50,
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Text(
                       clan.name,
                       style: Theme.of(context)
@@ -92,7 +92,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                           .labelLarge
                           ?.copyWith(color: Colors.grey),
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Wrap(
                       spacing: 0,
                       runSpacing: 0,
@@ -109,7 +109,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                           selected: isCWLChecked,
                           onSelected: (bool selected) => onCWLChanged(),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         FilterChip(
                           visualDensity: VisualDensity.compact,
                           selectedColor: Theme.of(context).colorScheme.primary,
@@ -122,7 +122,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                           selected: isRandomChecked,
                           onSelected: (bool selected) => onRandomChanged(),
                         ),
-                        SizedBox(width: 8),
+                        const SizedBox(width: 8),
                         FilterChip(
                           visualDensity: VisualDensity.compact,
                           selectedColor: Theme.of(context).colorScheme.primary,
@@ -137,7 +137,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
                         ),
                       ],
                     ),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                   ],
                 ),
               ),
@@ -157,7 +157,7 @@ class WarHistoryPlayersStatsHeader extends StatelessWidget {
           top: 40,
           right: 10,
           child: IconButton(
-            icon: Icon(Icons.filter_list, color: Colors.white),
+            icon: const Icon(Icons.filter_list, color: Colors.white),
             onPressed: onFilter,
           ),
         ),

--- a/lib/features/war_cwl/presentation/war_history/component/war_log_history_stats_tab.dart
+++ b/lib/features/war_cwl/presentation/war_history/component/war_log_history_stats_tab.dart
@@ -9,7 +9,7 @@ import 'package:clashkingapp/core/utils/debug_utils.dart';
 class WarLogHistoryStats extends StatefulWidget {
   final Clan clan;
 
-  WarLogHistoryStats(
+  const WarLogHistoryStats(
       {super.key,
       required this.clan});
 
@@ -27,27 +27,27 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Padding(
-          padding: EdgeInsets.all(2),
+          padding: const EdgeInsets.all(2),
           child: SizedBox(
             width: double.infinity,
             child: Card(
               child: Padding(
-                padding: EdgeInsets.all(8),
+                padding: const EdgeInsets.all(8),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Text(AppLocalizations.of(context)!.warStats,
                         style: Theme.of(context).textTheme.titleSmall),
-                    SizedBox(height: 8),
+                    const SizedBox(height: 8),
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Icon(LucideIcons.users, size: 16),
-                            SizedBox(width: 8),
+                            const Icon(LucideIcons.users, size: 16),
+                            const SizedBox(width: 8),
                             Text(
                                 "~${warLogStats.averageMembers.toStringAsFixed(0)}",
                                 style: Theme.of(context).textTheme.bodyMedium),
@@ -56,8 +56,8 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                         Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Icon(LucideIcons.percent, size: 16),
-                            SizedBox(width: 8),
+                            const Icon(LucideIcons.percent, size: 16),
+                            const SizedBox(width: 8),
                             Text(
                                 warLogStats
                                             .averageDestructionDifference >
@@ -81,15 +81,15 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
           children: [
             Expanded(
               child: Padding(
-                padding: EdgeInsets.all(2),
+                padding: const EdgeInsets.all(2),
                 child: Card(
                   child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                     child: Column(
                       children: [
                         Text(AppLocalizations.of(context)!.warAttacksTitle,
                             style: Theme.of(context).textTheme.bodyLarge),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -97,8 +97,8 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                                 style: Theme.of(context).textTheme.bodyMedium),
                             Row(
                               children: [
-                                Icon(LucideIcons.percent, size: 16),
-                                SizedBox(width: 8),
+                                const Icon(LucideIcons.percent, size: 16),
+                                const SizedBox(width: 8),
                                 Text(
                                     warLogStats.averageClanDestruction
                                         .toStringAsFixed(2),
@@ -106,18 +106,18 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                                         Theme.of(context).textTheme.bodyMedium),
                               ],
                             ),
-                            SizedBox(height: 8),
+                            const SizedBox(height: 8),
                             Text(AppLocalizations.of(context)!.statsMembers,
                                 style: Theme.of(context).textTheme.bodyMedium),
                             Row(
                               children: [
                                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                     imageUrl:
                                         "https://assets.clashk.ing/icons/Icon_HV_Attack_Star.png",
                                     height: 16),
-                                SizedBox(width: 8),
+                                const SizedBox(width: 8),
                                 Text(
                                     warLogStats.averageClanStarsPerMember
                                         .toStringAsFixed(2),
@@ -129,11 +129,11 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                               children: [
                                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                     imageUrl:
                                         "https://assets.clashk.ing/icons/Icon_HV_Sword.png",
                                     height: 16),
-                                SizedBox(width: 8),
+                                const SizedBox(width: 8),
                                 Text(
                                     warLogStats.averageAttacksPerMember
                                         .toStringAsFixed(2),
@@ -151,15 +151,15 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
             ),
             Expanded(
               child: Padding(
-                padding: EdgeInsets.all(2),
+                padding: const EdgeInsets.all(2),
                 child: Card(
                   child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                     child: Column(
                       children: [
                         Text(AppLocalizations.of(context)!.warDefensesTitle,
                             style: Theme.of(context).textTheme.bodyLarge),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -167,8 +167,8 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                                 style: Theme.of(context).textTheme.bodyMedium),
                             Row(
                               children: [
-                                Icon(LucideIcons.percent, size: 16),
-                                SizedBox(width: 8),
+                                const Icon(LucideIcons.percent, size: 16),
+                                const SizedBox(width: 8),
                                 Text(
                                     warLogStats
                                         .averageOpponentStarsPercentage
@@ -177,18 +177,18 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                                         Theme.of(context).textTheme.bodyMedium),
                               ],
                             ),
-                            SizedBox(height: 8),
+                            const SizedBox(height: 8),
                             Text(AppLocalizations.of(context)!.statsMembers,
                                 style: Theme.of(context).textTheme.bodyMedium),
                             Row(
                               children: [
                                 CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                                     imageUrl:
                                         "https://assets.clashk.ing/icons/Icon_HV_Attack_Star.png",
                                     height: 16),
-                                SizedBox(width: 8),
+                                const SizedBox(width: 8),
                                 Text(
                                     warLogStats
                                         .averageOpponentStarsPerMember
@@ -215,7 +215,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
           ],
         ),
         Padding(
-          padding: EdgeInsets.all(2),
+          padding: const EdgeInsets.all(2),
           child: SizedBox(
             width: double.infinity,
             child: GestureDetector(
@@ -225,7 +225,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                   context: context,
                   barrierDismissible: false,
                   builder: (BuildContext context) {
-                    return Center(
+                    return const Center(
                       child: CircularProgressIndicator(),
                     );
                   },
@@ -249,7 +249,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                 children: [
                   Card(
                     child: Padding(
-                      padding: EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(16),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                         children: [
@@ -257,7 +257,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                             flex: 2,
                             child: CachedNetworkImage(
   
-  errorWidget: (context, url, error) => Icon(Icons.error),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
                               imageUrl:
                                   'https://assets.clashk.ing/stickers/Villager_HV_Villager_7.png',
                               height: 90,
@@ -271,7 +271,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                                 style: Theme.of(context).textTheme.bodyLarge,
                                 textAlign: TextAlign.center),
                           ),
-                          Expanded(
+                          const Expanded(
                             flex: 2,
                             child: Icon(LucideIcons.chevronRight, size: 24),
                           ),
@@ -279,7 +279,7 @@ class WarLogHistoryStatsState extends State<WarLogHistoryStats>
                       ),
                     ),
                   ),
-                  BetaLabel(),
+                  const BetaLabel(),
                 ],
               ),
             ),

--- a/lib/features/war_cwl/presentation/war_history/component/war_log_history_tab.dart
+++ b/lib/features/war_cwl/presentation/war_history/component/war_log_history_tab.dart
@@ -108,22 +108,22 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
             '50v50': '50',
           },
         ),
-        SizedBox(height: 2),
+        const SizedBox(height: 2),
         filteredWarLogData.isEmpty
             ? Column(
                 children: [
-                  SizedBox(height: 16),
+                  const SizedBox(height: 16),
                   Card(
                     child: Padding(
-                      padding: EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(16),
                       child: Text(
                           AppLocalizations.of(context)?.generalNoDataAvailable ??
                               'No data available'),
                     ),
                   ),
-                  SizedBox(height: 32),
+                  const SizedBox(height: 32),
                   CachedNetworkImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
+                    errorWidget: (context, url, error) => const Icon(Icons.error),
                     imageUrl:
                         'https://assets.clashk.ing/stickers/Villager_HV_Villager_7.png',
                     height: 250,
@@ -141,7 +141,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          SizedBox(height: 2),
+          const SizedBox(height: 2),
           Center(
             child: Column(
               children: List<Widget>.generate(warLogData.length, (index) {
@@ -154,7 +154,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                       context: context,
                       barrierDismissible: false,
                       builder: (BuildContext context) {
-                        return Center(
+                        return const Center(
                           child: CircularProgressIndicator(),
                         );
                       },
@@ -178,7 +178,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                                           .onSurface),
                                 ),
                               ),
-                              duration: Duration(seconds: 1),
+                              duration: const Duration(seconds: 1),
                               backgroundColor:
                                   Theme.of(context).colorScheme.surface,
                             ),
@@ -199,7 +199,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                   },
                   child: Card(
                     margin:
-                        EdgeInsets.only(top: 4, bottom: 4, left: 4, right: 4),
+                        const EdgeInsets.only(top: 4, bottom: 4, left: 4, right: 4),
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: Column(
@@ -216,7 +216,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                                       height: 70,
                                       child: CachedNetworkImage(
                                           errorWidget: (context, url, error) =>
-                                              Icon(Icons.error),
+                                              const Icon(Icons.error),
                                           imageUrl:
                                               warLogDetail.clan.badgeUrls.large,
                                           fit: BoxFit.cover),
@@ -275,7 +275,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                                                 fontWeight: FontWeight.bold)),
                                     Text(
                                         '${warLogDetail.clan.destructionPercentage % 1 == 0 ? warLogDetail.clan.destructionPercentage.toInt().toString().padLeft(6, ' ') : warLogDetail.clan.destructionPercentage.toStringAsFixed(2).padLeft(5, '0')}%    ${warLogDetail.opponent.destructionPercentage % 1 == 0 ? ('${warLogDetail.opponent.destructionPercentage.toInt()}%').padRight(7, ' ') : ('${warLogDetail.opponent.destructionPercentage.toStringAsFixed(2)}%').padLeft(5, ' ')}'),
-                                    SizedBox(height: 2),
+                                    const SizedBox(height: 2),
                                     Row(
                                       mainAxisAlignment:
                                           MainAxisAlignment.center,
@@ -283,7 +283,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                                         CachedNetworkImage(
                                             errorWidget:
                                                 (context, url, error) =>
-                                                    Icon(Icons.error),
+                                                    const Icon(Icons.error),
                                             imageUrl:
                                                 'https://assets.clashk.ing/icons/Icon_HV_XP.png',
                                             width: 20,
@@ -304,7 +304,7 @@ class WarLogHistoryTabState extends State<WarLogHistoryTab> {
                                       height: 70,
                                       child: CachedNetworkImage(
                                           errorWidget: (context, url, error) =>
-                                              Icon(Icons.error),
+                                              const Icon(Icons.error),
                                           imageUrl: warLogDetail
                                               .opponent.badgeUrls.large,
                                           fit: BoxFit.cover),

--- a/lib/features/war_cwl/presentation/war_history/war_history_page.dart
+++ b/lib/features/war_cwl/presentation/war_history/war_history_page.dart
@@ -9,7 +9,7 @@ import 'package:clashkingapp/l10n/app_localizations.dart';
 class WarHistoryScreen extends StatefulWidget {
   final Clan clan;
 
-  WarHistoryScreen({super.key, required this.clan});
+  const WarHistoryScreen({super.key, required this.clan});
 
   @override
   WarHistoryScreenState createState() => WarHistoryScreenState();
@@ -57,7 +57,7 @@ class WarHistoryScreenState extends State<WarHistoryScreen>
               ],
               children: [
                 Padding(
-                  padding: EdgeInsets.all(8),
+                  padding: const EdgeInsets.all(8),
                   child: Column(
                     children: [
                       WarLogHistoryTab(clan: widget.clan),
@@ -65,7 +65,7 @@ class WarHistoryScreenState extends State<WarHistoryScreen>
                   ),
                 ),
                 Padding(
-                  padding: EdgeInsets.all(8),
+                  padding: const EdgeInsets.all(8),
                   child: Column(
                     children: [
                       WarLogHistoryStats(

--- a/lib/features/war_cwl/presentation/war_history/war_history_players.dart
+++ b/lib/features/war_cwl/presentation/war_history/war_history_players.dart
@@ -15,7 +15,7 @@ class PlayersWarHistoryScreen extends StatefulWidget {
   final Clan clan;
   final List<String> discordUser;
 
-  PlayersWarHistoryScreen(
+  const PlayersWarHistoryScreen(
       {super.key, required this.clan, required this.discordUser});
 
   @override
@@ -202,10 +202,10 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                               .colorScheme
                               .primary
                               .withValues(alpha: 0.7),
-                          labelPadding: EdgeInsets.all(0),
+                          labelPadding: const EdgeInsets.all(0),
                           label: CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl: ImageAssets.townHall(thLevel),
                               height: 24),
                           selected: memberThSelection[thLevel]!,
@@ -217,7 +217,7 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                         );
                       }).toList(),
                     ),
-                    SizedBox(height: 10),
+                    const SizedBox(height: 10),
                     Text(AppLocalizations.of(context)!.warOpponentSelectOpponentsThLevel,
                         style: Theme.of(context).textTheme.bodyMedium),
                     Wrap(
@@ -229,10 +229,10 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                               .colorScheme
                               .primary
                               .withValues(alpha: 0.7),
-                          labelPadding: EdgeInsets.all(0),
+                          labelPadding: const EdgeInsets.all(0),
                           label: CachedNetworkImage(
                               errorWidget: (context, url, error) =>
-                                  Icon(Icons.error),
+                                  const Icon(Icons.error),
                               imageUrl: ImageAssets.townHall(thLevel),
                               height: 24),
                           selected: enemyThSelection[thLevel]!,
@@ -244,7 +244,7 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                         );
                       }).toList(),
                     ),
-                    SizedBox(height: 10),
+                    const SizedBox(height: 10),
                     CheckboxListTile(
                       title: Text(AppLocalizations.of(context)!.warOpponentEqualThLevel,
                           style: Theme.of(context).textTheme.bodyMedium),
@@ -449,7 +449,7 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                 },
                 onBack: () => Navigator.of(context).pop(),
                 onFilter: showFilterDialog),
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
@@ -479,7 +479,7 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                   },
                 ),
                 IconButton(
-                  icon: Icon(LucideIcons.listRestart),
+                  icon: const Icon(LucideIcons.listRestart),
                   onPressed: () {
                     _resetFilters();
                   },
@@ -487,7 +487,7 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                 ),
               ],
             ),
-            SizedBox(height: 8),
+            const SizedBox(height: 8),
             ...sortedMembers.map(
               (member) {
                 MemberWarStats? memberWarStats =
@@ -498,10 +498,10 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                 }
 
                 return Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                   child: Card(
                     child: Padding(
-                      padding: EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(16),
                       child: Column(
                         children: [
                           Row(
@@ -511,12 +511,12 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                                 children: [
                                   CachedNetworkImage(
                                     errorWidget: (context, url, error) =>
-                                        Icon(Icons.error),
+                                        const Icon(Icons.error),
                                     imageUrl: ImageAssets.townHall(
                                         member.townHallLevel),
                                     height: 50,
                                   ),
-                                  SizedBox(width: 16),
+                                  const SizedBox(width: 16),
                                   Column(
                                     mainAxisAlignment: MainAxisAlignment.start,
                                     crossAxisAlignment:
@@ -535,10 +535,10 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                                       Text(memberWarStats?.warsParticipated
                                               .toString() ??
                                           ""),
-                                      SizedBox(width: 8),
+                                      const SizedBox(width: 8),
                                       CachedNetworkImage(
                                           errorWidget: (context, url, error) =>
-                                              Icon(Icons.error),
+                                              const Icon(Icons.error),
                                           imageUrl:
                                               "https://assets.clashk.ing/icons/Icon_HV_Clan_War.png",
                                           height: 16,
@@ -550,10 +550,10 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                                       Text(memberWarStats?.missedAttacks
                                               .toString() ??
                                           ""),
-                                      SizedBox(width: 8),
+                                      const SizedBox(width: 8),
                                       CachedNetworkImage(
                                           errorWidget: (context, url, error) =>
-                                              Icon(Icons.error),
+                                              const Icon(Icons.error),
                                           imageUrl:
                                               "https://assets.clashk.ing/bot/icons/broken_sword.png",
                                           height: 16,
@@ -564,13 +564,13 @@ class PlayersWarHistoryScreenState extends State<PlayersWarHistoryScreen>
                               ),
                             ],
                           ),
-                          SizedBox(height: 8),
+                          const SizedBox(height: 8),
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Column(
                                 children: [
-                                  Row(
+                                  const Row(
                                     children: [
                                       Icon(Icons.percent, size: 16),
                                       Icon(Icons.star, size: 16),

--- a/lib/features/war_cwl/presentation/war_stats/clan_war_log.dart
+++ b/lib/features/war_cwl/presentation/war_stats/clan_war_log.dart
@@ -114,21 +114,21 @@ class ClanWarLogState extends State<ClanWarLog> {
             '50v50': '50',
           },
         ),
-        SizedBox(height: 2),
+        const SizedBox(height: 2),
         filteredWarLogData.isEmpty
             ? Column(
                 children: [
-                  SizedBox(height: 16),
+                  const SizedBox(height: 16),
                   Card(
                     child: Padding(
-                      padding: EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(16),
                       child: Text(
                           AppLocalizations.of(context)?.generalNoDataAvailable ??
                               'No data available'),
                     ),
                   ),
-                  SizedBox(height: 32),
-                  MobileWebImage(
+                  const SizedBox(height: 32),
+                  const MobileWebImage(
                     imageUrl: ImageAssets.villager,
                     height: 250,
                     width: 200,
@@ -146,7 +146,7 @@ class ClanWarLogState extends State<ClanWarLog> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          SizedBox(height: 2),
+          const SizedBox(height: 2),
           Center(
             child: Column(
               children: List<Widget>.generate(warLogData.length, (index) {
@@ -159,7 +159,7 @@ class ClanWarLogState extends State<ClanWarLog> {
                       context: context,
                       barrierDismissible: false,
                       builder: (BuildContext context) {
-                        return Center(
+                        return const Center(
                           child: CircularProgressIndicator(),
                         );
                       },
@@ -183,7 +183,7 @@ class ClanWarLogState extends State<ClanWarLog> {
                                           .onSurface),
                                 ),
                               ),
-                              duration: Duration(seconds: 1),
+                              duration: const Duration(seconds: 1),
                               backgroundColor:
                                   Theme.of(context).colorScheme.surface,
                             ),

--- a/lib/features/war_cwl/presentation/war_stats/clan_war_stats_filter_dialog.dart
+++ b/lib/features/war_cwl/presentation/war_stats/clan_war_stats_filter_dialog.dart
@@ -165,7 +165,7 @@ class _ClanWarStatsFilterDialogState extends State<ClanWarStatsFilterDialog> {
     return Column(
       children: [
         ListTile(
-          title: Text('Start Date'),
+          title: const Text('Start Date'),
           subtitle:
               Text(_filter.startDate?.toString().split(' ')[0] ?? 'Not set'),
           trailing: const Icon(Icons.calendar_today),
@@ -183,7 +183,7 @@ class _ClanWarStatsFilterDialogState extends State<ClanWarStatsFilterDialog> {
           },
         ),
         ListTile(
-          title: Text('End Date'),
+          title: const Text('End Date'),
           subtitle:
               Text(_filter.endDate?.toString().split(' ')[0] ?? 'Not set'),
           trailing: const Icon(Icons.calendar_today),

--- a/lib/features/war_cwl/presentation/war_stats/war_stats_page.dart
+++ b/lib/features/war_cwl/presentation/war_stats/war_stats_page.dart
@@ -30,7 +30,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
   List<PlayerWarStats> filteredPlayers = [];
   ClanWarStatsFilter _currentFilter = ClanWarStatsFilter.defaultFilter();
   ClanWarStats? _filteredClanWarStats;
-  bool _isLoadingFiltered = false;
+  final bool _isLoadingFiltered = false;
   bool _hasAppliedFilters = false;
 
   // Track selected Town Hall levels for members and enemies
@@ -232,7 +232,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                               .colorScheme
                               .primary
                               .withAlpha(150),
-                          labelPadding: EdgeInsets.all(0),
+                          labelPadding: const EdgeInsets.all(0),
                           label: MobileWebImage(
                               imageUrl: ImageAssets.townHall(thLevel),
                               height: 24),
@@ -245,7 +245,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                         );
                       }).toList(),
                     ),
-                    SizedBox(height: 10),
+                    const SizedBox(height: 10),
                     Text(
                         AppLocalizations.of(context)!
                             .warOpponentSelectOpponentsThLevel,
@@ -259,7 +259,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                               .colorScheme
                               .primary
                               .withAlpha(150),
-                          labelPadding: EdgeInsets.all(0),
+                          labelPadding: const EdgeInsets.all(0),
                           label: MobileWebImage(
                               imageUrl: ImageAssets.townHall(thLevel),
                               height: 24),
@@ -272,7 +272,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                         );
                       }).toList(),
                     ),
-                    SizedBox(height: 10),
+                    const SizedBox(height: 10),
                     CheckboxListTile(
                       title: Text(
                           AppLocalizations.of(context)!.warOpponentEqualThLevel,
@@ -516,7 +516,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                         ],
                         children: [
                           Padding(
-                            padding: EdgeInsets.all(8),
+                            padding: const EdgeInsets.all(8),
                             child: Column(
                               children: [
                                 ClanWarLog(
@@ -527,7 +527,7 @@ class _ClanWarStatsScreenState extends State<ClanWarStatsScreen> {
                             ),
                           ),
                           Padding(
-                            padding: EdgeInsets.all(8),
+                            padding: const EdgeInsets.all(8),
                             child: Column(
                               children: [
                                 ClanWarStatsPlayers(

--- a/lib/features/war_cwl/presentation/war_stats/war_stats_players.dart
+++ b/lib/features/war_cwl/presentation/war_stats/war_stats_players.dart
@@ -75,7 +75,7 @@ class ClanWarStatsPlayers extends StatelessWidget {
               },
             ),
             IconButton(
-              icon: Icon(LucideIcons.listRestart),
+              icon: const Icon(LucideIcons.listRestart),
               onPressed: () {
                 resetFilters();
               },
@@ -104,7 +104,7 @@ class ClanWarStatsPlayers extends StatelessWidget {
               );
 
               if (totalAttacks == 0) {
-                return SizedBox.shrink();
+                return const SizedBox.shrink();
               }
 
               return GestureDetector(
@@ -129,14 +129,14 @@ class ClanWarStatsPlayers extends StatelessWidget {
                     if (context.mounted) {
                       navigator.pop();
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to load player data')),
+                        const SnackBar(content: Text('Failed to load player data')),
                       );
                     }
                   }
                 },
                 child: Card(
                   child: Padding(
-                    padding: EdgeInsets.all(16),
+                    padding: const EdgeInsets.all(16),
                     child: Column(
                       children: [
                         Row(
@@ -149,7 +149,7 @@ class ClanWarStatsPlayers extends StatelessWidget {
                                       member.townhallLevel),
                                   height: 50,
                                 ),
-                                SizedBox(width: 16),
+                                const SizedBox(width: 16),
                                 Column(
                                   mainAxisAlignment: MainAxisAlignment.start,
                                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -165,8 +165,8 @@ class ClanWarStatsPlayers extends StatelessWidget {
                                 Row(
                                   children: [
                                     Text(totalAttacks.toString()),
-                                    SizedBox(width: 8),
-                                    MobileWebImage(
+                                    const SizedBox(width: 8),
+                                    const MobileWebImage(
                                         imageUrl: ImageAssets.warClan,
                                         height: 16,
                                         width: 16),
@@ -176,8 +176,8 @@ class ClanWarStatsPlayers extends StatelessWidget {
                                   children: [
                                     Text(memberWarStats.missedAttacks
                                         .toString()),
-                                    SizedBox(width: 8),
-                                    MobileWebImage(
+                                    const SizedBox(width: 8),
+                                    const MobileWebImage(
                                         imageUrl: ImageAssets.brokenSword,
                                         height: 16,
                                         width: 16),
@@ -187,13 +187,13 @@ class ClanWarStatsPlayers extends StatelessWidget {
                             ),
                           ],
                         ),
-                        SizedBox(height: 8),
+                        const SizedBox(height: 8),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             Column(
                               children: [
-                                Row(
+                                const Row(
                                   children: [
                                     Icon(Icons.percent, size: 16),
                                     Icon(Icons.star, size: 16),

--- a/lib/l10n/update_arb.dart
+++ b/lib/l10n/update_arb.dart
@@ -39,7 +39,7 @@ void main() {
     });
 
     if (updated) {
-      file.writeAsStringSync(JsonEncoder.withIndent('  ').convert(targetJson));
+      file.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(targetJson));
       DebugUtils.debugSuccess('✅ ${file.path} has been updated.');
     } else {
       DebugUtils.debugInfo('📝 ${file.path} is already up-to-date.');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,7 +133,7 @@ Future<void> main() async {
             Provider(create: (_) => UserService()),
             Provider(create: (_) => TokenService()),
           ],
-          child: MyApp(),
+          child: const MyApp(),
         ),
       );
     },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   tuple: ^2.0.2
   custom_sliding_segmented_control: ^1.8.5
   dropdown_button2: ^3.1.0
-  home_widget : ^0.9.1
+  home_widget : ^0.9.2
   workmanager: ^0.9.0+3
   cached_network_image: ^3.4.1
   shimmer: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,8 @@ dev_dependencies:
 
   flutter_launcher_icons: ^0.14.4
   mockito: ^5.6.1
+  device_info_plus_platform_interface: ^8.1.0
+  plugin_platform_interface: ^2.1.8
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/test/core/constants/layout_constants_test.dart
+++ b/test/core/constants/layout_constants_test.dart
@@ -1,0 +1,14 @@
+import 'package:clashkingapp/core/constants/layout_constants.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('layout_constants', () {
+    test('kMaxContentWidth is 800.0', () {
+      expect(kMaxContentWidth, 800.0);
+    });
+
+    test('kChipRunSpacing returns a double', () {
+      expect(kChipRunSpacing, isA<double>());
+    });
+  });
+}

--- a/test/core/functions/functions_additional_test.dart
+++ b/test/core/functions/functions_additional_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io' show Platform;
+import 'dart:typed_data';
+
+import 'package:clashkingapp/core/functions/functions.dart';
+import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:device_info_plus_platform_interface/device_info_plus_platform_interface.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _FakeDeviceInfoPlatform extends DeviceInfoPlatform
+    with MockPlatformInterfaceMixin {
+  @override
+  Future<BaseDeviceInfo> deviceInfo() async {
+    if (Platform.isWindows) {
+      return WindowsDeviceInfo(
+        computerName: 'TestPC',
+        numberOfCores: 8,
+        systemMemoryInMegabytes: 16384,
+        userName: 'tester',
+        majorVersion: 10,
+        minorVersion: 0,
+        buildNumber: 22631,
+        platformId: 2,
+        csdVersion: '',
+        servicePackMajor: 0,
+        servicePackMinor: 0,
+        suitMask: 0,
+        productType: 1,
+        reserved: 0,
+        buildLab: 'test',
+        buildLabEx: 'test',
+        digitalProductId: Uint8List(0),
+        displayVersion: '11',
+        editionId: 'Pro',
+        installDate: DateTime(2024, 1, 1),
+        productId: 'test-product',
+        productName: 'Windows Test',
+        registeredOwner: 'Tester',
+        releaseId: '23H2',
+        deviceId: 'device-id',
+      );
+    }
+
+    if (Platform.isLinux) {
+      return LinuxDeviceInfo(
+        name: 'Test Linux',
+        version: '1.0',
+        id: 'test-linux',
+        prettyName: 'Test Linux',
+        machineId: 'machine-id',
+      );
+    }
+
+    if (Platform.isMacOS) {
+      return MacOsDeviceInfo.setMockInitialValues(
+        computerName: 'Test Mac',
+        hostName: 'test-mac.local',
+        arch: 'arm64',
+        model: 'Mac14,7',
+        modelName: 'MacBook Pro',
+        kernelVersion: '23.5.0',
+        osRelease: '14.5',
+        majorVersion: 14,
+        minorVersion: 5,
+        patchVersion: 0,
+        activeCPUs: 8,
+        memorySize: 16384,
+        cpuFrequency: 3200,
+        systemGUID: 'guid',
+      );
+    }
+
+    throw UnsupportedError(
+      'Unsupported test platform: ${Platform.operatingSystem}',
+    );
+  }
+}
+
+Future<BuildContext> _pumpLocalizedApp(WidgetTester tester) async {
+  late BuildContext context;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (buildContext) {
+          context = buildContext;
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return context;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    PackageInfo.setMockInitialValues(
+      appName: 'ClashKing',
+      packageName: 'com.clashking.app',
+      version: '1.2.3',
+      buildNumber: '42',
+      buildSignature: 'signature',
+    );
+  });
+
+  group('functions.dart additional coverage', () {
+    group('storage helpers', () {
+      test('stores and retrieves preferences', () async {
+        await storePrefs('selectedTag', '#PLAYER');
+
+        expect(await getPrefs('selectedTag'), '#PLAYER');
+      });
+
+      test('deletes a stored preference', () async {
+        await storePrefs('selectedTag', '#PLAYER');
+        await deletePrefs('selectedTag');
+
+        expect(await getPrefs('selectedTag'), isNull);
+      });
+
+      test('clears all stored preferences', () async {
+        await storePrefs('selectedTag', '#PLAYER');
+        await storePrefs('player_#PLAYER_clan_tag', '#CLAN');
+        await clearPrefs();
+
+        expect(await getPrefs('selectedTag'), isNull);
+        expect(await getPrefs('player_#PLAYER_clan_tag'), isNull);
+      });
+    });
+
+    testWidgets('getEndedAgoText returns localized text for each branch', (
+      tester,
+    ) async {
+      final context = await _pumpLocalizedApp(tester);
+      final localizations = AppLocalizations.of(context)!;
+
+      expect(getEndedAgoText(null, context), localizations.generalUnknown);
+      expect(
+        getEndedAgoText(
+          DateTime.now().subtract(const Duration(seconds: 30)),
+          context,
+        ),
+        localizations.timeEndedJustNow,
+      );
+      expect(
+        getEndedAgoText(
+          DateTime.now().subtract(const Duration(minutes: 5)),
+          context,
+        ),
+        localizations.timeEndedMinutesAgo(5),
+      );
+      expect(
+        getEndedAgoText(
+          DateTime.now().subtract(const Duration(hours: 3)),
+          context,
+        ),
+        localizations.timeEndedHoursAgo(3),
+      );
+      expect(
+        getEndedAgoText(
+          DateTime.now().subtract(const Duration(days: 2)),
+          context,
+        ),
+        localizations.timeEndedDaysAgo(2),
+      );
+    });
+
+    test('getAppAndDeviceInfo returns version and platform details', () async {
+      final previousPlatform = DeviceInfoPlatform.instance;
+      DeviceInfoPlatform.instance = _FakeDeviceInfoPlatform();
+      addTearDown(() => DeviceInfoPlatform.instance = previousPlatform);
+
+      final info = await getAppAndDeviceInfo();
+
+      expect(info, contains('Version: 1.2.3 (Build 42)'));
+      if (Platform.isWindows) {
+        expect(info, contains('Device: TestPC, OS: Windows 11'));
+      } else if (Platform.isLinux) {
+        expect(info, contains('Device: Test Linux, OS: Linux 1.0'));
+      } else if (Platform.isMacOS) {
+        expect(info, contains('Device: Mac14,7, OS: macOS 14.5'));
+      }
+    });
+  });
+}

--- a/test/core/functions/functions_test.dart
+++ b/test/core/functions/functions_test.dart
@@ -1,0 +1,81 @@
+import 'package:clashkingapp/core/functions/functions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('functions.dart utilities', () {
+    group('formatSecondsToHHMM', () {
+      test('formats 0 seconds', () {
+        expect(formatSecondsToHHMM(0.0), '00:00');
+      });
+
+      test('formats 1 hour', () {
+        expect(formatSecondsToHHMM(3600.0), '01:00');
+      });
+
+      test('formats 1 hour and 1 minute', () {
+        expect(formatSecondsToHHMM(3661.0), '01:01');
+      });
+
+      test('formats 2 hours', () {
+        expect(formatSecondsToHHMM(7200.0), '02:00');
+      });
+
+      test('rounds to the nearest second before formatting', () {
+        expect(formatSecondsToHHMM(90.0), '00:01');
+      });
+    });
+
+    group('findLastMondayOfMonth', () {
+      test('returns a Monday', () {
+        final result = findLastMondayOfMonth(2025, 5);
+
+        expect(result.weekday, DateTime.monday);
+      });
+
+      test('May 2025 last Monday is May 26', () {
+        final result = findLastMondayOfMonth(2025, 5);
+
+        expect(result.year, 2025);
+        expect(result.month, 5);
+        expect(result.day, 26);
+      });
+
+      test('December 2025 last Monday is December 29', () {
+        final result = findLastMondayOfMonth(2025, 12);
+
+        expect(result.year, 2025);
+        expect(result.month, 12);
+        expect(result.day, 29);
+      });
+    });
+
+    group('time frame helpers', () {
+      test('isInTimeFrameForRaid returns a bool', () {
+        expect(isInTimeFrameForRaid(), isA<bool>());
+      });
+
+      test('isInTimeFrameForClanGames returns a bool', () {
+        expect(isInTimeFrameForClanGames(), isA<bool>());
+      });
+
+      test('isInTimeFrameForCwl returns a bool', () {
+        expect(isInTimeFrameForCwl(), isA<bool>());
+      });
+    });
+
+    group('progress getters', () {
+      test('requiredSeasonPassPoints returns an int within range', () {
+        expect(requiredSeasonPassPoints, isA<int>());
+        expect(requiredSeasonPassPoints, greaterThanOrEqualTo(0));
+        expect(requiredSeasonPassPoints, lessThanOrEqualTo(2600));
+      });
+
+      test('requiredClanGamesPoints returns a non-negative int', () {
+        expect(requiredClanGamesPoints, isA<int>());
+        expect(requiredClanGamesPoints, greaterThanOrEqualTo(0));
+      });
+    });
+  });
+}

--- a/test/core/functions/legend_functions_test.dart
+++ b/test/core/functions/legend_functions_test.dart
@@ -1,0 +1,156 @@
+import 'package:clashkingapp/core/functions/legend_functions.dart';
+import 'package:clashkingapp/features/player/models/player_legend_day.dart';
+import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final PlayerLegendDay _dummyLegendDay = PlayerLegendDay.fromJson({});
+
+Future<BuildContext> _pumpLocalizedApp(WidgetTester tester) async {
+  late BuildContext context;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (buildContext) {
+          context = buildContext;
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return context;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('legend_functions.dart utilities', () {
+    group('convertToTimeAgo', () {
+      testWidgets('returns localized relative time text', (tester) async {
+        final context = await _pumpLocalizedApp(tester);
+        final localizations = AppLocalizations.of(context)!;
+        final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        expect(
+          convertToTimeAgo(nowSeconds - 30, context),
+          localizations.timeJustNow,
+        );
+        expect(
+          convertToTimeAgo(nowSeconds - 60, context),
+          localizations.timeMinuteAgo(1),
+        );
+        expect(
+          convertToTimeAgo(nowSeconds - (2 * 3600), context),
+          localizations.timeHoursAgo(2),
+        );
+        expect(
+          convertToTimeAgo(nowSeconds - (2 * 86400), context),
+          localizations.timeDaysAgo(2),
+        );
+      });
+    });
+
+    group('findSeasonStartDate', () {
+      test('returns the last Monday of the previous month before rollover', () {
+        final result = findSeasonStartDate(DateTime(2025, 5, 15));
+
+        expect(result.weekday, DateTime.monday);
+        expect(result.year, 2025);
+        expect(result.month, 4);
+        expect(result.day, 28);
+      });
+
+      test(
+        'returns the last Monday of the current month during the season',
+        () {
+          final result = findSeasonStartDate(DateTime(2025, 5, 30));
+
+          expect(result.weekday, DateTime.monday);
+          expect(result.year, 2025);
+          expect(result.month, 5);
+          expect(result.day, 26);
+        },
+      );
+    });
+
+    group('convertToContinuousScale', () {
+      test('returns an empty list for empty data', () {
+        final spots = convertToContinuousScale({}, DateTime.utc(2025, 4, 28));
+
+        expect(spots, isEmpty);
+      });
+
+      test('converts season data to continuous FlSpot values', () {
+        final spots = convertToContinuousScale({
+          '28': '5000',
+          '30': '5100',
+          '1': '5200',
+        }, DateTime.utc(2025, 4, 28));
+
+        expect(spots, hasLength(3));
+        expect(spots[0], isA<FlSpot>());
+        expect(spots[0].x, 0.0);
+        expect(spots[0].y, 5000.0);
+        expect(spots[1].x, 2.0);
+        expect(spots[1].y, 5100.0);
+        expect(spots[2].x, 3.0);
+        expect(spots[2].y, 5200.0);
+      });
+    });
+
+    group('findSeasonStartEndDate', () {
+      test('returns two dates for a date before the current season start', () {
+        final range = findSeasonStartEndDate(DateTime(2025, 5, 15));
+
+        expect(range, hasLength(2));
+        expect(range[0], DateTime(2025, 4, 28));
+        expect(range[0].weekday, DateTime.monday);
+        expect(range[1], DateTime(2025, 5, 25));
+        expect(range[1].isAfter(range[0]), isTrue);
+      });
+
+      test(
+        'returns Monday boundaries for a date inside the current season',
+        () {
+          final range = findSeasonStartEndDate(DateTime(2025, 5, 30));
+
+          expect(range, hasLength(2));
+          expect(range[0], DateTime(2025, 5, 26));
+          expect(range[0].weekday, DateTime.monday);
+          expect(range[1], DateTime(2025, 6, 30));
+          expect(range[1].weekday, DateTime.monday);
+        },
+      );
+    });
+
+    group('findCurrentSeasonMonth', () {
+      test('returns the first day of the season month', () {
+        final result = findCurrentSeasonMonth(DateTime(2025, 5, 15));
+
+        expect(result.year, 2025);
+        expect(result.month, 5);
+        expect(result.day, 1);
+      });
+    });
+
+    group('getLastMonthWithSeasonData', () {
+      test('returns the most recent month from season data', () {
+        final result = getLastMonthWithSeasonData({
+          '1-15': _dummyLegendDay,
+          '4-20': _dummyLegendDay,
+        });
+
+        expect(result.year, DateTime.now().year);
+        expect(result.month, 4);
+        expect(result.day, 1);
+      });
+
+      test('throws when season data is empty', () {
+        expect(() => getLastMonthWithSeasonData({}), throwsA(isA<Exception>()));
+      });
+    });
+  });
+}

--- a/test/core/services/api_service_test.dart
+++ b/test/core/services/api_service_test.dart
@@ -21,7 +21,7 @@ void main() {
       const input =
           'https://api-assets.clashofclans.com/leagues/256/image.png';
       final result = ApiService.cocAssetsProxyUrl(input);
-      expect(result, startsWith('https://coc-assets.clashk.ing/'));
+      expect(result, startsWith('https://proxy.clashk.ing/images/'));
       expect(result, isNot(contains('clashofclans.com')));
     });
 
@@ -45,7 +45,7 @@ void main() {
 
     test('FormatException returns format message', () {
       expect(
-        ApiService.getErrorMessage(FormatException('bad payload')),
+        ApiService.getErrorMessage(const FormatException('bad payload')),
         'Invalid response format.',
       );
     });

--- a/test/features/player/player_legend_card_test.dart
+++ b/test/features/player/player_legend_card_test.dart
@@ -1,0 +1,187 @@
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/coc_accounts/data/coc_account_service.dart';
+import 'package:clashkingapp/features/pages/widgets/player_legend_card.dart';
+import 'package:clashkingapp/features/player/data/player_service.dart';
+import 'package:clashkingapp/features/player/models/player.dart';
+import 'package:clashkingapp/features/player/models/player_clan.dart';
+import 'package:clashkingapp/features/player/models/player_legend_day.dart';
+import 'package:clashkingapp/features/player/models/player_legend_season.dart';
+import 'package:clashkingapp/features/player/models/player_legend_stats.dart';
+import 'package:clashkingapp/features/player/models/player_rankings.dart';
+import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+PlayerLegendSeason _buildSeason(PlayerLegendDay? currentDay) {
+  final now = DateTime.now();
+  final adjustedNow = now.toUtc().hour < 5
+      ? now.toUtc().subtract(const Duration(days: 1))
+      : now.toUtc();
+  final todayKey = adjustedNow.toIso8601String().split('T').first;
+
+  return PlayerLegendSeason(
+    start: now.subtract(const Duration(days: 1)),
+    end: now.add(const Duration(days: 30)),
+    dayOfSeason: 1,
+    duration: 30,
+    daysInLegend: currentDay == null ? 0 : 1,
+    endTrophies: 5500,
+    trophiesGainedTotal: currentDay?.trophiesGainedTotal ?? 0,
+    trophiesLostTotal: currentDay?.trophiesLostTotal ?? 0,
+    trophiesNet: currentDay?.trophiesTotal ?? 0,
+    trophiesNetRevised: currentDay?.trophiesTotal ?? 0,
+    totalAttacks: currentDay?.totalAttacks ?? 0,
+    totalDefenses: currentDay?.totalDefenses ?? 0,
+    avgGainedPerAttack: 0,
+    avgLostPerDefense: 0,
+    totalPossible: 0,
+    gainedLostPossible: 0,
+    gainedRatio: 0,
+    lostRatio: 0,
+    attackRatio: 0,
+    defenseRatio: 0,
+    days: currentDay == null ? {} : {todayKey: currentDay},
+    attackStarsDistribution: const {},
+    defenseStarsDistribution: const {},
+    attackStarsDistributionPercentages: const {},
+    defenseStarsDistributionPercentages: const {},
+  );
+}
+
+Player _buildPlayer({required String league, PlayerLegendDay? currentDay}) {
+  return Player(
+    name: 'Player',
+    tag: '#PLAYER',
+    townHallLevel: 16,
+    townHallWeaponLevel: 0,
+    expLevel: 200,
+    trophies: 5500,
+    bestTrophies: 5500,
+    warStars: 0,
+    attackWins: 0,
+    defenseWins: 0,
+    builderHallLevel: 0,
+    builderBaseTrophies: 0,
+    bestBuilderBaseTrophies: 0,
+    achievements: const [],
+    clanTag: '',
+    clanOverview: PlayerClanOverview.empty(),
+    role: '',
+    warPreference: '',
+    donations: 0,
+    donationsReceived: 0,
+    clanCapitalContributions: 0,
+    league: league,
+    townHallPic: ImageAssets.townHall(16),
+    builderHallPic: ImageAssets.builderHall(1),
+    leagueUrl: '',
+    clanGamesPoint: const [],
+    seasonPass: const [],
+    lastOnline: DateTime.now(),
+    heroes: const [],
+    bbHeroes: const [],
+    troops: const [],
+    superTroops: const [],
+    bbTroops: const [],
+    spells: const [],
+    equipments: const [],
+    siegeMachines: const [],
+    pets: const [],
+    legendsBySeason: PlayerLegendStats(
+      seasons: {'current': _buildSeason(currentDay)},
+    ),
+    rankings: PlayerRankings(
+      tag: '#PLAYER',
+      countryCode: 'us',
+      countryName: 'United States',
+      localRank: 123,
+      globalRank: 456,
+    ),
+    legendRanking: const [],
+  );
+}
+
+Future<Widget> _buildTestApp(Player player) async {
+  FlutterSecureStorage.setMockInitialValues({});
+  final playerService = PlayerService();
+  playerService.profiles.add(player);
+
+  final cocAccountService = CocAccountService();
+  cocAccountService.addLocalAccount({'player_tag': player.tag});
+  await cocAccountService.setSelectedTag(player.tag);
+
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<PlayerService>.value(value: playerService),
+      ChangeNotifierProvider<CocAccountService>.value(value: cocAccountService),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: PlayerLegendCard()),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PlayerLegendCard', () {
+    testWidgets('renders ranking and trophies chips for current day data', (
+      tester,
+    ) async {
+      final currentDay = PlayerLegendDay.fromJson({
+        'trophies_gained_total': 120,
+        'trophies_lost_total': 80,
+        'trophies_total': 40,
+        'num_attacks': 4,
+        'num_defenses': 3,
+        'start_trophies': 5500,
+      });
+
+      await tester.pumpWidget(
+        await _buildTestApp(
+          _buildPlayer(league: 'Legend League', currentDay: currentDay),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('123'), findsOneWidget);
+      expect(find.text('456'), findsOneWidget);
+      expect(find.text('+40'), findsOneWidget);
+    });
+
+    testWidgets(
+      'renders zero-state legend chips when current day data is missing',
+      (tester) async {
+        await tester.pumpWidget(
+          await _buildTestApp(
+            _buildPlayer(league: 'Legend League', currentDay: null),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('123'), findsOneWidget);
+        expect(find.text('456'), findsOneWidget);
+        expect(find.text('0'), findsWidgets);
+      },
+    );
+
+    testWidgets('renders no-data text for non-legend players', (tester) async {
+      await tester.pumpWidget(
+        await _buildTestApp(
+          _buildPlayer(league: 'Titan League I', currentDay: null),
+        ),
+      );
+      await tester.pump();
+
+      final context = tester.element(find.byType(PlayerLegendCard));
+      expect(
+        find.text(AppLocalizations.of(context)!.legendsNoDataToday),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Enable lint rules: prefer_const_constructors, prefer_const_constructors_in_immutables, prefer_const_literals_to_create_immutables, prefer_final_fields, use_key_in_widget_constructors (were all disabled, causing ~850 Sonar code smells)
- Run dart fix --apply: 855 automatic const/final/key fixes across 119 files
- Vulnerability (S5324): replace getExternalStorageDirectory() with getDownloadsDirectory() ?? getApplicationDocumentsDirectory() in excel_download_icon.dart to avoid unsafe Android external storage access
- Security hotspot (xss/others): restrict WebView navigation in features_vote.dart to features.vote domain only via onNavigationRequest callback
- Duplicate literals (S1192):
  - player_achievement_page.dart: extract 'Keep Your Account Safe!', 'Dragon Slayer', 'Ungrateful Child' to private constants
  - clan_capital_raid.dart: extract '#,###' format string to constant
  - player_legend_card.dart: extract '#,###' format string to constant
  - war_stats_filter_dialog.dart: extract 'All Time' fallback to constant
- S2933: make _isLoadingFiltered final in war_stats_page.dart
- Fix outdated test: update cocAssetsProxyUrl test to current proxy.clashk.ing/images URL