### PR TITLE
feat: clan info tabs (Composition, Top Players, Activity) + hero sort + member search

### DIFF
--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -40,6 +40,7 @@ class ClanService extends ChangeNotifier {
   final Map<String, List<Map<String, dynamic>>> _seasonalDonations = {};
   final Map<String, Map<String, dynamic>> _clanCompositions = {};
   final Map<String, Map<String, dynamic>> _seasonTopPerformers = {};
+  final Map<String, ClanJoinLeave> _singleClanJoinLeave = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -707,6 +708,17 @@ class ClanService extends ChangeNotifier {
       }
     } catch (e) {
       Sentry.captureException(e);
+    }
+  }
+
+  ClanJoinLeave? getSingleClanJoinLeave(String clanTag) => _singleClanJoinLeave[clanTag];
+
+  Future<void> fetchSingleClanJoinLeave(String clanTag) async {
+    if (_singleClanJoinLeave.containsKey(clanTag)) return;
+    final result = await _fetchSingleClanJoinLeave(clanTag);
+    if (result != null) {
+      _singleClanJoinLeave[clanTag] = result;
+      _safeNotify();
     }
   }
 

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -42,6 +42,9 @@ class ClanService extends ChangeNotifier {
   final Map<String, Map<String, dynamic>> _seasonTopPerformers = {};
   final Map<String, ClanJoinLeave> _singleClanJoinLeave = {};
   final Map<String, List<String>> _memberTagOrder = {};
+  final Map<String, List<Map<String, dynamic>>> _clanLegendDay = {};
+  final Map<String, Map<String, dynamic>> _clanGames = {};
+  final Map<String, List<Map<String, dynamic>>> _clanWarOpt = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -809,6 +812,78 @@ class ClanService extends ChangeNotifier {
         final data = jsonDecode(ApiService.decodeResponseBody(response));
         _clanRankings[clanTag] = data as Map<String, dynamic>;
         _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  List<Map<String, dynamic>>? getClanWarOpt(String clanTag) =>
+      _clanWarOpt[clanTag];
+
+  Future<void> fetchClanWarOpt(String clanTag) async {
+    if (_clanWarOpt.containsKey(clanTag)) return;
+    try {
+      final encodedTag = Uri.encodeComponent(clanTag);
+      final response = await _apiService.getResponse(
+        '/clan/$encodedTag/war-opt',
+        requiresAuth: false,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        final items = (data['items'] as List<dynamic>? ?? [])
+            .cast<Map<String, dynamic>>();
+        _clanWarOpt[clanTag] = items;
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  List<Map<String, dynamic>>? getClanLegendDay(String clanTag, String day) =>
+      _clanLegendDay['$clanTag/$day'];
+
+  Map<String, dynamic>? getClanGames(String clanTag, String season) =>
+      _clanGames['$clanTag/$season'];
+
+  Future<void> fetchClanGames(String clanTag, String season) async {
+    final key = '$clanTag/$season';
+    if (_clanGames.containsKey(key)) return;
+    try {
+      final encodedTag = Uri.encodeComponent(clanTag);
+      final response = await _apiService.getResponse(
+        '/clan/$encodedTag/games/$season',
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        _clanGames[key] = data as Map<String, dynamic>;
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  Future<void> fetchClanLegendDay(
+      String clanTag, String day, List<String> playerTags) async {
+    final key = '$clanTag/$day';
+    if (_clanLegendDay.containsKey(key) || playerTags.isEmpty) return;
+    try {
+      final query = playerTags
+          .map((t) => 'players=${Uri.encodeQueryComponent(t)}')
+          .join('&');
+      final response = await _apiService.getResponse(
+        '/legends/players/day/$day?$query',
+        requiresAuth: false,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        if (data is List) {
+          _clanLegendDay[key] = data.cast<Map<String, dynamic>>();
+          _safeNotify();
+        }
       }
     } catch (e) {
       Sentry.captureException(e);

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -41,6 +41,7 @@ class ClanService extends ChangeNotifier {
   final Map<String, Map<String, dynamic>> _clanCompositions = {};
   final Map<String, Map<String, dynamic>> _seasonTopPerformers = {};
   final Map<String, ClanJoinLeave> _singleClanJoinLeave = {};
+  final Map<String, List<String>> _memberTagOrder = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -704,6 +705,32 @@ class ClanService extends ChangeNotifier {
         final data = jsonDecode(ApiService.decodeResponseBody(response));
         _seasonalDonations[key] =
             (data['items'] as List<dynamic>).cast<Map<String, dynamic>>();
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  List<String>? getMemberTagOrder(String clanTag, String attribute) =>
+      _memberTagOrder['$clanTag/$attribute'];
+
+  Future<void> fetchMembersSortedBy(
+      String clanTag, String attribute, List<String> memberTags) async {
+    final key = '$clanTag/$attribute';
+    if (_memberTagOrder.containsKey(key)) return;
+    try {
+      final encodedAttr = Uri.encodeComponent(attribute);
+      final response = await _apiService.postResponse(
+        '/players/sorted/$encodedAttr',
+        body: {'player_tags': memberTags},
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        final items = (data['items'] as List<dynamic>? ?? []);
+        _memberTagOrder[key] =
+            items.map((e) => (e as Map)['tag']?.toString() ?? '').toList();
         _safeNotify();
       }
     } catch (e) {

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -38,6 +38,8 @@ class ClanService extends ChangeNotifier {
   List<ClanWarStats> warStatsList = [];
   final Map<String, Map<String, dynamic>> _clanRankings = {};
   final Map<String, List<Map<String, dynamic>>> _seasonalDonations = {};
+  final Map<String, Map<String, dynamic>> _clanCompositions = {};
+  final Map<String, Map<String, dynamic>> _seasonTopPerformers = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -701,6 +703,56 @@ class ClanService extends ChangeNotifier {
         final data = jsonDecode(ApiService.decodeResponseBody(response));
         _seasonalDonations[key] =
             (data['items'] as List<dynamic>).cast<Map<String, dynamic>>();
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  Map<String, dynamic>? getClanComposition(String clanTag) => _clanCompositions[clanTag];
+
+  Map<String, dynamic>? getSeasonTopPerformers(String clanTag, String season) =>
+      _seasonTopPerformers['$clanTag/$season'];
+
+  Future<void> fetchSeasonTopPerformers(
+      String clanTag, String season, List<String> memberTags) async {
+    final key = '$clanTag/$season';
+    if (_seasonTopPerformers.containsKey(key)) return;
+    try {
+      final response = await _apiService.postResponse(
+        '/players/summary/$season/top?limit=5',
+        body: {'player_tags': memberTags},
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        // Flatten list of {category: [items]} into a single map
+        final Map<String, dynamic> result = {};
+        for (final entry in (data['items'] as List<dynamic>? ?? [])) {
+          if (entry is Map<String, dynamic>) {
+            result.addAll(entry);
+          }
+        }
+        _seasonTopPerformers[key] = result;
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  Future<void> fetchClanComposition(String clanTag) async {
+    if (_clanCompositions.containsKey(clanTag)) return;
+    try {
+      final encodedTag = Uri.encodeComponent(clanTag);
+      final response = await _apiService.getResponse(
+        '/clan/compo?clan_tags=$encodedTag',
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        _clanCompositions[clanTag] = data as Map<String, dynamic>;
         _safeNotify();
       }
     } catch (e) {

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -45,6 +45,7 @@ class ClanService extends ChangeNotifier {
   final Map<String, List<Map<String, dynamic>>> _clanLegendDay = {};
   final Map<String, Map<String, dynamic>> _clanGames = {};
   final Map<String, List<Map<String, dynamic>>> _clanWarOpt = {};
+  final Map<String, List<Map<String, dynamic>>> _clanMemberLocations = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -834,6 +835,30 @@ class ClanService extends ChangeNotifier {
         final items = (data['items'] as List<dynamic>? ?? [])
             .cast<Map<String, dynamic>>();
         _clanWarOpt[clanTag] = items;
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
+
+  List<Map<String, dynamic>>? getClanMemberLocations(String clanTag) =>
+      _clanMemberLocations[clanTag];
+
+  Future<void> fetchClanMemberLocations(
+      String clanTag, List<String> playerTags) async {
+    if (_clanMemberLocations.containsKey(clanTag) || playerTags.isEmpty) return;
+    try {
+      final response = await _apiService.postResponse(
+        '/players/location',
+        body: {'player_tags': playerTags},
+        requiresAuth: false,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        final items = (data['items'] as List<dynamic>? ?? [])
+            .cast<Map<String, dynamic>>();
+        _clanMemberLocations[clanTag] = items;
         _safeNotify();
       }
     } catch (e) {

--- a/lib/features/clan/presentation/clan_info/clan_activity_tab.dart
+++ b/lib/features/clan/presentation/clan_info/clan_activity_tab.dart
@@ -1,0 +1,73 @@
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
+import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:clashkingapp/features/clan/presentation/join_leave/clan_join_leave_events.dart';
+import 'package:clashkingapp/features/clan/presentation/join_leave/clan_join_leave_stats.dart';
+import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class ClanActivityTab extends StatefulWidget {
+  final Clan clanInfo;
+
+  const ClanActivityTab({super.key, required this.clanInfo});
+
+  @override
+  State<ClanActivityTab> createState() => _ClanActivityTabState();
+}
+
+class _ClanActivityTabState extends State<ClanActivityTab> {
+  bool _showEvents = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // Prefer pre-loaded data from the main flow; otherwise fetch on demand.
+      final svc = context.read<ClanService>();
+      if ((widget.clanInfo.joinLeave?.joinLeaveList.isEmpty ?? true) &&
+          svc.getSingleClanJoinLeave(widget.clanInfo.tag) == null) {
+        svc.fetchSingleClanJoinLeave(widget.clanInfo.tag);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final svc = context.watch<ClanService>();
+
+    // Prefer the pre-loaded data from clan.joinLeave (main dashboard flow).
+    // Fall back to on-demand fetched data (search / direct open).
+    final jl = (widget.clanInfo.joinLeave?.joinLeaveList.isNotEmpty ?? false)
+        ? widget.clanInfo.joinLeave
+        : svc.getSingleClanJoinLeave(widget.clanInfo.tag);
+
+    if (jl == null) {
+      return const Padding(
+        padding: EdgeInsets.all(32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: SegmentedButton<bool>(
+            segments: [
+              ButtonSegment(value: false, label: Text(loc.generalStats)),
+              ButtonSegment(value: true, label: Text(loc.warEventsTitle)),
+            ],
+            selected: {_showEvents},
+            onSelectionChanged: (s) => setState(() => _showEvents = s.first),
+          ),
+        ),
+        if (_showEvents)
+          ClanJoinLeaveEvents(joinLeaveClan: jl)
+        else
+          ClanJoinLeaveStats(joinLeaveClan: jl),
+      ],
+    );
+  }
+}

--- a/lib/features/clan/presentation/clan_info/clan_composition_tab.dart
+++ b/lib/features/clan/presentation/clan_info/clan_composition_tab.dart
@@ -1,0 +1,213 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class ClanCompositionTab extends StatefulWidget {
+  final String clanTag;
+
+  const ClanCompositionTab({super.key, required this.clanTag});
+
+  @override
+  State<ClanCompositionTab> createState() => _ClanCompositionTabState();
+}
+
+class _ClanCompositionTabState extends State<ClanCompositionTab> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<ClanService>().fetchClanComposition(widget.clanTag);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final compo = context.watch<ClanService>().getClanComposition(widget.clanTag);
+
+    if (compo == null) {
+      return const Padding(
+        padding: EdgeInsets.all(32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final townhall = Map<String, int>.from(
+      (compo['townhall'] as Map? ?? {}).map((k, v) => MapEntry(k.toString(), (v as num).toInt())),
+    );
+    final league = Map<String, int>.from(
+      (compo['league'] as Map? ?? {}).map((k, v) => MapEntry(k.toString(), (v as num).toInt())),
+    );
+    final location = Map<String, int>.from(
+      (compo['location'] as Map? ?? {}).map((k, v) => MapEntry(k.toString(), (v as num).toInt())),
+    );
+    final countryMap = Map<String, String>.from(
+      (compo['country_map'] as Map? ?? {}).map((k, v) => MapEntry(k.toString(), v.toString())),
+    );
+    final total = (compo['total_members'] as num? ?? 1).toInt();
+
+    final sortedTH = townhall.entries.toList()
+      ..sort((a, b) {
+        final ia = int.tryParse(a.key) ?? 0;
+        final ib = int.tryParse(b.key) ?? 0;
+        return ib.compareTo(ia);
+      });
+
+    final leagueOrder = [
+      'Legend League',
+      'Titan League I', 'Titan League II', 'Titan League III',
+      'Champion League I', 'Champion League II', 'Champion League III',
+      'Master League I', 'Master League II', 'Master League III',
+      'Crystal League I', 'Crystal League II', 'Crystal League III',
+      'Gold League I', 'Gold League II', 'Gold League III',
+      'Silver League I', 'Silver League II', 'Silver League III',
+      'Bronze League I', 'Bronze League II', 'Bronze League III',
+      'Unranked',
+    ];
+    final sortedLeagues = league.entries.toList()
+      ..sort((a, b) {
+        final ia = leagueOrder.indexOf(a.key);
+        final ib = leagueOrder.indexOf(b.key);
+        return (ia == -1 ? 99 : ia).compareTo(ib == -1 ? 99 : ib);
+      });
+
+    final sortedCountries = location.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionTitle('Town Hall'),
+          const SizedBox(height: 6),
+          ...sortedTH.map((e) => _BarRow(
+            leading: CachedNetworkImage(
+              imageUrl: ImageAssets.townHall(int.tryParse(e.key) ?? 1),
+              width: 28,
+              height: 28,
+              errorWidget: (ctx, url, err) => const Icon(Icons.error, size: 20),
+            ),
+            label: 'TH${e.key}',
+            count: e.value,
+            total: total,
+          )),
+          const SizedBox(height: 16),
+          _SectionTitle('League'),
+          const SizedBox(height: 6),
+          ...sortedLeagues.map((e) => _BarRow(
+            leading: CachedNetworkImage(
+              imageUrl: ImageAssets.getLeagueImage(e.key),
+              width: 28,
+              height: 28,
+              errorWidget: (ctx, url, err) => const Icon(Icons.error, size: 20),
+            ),
+            label: e.key,
+            count: e.value,
+            total: total,
+          )),
+          if (sortedCountries.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionTitle('Countries'),
+            const SizedBox(height: 6),
+            ...sortedCountries.take(15).map((e) {
+              final code = e.key;
+              final name = countryMap[code] ?? code;
+              return _BarRow(
+                leading: CachedNetworkImage(
+                  imageUrl: ImageAssets.flag(code),
+                  width: 28,
+                  height: 20,
+                  errorWidget: (ctx, url, err) =>
+                      const Icon(Icons.flag, size: 20),
+                ),
+                label: name,
+                count: e.value,
+                total: total,
+              );
+            }),
+          ],
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String text;
+  const _SectionTitle(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+    );
+  }
+}
+
+class _BarRow extends StatelessWidget {
+  final Widget leading;
+  final String label;
+  final int count;
+  final int total;
+
+  const _BarRow({
+    required this.leading,
+    required this.label,
+    required this.count,
+    required this.total,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fraction = total > 0 ? count / total : 0.0;
+    final pct = (fraction * 100).round();
+    final barColor = Theme.of(context).colorScheme.primary;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          SizedBox(width: 32, child: Center(child: leading)),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: 100,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: fraction.toDouble(),
+                minHeight: 14,
+                backgroundColor: barColor.withAlpha(30),
+                valueColor: AlwaysStoppedAnimation<Color>(barColor),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: 42,
+            child: Text(
+              '$count ($pct%)',
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.right,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/clan/presentation/clan_info/clan_games_tab.dart
+++ b/lib/features/clan/presentation/clan_info/clan_games_tab.dart
@@ -1,0 +1,242 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
+import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+List<String> _recentGameSeasons({int count = 6}) {
+  final now = DateTime.now().toUtc();
+  return List.generate(count, (i) {
+    final dt = DateTime(now.year, now.month - i, 1);
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}';
+  });
+}
+
+class ClanGamesTab extends StatefulWidget {
+  final Clan clanInfo;
+
+  const ClanGamesTab({super.key, required this.clanInfo});
+
+  @override
+  State<ClanGamesTab> createState() => _ClanGamesTabState();
+}
+
+class _ClanGamesTabState extends State<ClanGamesTab> {
+  late String _selectedSeason;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now().toUtc();
+    _selectedSeason =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}';
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context
+            .read<ClanService>()
+            .fetchClanGames(widget.clanInfo.tag, _selectedSeason);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final clanService = context.watch<ClanService>();
+    final gamesData =
+        clanService.getClanGames(widget.clanInfo.tag, _selectedSeason);
+
+    final nameMap = {
+      for (final m in widget.clanInfo.memberList) m.tag: m.name,
+    };
+    final thMap = {
+      for (final m in widget.clanInfo.memberList) m.tag: m.townHallLevel,
+    };
+
+    final seasons = _recentGameSeasons();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Season selector
+        Padding(
+          padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+          child: SizedBox(
+            height: 32,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              itemCount: seasons.length,
+              separatorBuilder: (ctx, i) => const SizedBox(width: 6),
+              itemBuilder: (context, i) {
+                final season = seasons[i];
+                final parts = season.split('-');
+                final label = parts.length == 2
+                    ? DateFormat('MMM yy').format(
+                        DateTime(
+                            int.parse(parts[0]), int.parse(parts[1])))
+                    : season;
+                final isSelected = _selectedSeason == season;
+                return ChoiceChip(
+                  label: Text(label),
+                  selected: isSelected,
+                  onSelected: (_) {
+                    if (!isSelected) {
+                      setState(() => _selectedSeason = season);
+                      context
+                          .read<ClanService>()
+                          .fetchClanGames(widget.clanInfo.tag, season);
+                    }
+                  },
+                  labelStyle: TextStyle(
+                    fontSize: 11,
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.onPrimary
+                        : Theme.of(context).colorScheme.onSurface,
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _buildBody(context, gamesData, nameMap, thMap),
+      ],
+    );
+  }
+
+  Widget _buildBody(
+    BuildContext context,
+    Map<String, dynamic>? gamesData,
+    Map<String, String> nameMap,
+    Map<String, int> thMap,
+  ) {
+    if (gamesData == null) {
+      return const Padding(
+        padding: EdgeInsets.all(32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final tracked = gamesData['tracked'] as bool? ?? false;
+    if (!tracked) {
+      return Padding(
+        padding: const EdgeInsets.all(32),
+        child: Center(
+          child: Text(
+            'Clan Games not tracked for this clan yet',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final items = (gamesData['items'] as List<dynamic>? ?? [])
+        .cast<Map<String, dynamic>>();
+
+    if (items.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(32),
+        child: Center(
+          child: Text(
+            'No Clan Games data for $_selectedSeason',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final maxPoints = items
+        .map((e) => (e['points'] as num? ?? 0).toInt())
+        .reduce((a, b) => a > b ? a : b);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Column(
+        children: items.asMap().entries.map((entry) {
+          final i = entry.key;
+          final e = entry.value;
+          final tag = e['tag'] as String? ?? '';
+          final points = (e['points'] as num? ?? 0).toInt();
+          final name = nameMap[tag] ?? tag;
+          final th = thMap[tag] ?? 0;
+          final fraction = maxPoints > 0 ? points / maxPoints : 0.0;
+
+          return Card(
+            margin: const EdgeInsets.only(bottom: 6),
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 24,
+                    child: Text(
+                      '${i + 1}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  if (th > 0)
+                    CachedNetworkImage(
+                      imageUrl: ImageAssets.townHall(th),
+                      width: 32,
+                      height: 32,
+                      errorWidget: (ctx, url, err) =>
+                          const SizedBox(width: 32),
+                    )
+                  else
+                    const SizedBox(width: 32),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          name,
+                          style:
+                              Theme.of(context).textTheme.bodyMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 4),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: fraction.toDouble(),
+                            minHeight: 8,
+                            backgroundColor: Theme.of(context)
+                                .colorScheme
+                                .primary
+                                .withValues(alpha: 0.2),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _formatPoints(points),
+                    style:
+                        Theme.of(context).textTheme.bodySmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  String _formatPoints(int pts) =>
+      pts >= 1000 ? '${(pts / 1000).toStringAsFixed(1)}k' : '$pts';
+}

--- a/lib/features/clan/presentation/clan_info/clan_legend_tab.dart
+++ b/lib/features/clan/presentation/clan_info/clan_legend_tab.dart
@@ -1,0 +1,294 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
+import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:clashkingapp/features/clan/models/clan_member.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+class ClanLegendTab extends StatefulWidget {
+  final Clan clanInfo;
+
+  const ClanLegendTab({super.key, required this.clanInfo});
+
+  @override
+  State<ClanLegendTab> createState() => _ClanLegendTabState();
+}
+
+class _ClanLegendTabState extends State<ClanLegendTab> {
+  late final String _todayKey;
+  late final List<ClanMember> _legendMembers;
+
+  @override
+  void initState() {
+    super.initState();
+    // CoC legend day resets at 05:00 UTC
+    final cocNow = DateTime.now().toUtc().subtract(const Duration(hours: 5));
+    _todayKey = DateFormat('yyyy-MM-dd').format(cocNow);
+
+    _legendMembers = widget.clanInfo.memberList
+        .where((m) => m.league.name == 'Legend League')
+        .toList()
+      ..sort((a, b) => b.trophies.compareTo(a.trophies));
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _legendMembers.isNotEmpty) {
+        context.read<ClanService>().fetchClanLegendDay(
+              widget.clanInfo.tag,
+              _todayKey,
+              _legendMembers.map((m) => m.tag).toList(),
+            );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_legendMembers.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CachedNetworkImage(
+                imageUrl: ImageAssets.legendBlazon,
+                width: 64,
+                height: 64,
+                errorWidget: (ctx, url, err) => const Icon(Icons.emoji_events, size: 64),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'No Legend League players in this clan',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final clanService = context.watch<ClanService>();
+    final dayData = clanService.getClanLegendDay(widget.clanInfo.tag, _todayKey);
+
+    // Build lookup: tag → today's day stats
+    final Map<String, Map<String, dynamic>> statsMap = {};
+    if (dayData != null) {
+      for (final player in dayData) {
+        final tag = player['tag'] as String? ?? '';
+        final legends = player['legends'] as Map<String, dynamic>? ?? {};
+        final todayStats = legends[_todayKey] as Map<String, dynamic>?;
+        if (tag.isNotEmpty && todayStats != null) {
+          statsMap[tag] = todayStats;
+        }
+      }
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CachedNetworkImage(
+                imageUrl: ImageAssets.legendBlazon,
+                width: 24,
+                height: 24,
+                errorWidget: (ctx, url, err) => const Icon(Icons.emoji_events, size: 24),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Legend League — ${_legendMembers.length} player${_legendMembers.length == 1 ? '' : 's'}',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 2),
+          Text(
+            _todayKey,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.5),
+                ),
+          ),
+          const SizedBox(height: 12),
+          if (dayData == null)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: CircularProgressIndicator(),
+              ),
+            )
+          else
+            ..._legendMembers.asMap().entries.map((entry) {
+              final rank = entry.key + 1;
+              final member = entry.value;
+              final stats = statsMap[member.tag];
+              return _LegendPlayerCard(
+                rank: rank,
+                member: member,
+                stats: stats,
+              );
+            }),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _LegendPlayerCard extends StatelessWidget {
+  final int rank;
+  final ClanMember member;
+  final Map<String, dynamic>? stats;
+
+  const _LegendPlayerCard({
+    required this.rank,
+    required this.member,
+    required this.stats,
+  });
+
+  int _countAttacks() {
+    if (stats == null) return 0;
+    final atks = stats!['attacks'] as List?;
+    if (atks != null) return atks.length;
+    final n = stats!['num_attacks'] as num?;
+    return n?.toInt() ?? 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final attacksDone = _countAttacks();
+    final hasData = stats != null;
+
+    final gained = hasData
+        ? (stats!['trophies_gained_total'] as num? ?? 0).toInt()
+        : null;
+    final lost = hasData
+        ? (stats!['trophies_lost_total'] as num? ?? 0).toInt()
+        : null;
+    final net = (gained != null && lost != null) ? gained - lost : null;
+
+    final netStr = net == null
+        ? null
+        : net >= 0
+            ? '+$net'
+            : '$net';
+    final netColor = net == null
+        ? Colors.grey
+        : net > 0
+            ? Colors.green
+            : net < 0
+                ? Colors.red
+                : Colors.grey;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 24,
+              child: Text(
+                '$rank',
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(width: 4),
+            CachedNetworkImage(
+              imageUrl: ImageAssets.townHall(member.townHallLevel),
+              width: 32,
+              height: 32,
+              errorWidget: (ctx, url, err) =>
+                  const Icon(Icons.error, size: 20),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    member.name,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  // 8 attack dots
+                  Row(
+                    children: List.generate(8, (i) {
+                      final filled = i < attacksDone;
+                      return Container(
+                        width: 9,
+                        height: 9,
+                        margin: const EdgeInsets.only(right: 2),
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: filled
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context)
+                                  .colorScheme
+                                  .primary
+                                  .withValues(alpha: 0.2),
+                        ),
+                      );
+                    }),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl: ImageAssets.trophies,
+                      width: 14,
+                      height: 14,
+                      errorWidget: (ctx, url, err) =>
+                          const SizedBox(width: 14),
+                    ),
+                    const SizedBox(width: 2),
+                    Text(
+                      '${member.trophies}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+                if (netStr != null)
+                  Text(
+                    netStr,
+                    style:
+                        Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: netColor,
+                              fontWeight: FontWeight.bold,
+                            ),
+                  ),
+                Text(
+                  '$attacksDone/8 atk',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onSurface
+                            .withValues(alpha: 0.6),
+                      ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -33,6 +33,7 @@ class ClanMembers extends StatefulWidget {
 }
 
 const _donationFilters = {'donations', 'donationsReceived', 'donationsRatio'};
+const _warOptFilter = 'warOpt';
 
 // Hero sort keys → CoC attribute path used by /players/sorted/{attribute}
 const _heroSortKeys = {
@@ -66,6 +67,9 @@ class ClanMembersState extends State<ClanMembers> {
       context.read<ClanService>().fetchMembersSortedBy(
             widget.clanInfo.tag, attr, tags);
     }
+    if (newFilter == _warOptFilter) {
+      context.read<ClanService>().fetchClanWarOpt(widget.clanInfo.tag);
+    }
   }
 
   @override
@@ -88,6 +92,7 @@ class ClanMembersState extends State<ClanMembers> {
       'Grand Warden': 'heroGW',
       'Royal Champion': 'heroRC',
       'Minion Prince': 'heroMinion',
+      'War Preference': _warOptFilter,
     };
 
     final cocService = context.watch<CocAccountService>();
@@ -103,6 +108,18 @@ class ClanMembersState extends State<ClanMembers> {
         ? clanService.getMemberTagOrder(
             widget.clanInfo.tag, _heroSortKeys[currentFilter]!)
         : null;
+
+    // War opt: build tag → 'in'/'out' lookup
+    final isWarOptSort = currentFilter == _warOptFilter;
+    final warOptItems = clanService.getClanWarOpt(widget.clanInfo.tag);
+    final Map<String, String> warOptMap = {};
+    if (warOptItems != null) {
+      for (final item in warOptItems) {
+        final tag = item['tag'] as String? ?? '';
+        final pref = item['warPreference'] as String? ?? '';
+        if (tag.isNotEmpty) warOptMap[tag] = pref;
+      }
+    }
 
     // Build a lookup map from tag → {donated, received} for seasonal data
     final Map<String, ({int donated, int received})> seasonLookup = {};
@@ -136,6 +153,11 @@ class ClanMembersState extends State<ClanMembers> {
       };
       members.sort((a, b) =>
           (tagIndex[a.tag] ?? 999).compareTo(tagIndex[b.tag] ?? 999));
+    } else if (isWarOptSort && warOptItems != null) {
+      // in before out, unknown last
+      int optWeight(String pref) => pref == 'in' ? 0 : pref == 'out' ? 1 : 2;
+      members.sort((a, b) =>
+          optWeight(warOptMap[a.tag] ?? '').compareTo(optWeight(warOptMap[b.tag] ?? '')));
     } else {
     members.sort((a, b) {
       switch (currentFilter) {
@@ -165,7 +187,7 @@ class ClanMembersState extends State<ClanMembers> {
           return 0;
       }
     });
-    } // end else (non-hero sort)
+    } // end else (non-hero/non-war-opt sort)
 
     // Apply name/tag search filter
     if (_searchQuery.isNotEmpty) {
@@ -215,6 +237,10 @@ class ClanMembersState extends State<ClanMembers> {
                 sortByOptions: filterOptions,
               ),
               if (isHeroSort && heroTagOrder == null) ...[
+                const SizedBox(height: 4),
+                const LinearProgressIndicator(),
+              ],
+              if (isWarOptSort && warOptItems == null) ...[
                 const SizedBox(height: 4),
                 const LinearProgressIndicator(),
               ],
@@ -349,7 +375,7 @@ class ClanMembersState extends State<ClanMembers> {
                       ),
                       Expanded(
                         flex: 3,
-                        child: _buildStatColumn(member, getDonated, getReceived),
+                        child: _buildStatColumn(member, getDonated, getReceived, warOptMap),
                       ),
                     ],
                   ),
@@ -365,6 +391,7 @@ class ClanMembersState extends State<ClanMembers> {
     ClanMember member,
     int Function(ClanMember) getDonated,
     int Function(ClanMember) getReceived,
+    Map<String, String> warOptMap,
   ) {
     switch (currentFilter) {
       case 'expLevel':
@@ -408,6 +435,18 @@ class ClanMembersState extends State<ClanMembers> {
       case 'townHallLevel':
         return _iconText(
             member.league.tinyIconUrl ?? "", member.trophies.toString());
+      case _warOptFilter:
+        final pref = warOptMap[member.tag] ?? '';
+        final isIn = pref == 'in';
+        final isOut = pref == 'out';
+        return _iconText(
+          isIn
+              ? ImageAssets.warPreferenceIn
+              : isOut
+                  ? ImageAssets.warPreferenceOut
+                  : ImageAssets.warPreferenceOut,
+          isIn ? 'In' : isOut ? 'Out' : '—',
+        );
       default:
         return const SizedBox.shrink();
     }

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -46,6 +46,14 @@ const _heroSortKeys = {
 class ClanMembersState extends State<ClanMembers> {
   String currentFilter = 'trophies';
   String? _selectedSeason;
+  String _searchQuery = '';
+  final _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
 
   void updateFilter(String newFilter) {
     setState(() {
@@ -159,12 +167,48 @@ class ClanMembersState extends State<ClanMembers> {
     });
     } // end else (non-hero sort)
 
+    // Apply name/tag search filter
+    if (_searchQuery.isNotEmpty) {
+      final q = _searchQuery.toLowerCase();
+      members = members
+          .where((m) =>
+              m.name.toLowerCase().contains(q) ||
+              m.tag.toLowerCase().contains(q))
+          .toList();
+    }
+
     return Column(
       mainAxisSize: MainAxisSize.max,
       children: [
         Center(
           child: Column(
             children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                child: TextField(
+                  controller: _searchController,
+                  decoration: InputDecoration(
+                    hintText: 'Search members…',
+                    prefixIcon: const Icon(Icons.search, size: 20),
+                    suffixIcon: _searchQuery.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear, size: 18),
+                            onPressed: () => setState(() {
+                              _searchQuery = '';
+                              _searchController.clear();
+                            }),
+                          )
+                        : null,
+                    isDense: true,
+                    contentPadding:
+                        const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                    border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24)),
+                  ),
+                  onChanged: (v) => setState(() => _searchQuery = v),
+                ),
+              ),
+              const SizedBox(height: 4),
               FilterDropdown(
                 sortBy: currentFilter,
                 updateSortBy: updateFilter,

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -34,6 +34,15 @@ class ClanMembers extends StatefulWidget {
 
 const _donationFilters = {'donations', 'donationsReceived', 'donationsRatio'};
 
+// Hero sort keys → CoC attribute path used by /players/sorted/{attribute}
+const _heroSortKeys = {
+  'heroBK': 'heroes[name=Barbarian King].level',
+  'heroAQ': 'heroes[name=Archer Queen].level',
+  'heroGW': 'heroes[name=Grand Warden].level',
+  'heroRC': 'heroes[name=Royal Champion].level',
+  'heroMinion': 'heroes[name=Minion Prince].level',
+};
+
 class ClanMembersState extends State<ClanMembers> {
   String currentFilter = 'trophies';
   String? _selectedSeason;
@@ -43,6 +52,12 @@ class ClanMembersState extends State<ClanMembers> {
       currentFilter = newFilter;
       if (!_donationFilters.contains(newFilter)) _selectedSeason = null;
     });
+    if (_heroSortKeys.containsKey(newFilter)) {
+      final attr = _heroSortKeys[newFilter]!;
+      final tags = widget.clanInfo.memberList.map((m) => m.tag).toList();
+      context.read<ClanService>().fetchMembersSortedBy(
+            widget.clanInfo.tag, attr, tags);
+    }
   }
 
   @override
@@ -60,13 +75,25 @@ class ClanMembersState extends State<ClanMembers> {
           'donationsReceived',
       AppLocalizations.of(context)?.gameDonationsRatio ?? 'Donation Ratio':
           'donationsRatio',
+      'Barbarian King': 'heroBK',
+      'Archer Queen': 'heroAQ',
+      'Grand Warden': 'heroGW',
+      'Royal Champion': 'heroRC',
+      'Minion Prince': 'heroMinion',
     };
-    
+
     final cocService = context.watch<CocAccountService>();
     final activeUserTags = cocService.getAccountTags();
     final clanService = context.watch<ClanService>();
     final seasonalData = _selectedSeason != null
         ? clanService.getSeasonalDonations(widget.clanInfo.tag, _selectedSeason!)
+        : null;
+
+    // Hero sort: use API-returned tag order when available
+    final isHeroSort = _heroSortKeys.containsKey(currentFilter);
+    final heroTagOrder = isHeroSort
+        ? clanService.getMemberTagOrder(
+            widget.clanInfo.tag, _heroSortKeys[currentFilter]!)
         : null;
 
     // Build a lookup map from tag → {donated, received} for seasonal data
@@ -95,6 +122,13 @@ class ClanMembersState extends State<ClanMembers> {
 
     List<ClanMember> members = widget.clanInfo.memberList.toList();
 
+    if (isHeroSort && heroTagOrder != null) {
+      final tagIndex = {
+        for (int i = 0; i < heroTagOrder.length; i++) heroTagOrder[i]: i,
+      };
+      members.sort((a, b) =>
+          (tagIndex[a.tag] ?? 999).compareTo(tagIndex[b.tag] ?? 999));
+    } else {
     members.sort((a, b) {
       switch (currentFilter) {
         case 'role':
@@ -123,6 +157,7 @@ class ClanMembersState extends State<ClanMembers> {
           return 0;
       }
     });
+    } // end else (non-hero sort)
 
     return Column(
       mainAxisSize: MainAxisSize.max,
@@ -135,6 +170,10 @@ class ClanMembersState extends State<ClanMembers> {
                 updateSortBy: updateFilter,
                 sortByOptions: filterOptions,
               ),
+              if (isHeroSort && heroTagOrder == null) ...[
+                const SizedBox(height: 4),
+                const LinearProgressIndicator(),
+              ],
               if (_donationFilters.contains(currentFilter)) ...[
                 const SizedBox(height: 4),
                 _SeasonSelector(

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -42,7 +42,9 @@ const _heroSortKeys = {
   'heroGW': 'heroes[name=Grand Warden].level',
   'heroRC': 'heroes[name=Royal Champion].level',
   'heroMinion': 'heroes[name=Minion Prince].level',
+  'heroCumulative': 'cumulative_heroes',
 };
+const _locationFilter = 'memberCountry';
 
 class ClanMembersState extends State<ClanMembers> {
   String currentFilter = 'trophies';
@@ -70,6 +72,10 @@ class ClanMembersState extends State<ClanMembers> {
     if (newFilter == _warOptFilter) {
       context.read<ClanService>().fetchClanWarOpt(widget.clanInfo.tag);
     }
+    if (newFilter == _locationFilter) {
+      final tags = widget.clanInfo.memberList.map((m) => m.tag).toList();
+      context.read<ClanService>().fetchClanMemberLocations(widget.clanInfo.tag, tags);
+    }
   }
 
   @override
@@ -92,7 +98,9 @@ class ClanMembersState extends State<ClanMembers> {
       'Grand Warden': 'heroGW',
       'Royal Champion': 'heroRC',
       'Minion Prince': 'heroMinion',
+      'All Heroes': 'heroCumulative',
       'War Preference': _warOptFilter,
+      'Country': _locationFilter,
     };
 
     final cocService = context.watch<CocAccountService>();
@@ -118,6 +126,17 @@ class ClanMembersState extends State<ClanMembers> {
         final tag = item['tag'] as String? ?? '';
         final pref = item['warPreference'] as String? ?? '';
         if (tag.isNotEmpty) warOptMap[tag] = pref;
+      }
+    }
+
+    // Location: build tag → {country_name, country_code} lookup
+    final isLocationSort = currentFilter == _locationFilter;
+    final locationItems = clanService.getClanMemberLocations(widget.clanInfo.tag);
+    final Map<String, Map<String, dynamic>> locMap = {};
+    if (locationItems != null) {
+      for (final item in locationItems) {
+        final tag = item['tag'] as String? ?? '';
+        if (tag.isNotEmpty) locMap[tag] = item;
       }
     }
 
@@ -158,6 +177,12 @@ class ClanMembersState extends State<ClanMembers> {
       int optWeight(String pref) => pref == 'in' ? 0 : pref == 'out' ? 1 : 2;
       members.sort((a, b) =>
           optWeight(warOptMap[a.tag] ?? '').compareTo(optWeight(warOptMap[b.tag] ?? '')));
+    } else if (isLocationSort && locationItems != null) {
+      members.sort((a, b) {
+        final ca = locMap[a.tag]?['country_name'] as String? ?? 'zzz';
+        final cb = locMap[b.tag]?['country_name'] as String? ?? 'zzz';
+        return ca.compareTo(cb);
+      });
     } else {
     members.sort((a, b) {
       switch (currentFilter) {
@@ -241,6 +266,10 @@ class ClanMembersState extends State<ClanMembers> {
                 const LinearProgressIndicator(),
               ],
               if (isWarOptSort && warOptItems == null) ...[
+                const SizedBox(height: 4),
+                const LinearProgressIndicator(),
+              ],
+              if (isLocationSort && locationItems == null) ...[
                 const SizedBox(height: 4),
                 const LinearProgressIndicator(),
               ],
@@ -375,7 +404,7 @@ class ClanMembersState extends State<ClanMembers> {
                       ),
                       Expanded(
                         flex: 3,
-                        child: _buildStatColumn(member, getDonated, getReceived, warOptMap),
+                        child: _buildStatColumn(member, getDonated, getReceived, warOptMap, locMap),
                       ),
                     ],
                   ),
@@ -392,6 +421,7 @@ class ClanMembersState extends State<ClanMembers> {
     int Function(ClanMember) getDonated,
     int Function(ClanMember) getReceived,
     Map<String, String> warOptMap,
+    Map<String, Map<String, dynamic>> locMap,
   ) {
     switch (currentFilter) {
       case 'expLevel':
@@ -446,6 +476,35 @@ class ClanMembersState extends State<ClanMembers> {
                   ? ImageAssets.warPreferenceOut
                   : ImageAssets.warPreferenceOut,
           isIn ? 'In' : isOut ? 'Out' : '—',
+        );
+      case _locationFilter:
+        final loc = locMap[member.tag];
+        final code = loc?['country_code'] as String? ?? '';
+        final name = loc?['country_name'] as String? ?? '—';
+        if (code.isEmpty) {
+          return Padding(
+            padding: const EdgeInsets.only(left: 20),
+            child: Text('—', style: Theme.of(context).textTheme.bodySmall),
+          );
+        }
+        return Row(
+          children: [
+            const SizedBox(width: 8),
+            CachedNetworkImage(
+              imageUrl: ImageAssets.flag(code),
+              width: 22,
+              height: 16,
+              errorWidget: (ctx, url, err) => const SizedBox(width: 22),
+            ),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                name,
+                style: Theme.of(context).textTheme.bodySmall,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
         );
       default:
         return const SizedBox.shrink();

--- a/lib/features/clan/presentation/clan_info/clan_page.dart
+++ b/lib/features/clan/presentation/clan_info/clan_page.dart
@@ -1,6 +1,7 @@
 import 'package:clashkingapp/common/widgets/navigation/scrollable_tab.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
 import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:clashkingapp/features/clan/presentation/clan_info/clan_activity_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_composition_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_header.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_members.dart';
@@ -55,11 +56,13 @@ class _ClanInfoScreenState extends State<ClanInfoScreen> {
                 Tab(text: 'Members'),
                 Tab(text: 'Composition'),
                 Tab(text: 'Top Players'),
+                Tab(text: 'Activity'),
               ],
               children: [
                 ClanMembers(clanInfo: widget.clanInfo),
                 ClanCompositionTab(clanTag: widget.clanInfo.tag),
                 ClanTopPerformersTab(clanInfo: widget.clanInfo),
+                ClanActivityTab(clanInfo: widget.clanInfo),
               ],
             ),
           ],

--- a/lib/features/clan/presentation/clan_info/clan_page.dart
+++ b/lib/features/clan/presentation/clan_info/clan_page.dart
@@ -1,7 +1,10 @@
+import 'package:clashkingapp/common/widgets/navigation/scrollable_tab.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
 import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:clashkingapp/features/clan/presentation/clan_info/clan_composition_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_header.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_members.dart';
+import 'package:clashkingapp/features/clan/presentation/clan_info/clan_top_performers_tab.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -40,7 +43,25 @@ class _ClanInfoScreenState extends State<ClanInfoScreen> {
               child: ClanInfoHeaderCard(clanInfo: widget.clanInfo, ranking: ranking),
             ),
             const SizedBox(height: 8),
-            ClanMembers(clanInfo: widget.clanInfo),
+            ScrollableTab(
+              scrollable: true,
+              labelColor: Theme.of(context).colorScheme.onSurface,
+              unselectedLabelColor:
+                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+              tabBarDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+              ),
+              tabs: const [
+                Tab(text: 'Members'),
+                Tab(text: 'Composition'),
+                Tab(text: 'Top Players'),
+              ],
+              children: [
+                ClanMembers(clanInfo: widget.clanInfo),
+                ClanCompositionTab(clanTag: widget.clanInfo.tag),
+                ClanTopPerformersTab(clanInfo: widget.clanInfo),
+              ],
+            ),
           ],
         ),
       ),

--- a/lib/features/clan/presentation/clan_info/clan_page.dart
+++ b/lib/features/clan/presentation/clan_info/clan_page.dart
@@ -4,6 +4,8 @@ import 'package:clashkingapp/features/clan/models/clan.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_activity_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_composition_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_header.dart';
+import 'package:clashkingapp/features/clan/presentation/clan_info/clan_games_tab.dart';
+import 'package:clashkingapp/features/clan/presentation/clan_info/clan_legend_tab.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_members.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_top_performers_tab.dart';
 import 'package:flutter/material.dart';
@@ -57,12 +59,16 @@ class _ClanInfoScreenState extends State<ClanInfoScreen> {
                 Tab(text: 'Composition'),
                 Tab(text: 'Top Players'),
                 Tab(text: 'Activity'),
+                Tab(text: 'Legend'),
+                Tab(text: 'Games'),
               ],
               children: [
                 ClanMembers(clanInfo: widget.clanInfo),
                 ClanCompositionTab(clanTag: widget.clanInfo.tag),
                 ClanTopPerformersTab(clanInfo: widget.clanInfo),
                 ClanActivityTab(clanInfo: widget.clanInfo),
+                ClanLegendTab(clanInfo: widget.clanInfo),
+                ClanGamesTab(clanInfo: widget.clanInfo),
               ],
             ),
           ],

--- a/lib/features/clan/presentation/clan_info/clan_top_performers_tab.dart
+++ b/lib/features/clan/presentation/clan_info/clan_top_performers_tab.dart
@@ -1,0 +1,247 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
+import 'package:clashkingapp/features/clan/models/clan.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+List<String> _recentSeasons({int count = 6}) {
+  final now = DateTime.now().toUtc();
+  return List.generate(count, (i) {
+    final dt = DateTime(now.year, now.month - i, 1);
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}';
+  });
+}
+
+const _baseUrl = ImageAssets.baseUrl;
+
+// Category display config: label, icon asset URL
+const _categories = [
+  _CatInfo('donated', 'Donations', ImageAssets.sword),
+  _CatInfo('received', 'Donations Received', ImageAssets.sword),
+  _CatInfo('capital_donated', 'Capital Gold Donated', ImageAssets.capitalGold),
+  _CatInfo('capital_raided', 'Capital Gold Raided', ImageAssets.capitalGold),
+  _CatInfo('war_stars', 'War Stars', ImageAssets.builderBaseStar),
+  _CatInfo('gold', 'Gold Looted', '$_baseUrl/resources/gold.webp'),
+  _CatInfo('elixir', 'Elixir Looted', '$_baseUrl/resources/elixir.webp'),
+  _CatInfo('dark_elixir', 'Dark Elixir Looted', '$_baseUrl/resources/dark_elixir.webp'),
+  _CatInfo('attack_wins', 'Attack Wins', ImageAssets.attacks),
+  _CatInfo('activity', 'Activity', ImageAssets.hitrate),
+];
+
+class _CatInfo {
+  final String key;
+  final String label;
+  final String imageUrl;
+  const _CatInfo(this.key, this.label, this.imageUrl);
+}
+
+class ClanTopPerformersTab extends StatefulWidget {
+  final Clan clanInfo;
+
+  const ClanTopPerformersTab({super.key, required this.clanInfo});
+
+  @override
+  State<ClanTopPerformersTab> createState() => _ClanTopPerformersTabState();
+}
+
+class _ClanTopPerformersTabState extends State<ClanTopPerformersTab> {
+  late String _selectedSeason;
+  final _seasons = _recentSeasons();
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedSeason = _seasons.first;
+    _fetch(_selectedSeason);
+  }
+
+  void _fetch(String season) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final tags = widget.clanInfo.memberList.map((m) => m.tag).toList();
+      context.read<ClanService>().fetchSeasonTopPerformers(
+            widget.clanInfo.tag,
+            season,
+            tags,
+          );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final data = context
+        .watch<ClanService>()
+        .getSeasonTopPerformers(widget.clanInfo.tag, _selectedSeason);
+
+    final nameByTag = {
+      for (final m in widget.clanInfo.memberList) m.tag: m.name,
+    };
+
+    return Column(
+      children: [
+        const SizedBox(height: 8),
+        _SeasonSelector(
+          seasons: _seasons,
+          selected: _selectedSeason,
+          onChanged: (s) {
+            setState(() => _selectedSeason = s);
+            _fetch(s);
+          },
+        ),
+        const SizedBox(height: 8),
+        if (data == null)
+          const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else
+          ..._categories.map((cat) {
+            final items = data[cat.key] as List<dynamic>? ?? [];
+            if (items.isEmpty) return const SizedBox.shrink();
+            return _CategoryCard(
+              cat: cat,
+              items: items,
+              nameByTag: nameByTag,
+            );
+          }),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+class _SeasonSelector extends StatelessWidget {
+  final List<String> seasons;
+  final String selected;
+  final void Function(String) onChanged;
+
+  const _SeasonSelector({
+    required this.seasons,
+    required this.selected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 32,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        itemCount: seasons.length,
+        separatorBuilder: (context, i) => const SizedBox(width: 6),
+        itemBuilder: (context, i) {
+          final season = seasons[i];
+          final parts = season.split('-');
+          final label = parts.length == 2
+              ? DateFormat('MMM yy')
+                  .format(DateTime(int.parse(parts[0]), int.parse(parts[1])))
+              : season;
+          final isSelected = selected == season;
+          return ChoiceChip(
+            label: Text(label),
+            selected: isSelected,
+            onSelected: (_) => onChanged(season),
+            labelStyle: TextStyle(
+              fontSize: 11,
+              color: isSelected
+                  ? Theme.of(context).colorScheme.onPrimary
+                  : Theme.of(context).colorScheme.onSurface,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CategoryCard extends StatelessWidget {
+  final _CatInfo cat;
+  final List<dynamic> items;
+  final Map<String, String> nameByTag;
+
+  const _CategoryCard({
+    required this.cat,
+    required this.items,
+    required this.nameByTag,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CachedNetworkImage(
+                  imageUrl: cat.imageUrl,
+                  width: 20,
+                  height: 20,
+                  errorWidget: (ctx, url, err) =>
+                      const Icon(Icons.star, size: 20),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  cat.label,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ...items.asMap().entries.map((e) {
+              final rank = e.key + 1;
+              final item = e.value as Map<String, dynamic>;
+              final tag = item['tag'] as String? ?? '';
+              final value = item['value'] as num? ?? 0;
+              final name = nameByTag[tag] ?? tag;
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 20,
+                      child: Text(
+                        '$rank.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: rank == 1
+                                  ? Colors.amber
+                                  : rank == 2
+                                      ? Colors.grey[400]
+                                      : rank == 3
+                                          ? Colors.brown[300]
+                                          : null,
+                              fontWeight: rank <= 3 ? FontWeight.bold : null,
+                            ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        name,
+                        style: Theme.of(context).textTheme.bodySmall,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      NumberFormat('#,###').format(value),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -2,6 +2,7 @@ What’s new
 - Clan info page now has Members, Composition, Top Players, and Activity tabs
 - Composition tab shows TH, league, and country distribution with visual bars
 - Members tab can now sort by hero level (BK, AQ, GW, RC, Minion Prince) using ClashKing data
+- Members tab has a name/tag search field to quickly filter large clans
 - Top Players tab shows per-season leaderboards for donations, war stars, gold looted, and more
 - Clan page now shows global and local rank chips in the header
 - CWL screen has a new History tab showing the clan’s CWL ranking per season

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,4 +1,7 @@
 What’s new
+- Clan info page now has Members, Composition, and Top Players tabs
+- Composition tab shows TH, league, and country distribution with visual bars
+- Top Players tab shows per-season leaderboards for donations, war stars, gold looted, and more
 - Clan page now shows global and local rank chips in the header
 - CWL screen has a new History tab showing the clan’s CWL ranking per season
 - CWL Teams tab now shows promotion and relegation zone indicators

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,6 +1,7 @@
 What’s new
 - Clan info page now has Members, Composition, Top Players, and Activity tabs
 - Composition tab shows TH, league, and country distribution with visual bars
+- Members tab can now sort by hero level (BK, AQ, GW, RC, Minion Prince) using ClashKing data
 - Top Players tab shows per-season leaderboards for donations, war stars, gold looted, and more
 - Clan page now shows global and local rank chips in the header
 - CWL screen has a new History tab showing the clan’s CWL ranking per season

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,5 +1,8 @@
 What’s new
-- Clan info page now has Members, Composition, Top Players, and Activity tabs
+- Clan info page now has Members, Composition, Top Players, Activity, Legend, and Games tabs
+- Legend tab shows all clan members in Legend League with today's attack count, trophies, and net trophy change
+- Games tab shows per-player Clan Games contribution with a season selector for historical data
+- Members tab can now sort by War Preference to see who is opted in or out of war
 - Composition tab shows TH, league, and country distribution with visual bars
 - Members tab can now sort by hero level (BK, AQ, GW, RC, Minion Prince) using ClashKing data
 - Members tab has a name/tag search field to quickly filter large clans

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,5 +1,5 @@
 What’s new
-- Clan info page now has Members, Composition, and Top Players tabs
+- Clan info page now has Members, Composition, Top Players, and Activity tabs
 - Composition tab shows TH, league, and country distribution with visual bars
 - Top Players tab shows per-season leaderboards for donations, war stars, gold looted, and more
 - Clan page now shows global and local rank chips in the header

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -3,6 +3,7 @@ What’s new
 - Legend tab shows all clan members in Legend League with today's attack count, trophies, and net trophy change
 - Games tab shows per-player Clan Games contribution with a season selector for historical data
 - Members tab can now sort by War Preference to see who is opted in or out of war
+- Members tab can sort by "All Heroes" (cumulative hero levels) and "Country" (shows flag and sorts alphabetically)
 - Composition tab shows TH, league, and country distribution with visual bars
 - Members tab can now sort by hero level (BK, AQ, GW, RC, Minion Prince) using ClashKing data
 - Members tab has a name/tag search field to quickly filter large clans


### PR DESCRIPTION
## Summary

- **Clan info page restructured into 4 tabs**: Members, Composition, Top Players, Activity
- **Composition tab**: calls `GET /v2/clan/compo` to show TH, league, and country distribution as horizontal bar rows with percentages
- **Top Players tab**: calls `POST /v2/players/summary/{season}/top` (limit 5) to show season leaderboards for donations, war stars, gold/elixir/dark elixir looted, capital gold, and activity — with a season picker for the last 6 months
- **Activity tab**: reuses existing ClanJoinLeaveStats + ClanJoinLeaveEvents widgets; fetches join/leave data on demand when not pre-loaded (e.g. clan opened from search)
- **Hero sort on members**: adds BK, AQ, GW, RC, Minion Prince sort options via `POST /v2/players/sorted/{attr}` with a LinearProgressIndicator while results load
- **Member name/tag search**: text field above the sort dropdown filters members in real-time

## New API endpoints used

| Endpoint | Purpose |
|---|---|
| `GET /v2/clan/compo?clan_tags=…` | TH/league/country breakdown |
| `POST /v2/players/summary/{season}/top` | Season top performers |
| `POST /v2/players/sorted/{attribute}` | Hero-level sorting |
| `GET /v2/clan/{tag}/join-leave?current_season=true` | On-demand activity data |

## Test plan

- [ ] Open any clan → verify 4 tabs appear (Members, Composition, Top Players, Activity)
- [ ] Composition tab loads and shows bars for TH levels, leagues, countries
- [ ] Top Players tab shows leaderboards; switching season fetches new data
- [ ] Activity tab shows join/leave stats and events
- [ ] In Members tab, select "Barbarian King" sort → loading bar appears → members reorder by BK level
- [ ] Type a player name in the search field → list filters in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)