### PR TITLE
feat: clan ranking + CWL history + promo banners + seasonal donations [REVIEW]

### DIFF
--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -36,6 +36,7 @@ class ClanService extends ChangeNotifier {
   List<CapitalHistoryItems> capitalHistory = [];
   List<ClanWarLog> warLogList = [];
   List<ClanWarStats> warStatsList = [];
+  final Map<String, Map<String, dynamic>> _clanRankings = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -664,5 +665,23 @@ class ClanService extends ChangeNotifier {
 
   void notifyDataChanged() {
     _safeNotify();
+  }
+
+  Map<String, dynamic>? getClanRanking(String clanTag) => _clanRankings[clanTag];
+
+  Future<void> fetchClanRanking(String clanTag) async {
+    try {
+      final response = await _apiService.getResponse(
+        '/clan/$clanTag/ranking',
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        _clanRankings[clanTag] = data as Map<String, dynamic>;
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
   }
 }

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -37,6 +37,7 @@ class ClanService extends ChangeNotifier {
   List<ClanWarLog> warLogList = [];
   List<ClanWarStats> warStatsList = [];
   final Map<String, Map<String, dynamic>> _clanRankings = {};
+  final Map<String, List<Map<String, dynamic>>> _seasonalDonations = {};
 
   static const String _errLoadingClanData = 'Error loading clan data';
 
@@ -668,6 +669,28 @@ class ClanService extends ChangeNotifier {
   }
 
   Map<String, dynamic>? getClanRanking(String clanTag) => _clanRankings[clanTag];
+
+  List<Map<String, dynamic>>? getSeasonalDonations(String clanTag, String season) =>
+      _seasonalDonations['$clanTag/$season'];
+
+  Future<void> fetchDonationsBySeason(String clanTag, String season) async {
+    final key = '$clanTag/$season';
+    if (_seasonalDonations.containsKey(key)) return;
+    try {
+      final response = await _apiService.getResponse(
+        '/clan/$clanTag/donations/$season',
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        _seasonalDonations[key] =
+            (data['items'] as List<dynamic>).cast<Map<String, dynamic>>();
+        _safeNotify();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
+  }
 
   Future<void> fetchClanRanking(String clanTag) async {
     try {

--- a/lib/features/clan/data/clan_service.dart
+++ b/lib/features/clan/data/clan_service.dart
@@ -381,6 +381,22 @@ class ClanService extends ChangeNotifier {
 
     try {
       final warLogs = await Future.wait(clanTags.map((tag) async {
+        // Prefer v2 endpoint: more history (up to 50 wars), works even if log is private
+        final v2Response = await _apiService.getResponse(
+          '/war/$tag/previous?limit=50',
+          requiresAuth: true,
+        );
+
+        if (v2Response.statusCode == 200) {
+          final body = ApiService.decodeResponseBody(v2Response);
+          final jsonBody = json.decode(body) as Map<String, dynamic>;
+          final warLog = ClanWarLog.fromJson(jsonBody, tag);
+          warLog.warLogStats =
+              await WarLogStatsService.analyzeWarLogs(warLog.items);
+          return warLog;
+        }
+
+        // Fallback to CoC proxy (max 20 wars, private logs return 403)
         final response = await _apiService.getResponse(
           '',
           url:

--- a/lib/features/clan/presentation/clan_info/clan_header.dart
+++ b/lib/features/clan/presentation/clan_info/clan_header.dart
@@ -272,6 +272,7 @@ class ClanInfoHeaderCard extends StatelessWidget {
               clanInfo: clanInfo.warCwl!.leagueInfo!.clans.firstWhere(
                 (clan) => clan.tag == clanInfo.tag,
               ),
+              warLeagueName: clanInfo.warLeague?.name,
             ),
           ),
         );

--- a/lib/features/clan/presentation/clan_info/clan_header.dart
+++ b/lib/features/clan/presentation/clan_info/clan_header.dart
@@ -19,8 +19,9 @@ import 'package:url_launcher/url_launcher.dart';
 
 class ClanInfoHeaderCard extends StatelessWidget {
   final Clan clanInfo;
+  final Map<String, dynamic>? ranking;
 
-  const ClanInfoHeaderCard({super.key, required this.clanInfo});
+  const ClanInfoHeaderCard({super.key, required this.clanInfo, this.ranking});
 
   @override
   Widget build(BuildContext context) {
@@ -161,6 +162,19 @@ class ClanInfoHeaderCard extends StatelessWidget {
             context: context,
             imageUrl: ImageAssets.townHall(clanInfo.requiredTownhallLevel),
             label: clanInfo.requiredTownhallLevel.toString(),
+          ),
+        if (ranking?['global_rank'] != null)
+          IconChip(
+            icon: Icons.public,
+            size: 16,
+            color: Theme.of(context).colorScheme.onSurface,
+            label: '#${ranking!['global_rank']}',
+          ),
+        if (ranking?['local_rank'] != null && ranking?['country_code'] != null)
+          ImageChip(
+            context: context,
+            imageUrl: ImageAssets.flag(ranking!['country_code'] as String),
+            label: '#${ranking!['local_rank']}',
           ),
         IconChip(
           icon: Icons.mail,

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -1,16 +1,26 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:clashkingapp/common/widgets/inputs/filter_dropdown.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
 import 'package:clashkingapp/features/clan/models/clan.dart';
 import 'package:clashkingapp/features/clan/models/clan_member.dart';
 import 'package:clashkingapp/features/coc_accounts/data/coc_account_service.dart';
 import 'package:clashkingapp/features/player/data/player_service.dart';
 import 'package:clashkingapp/features/player/models/player.dart';
 import 'package:clashkingapp/features/player/presentation/player/player_page.dart';
+import 'package:intl/intl.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+
+List<String> _recentSeasons({int count = 12}) {
+  final now = DateTime.now().toUtc();
+  return List.generate(count, (i) {
+    final dt = DateTime(now.year, now.month - i, 1);
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}';
+  });
+}
 
 class ClanMembers extends StatefulWidget {
   final Clan clanInfo;
@@ -22,12 +32,16 @@ class ClanMembers extends StatefulWidget {
   ClanMembersState createState() => ClanMembersState();
 }
 
+const _donationFilters = {'donations', 'donationsReceived', 'donationsRatio'};
+
 class ClanMembersState extends State<ClanMembers> {
   String currentFilter = 'trophies';
+  String? _selectedSeason;
 
   void updateFilter(String newFilter) {
     setState(() {
       currentFilter = newFilter;
+      if (!_donationFilters.contains(newFilter)) _selectedSeason = null;
     });
   }
 
@@ -50,6 +64,27 @@ class ClanMembersState extends State<ClanMembers> {
     
     final cocService = context.watch<CocAccountService>();
     final activeUserTags = cocService.getAccountTags();
+    final clanService = context.watch<ClanService>();
+    final seasonalData = _selectedSeason != null
+        ? clanService.getSeasonalDonations(widget.clanInfo.tag, _selectedSeason!)
+        : null;
+
+    // Build a lookup map from tag → {donated, received} for seasonal data
+    final Map<String, ({int donated, int received})> seasonLookup = {};
+    if (seasonalData != null) {
+      for (final item in seasonalData) {
+        final tag = item['tag'] as String? ?? '';
+        seasonLookup[tag] = (
+          donated: (item['donated'] as num? ?? 0).toInt(),
+          received: (item['received'] as num? ?? 0).toInt(),
+        );
+      }
+    }
+
+    int getDonated(ClanMember m) =>
+        seasonLookup[m.tag]?.donated ?? m.donations;
+    int getReceived(ClanMember m) =>
+        seasonLookup[m.tag]?.received ?? m.donationsReceived;
 
     Map<String, int> roleWeights = {
       'leader': 4,
@@ -73,14 +108,16 @@ class ClanMembersState extends State<ClanMembers> {
         case 'builderBaseTrophies':
           return b.builderBaseTrophies.compareTo(a.builderBaseTrophies);
         case 'donations':
-          return b.donations.compareTo(a.donations);
+          return getDonated(b).compareTo(getDonated(a));
         case 'donationsReceived':
-          return b.donationsReceived.compareTo(a.donationsReceived);
+          return getReceived(b).compareTo(getReceived(a));
         case 'donationsRatio':
-          double ratioA = a.donations /
-              (a.donationsReceived == 0 ? 1 : a.donationsReceived);
-          double ratioB = b.donations /
-              (b.donationsReceived == 0 ? 1 : b.donationsReceived);
+          final dA = getDonated(a);
+          final rA = getReceived(a);
+          final dB = getDonated(b);
+          final rB = getReceived(b);
+          double ratioA = dA / (rA == 0 ? 1 : rA);
+          double ratioB = dB / (rB == 0 ? 1 : rB);
           return ratioB.compareTo(ratioA);
         default:
           return 0;
@@ -98,6 +135,21 @@ class ClanMembersState extends State<ClanMembers> {
                 updateSortBy: updateFilter,
                 sortByOptions: filterOptions,
               ),
+              if (_donationFilters.contains(currentFilter)) ...[
+                const SizedBox(height: 4),
+                _SeasonSelector(
+                  clanTag: widget.clanInfo.tag,
+                  selectedSeason: _selectedSeason,
+                  onSeasonChanged: (season) {
+                    setState(() => _selectedSeason = season);
+                    if (season != null) {
+                      context
+                          .read<ClanService>()
+                          .fetchDonationsBySeason(widget.clanInfo.tag, season);
+                    }
+                  },
+                ),
+              ],
               const SizedBox(height: 6),
             ],
           ),
@@ -214,7 +266,7 @@ class ClanMembersState extends State<ClanMembers> {
                       ),
                       Expanded(
                         flex: 3,
-                        child: _buildStatColumn(member),
+                        child: _buildStatColumn(member, getDonated, getReceived),
                       ),
                     ],
                   ),
@@ -226,7 +278,11 @@ class ClanMembersState extends State<ClanMembers> {
     );
   }
 
-  Widget _buildStatColumn(ClanMember member) {
+  Widget _buildStatColumn(
+    ClanMember member,
+    int Function(ClanMember) getDonated,
+    int Function(ClanMember) getReceived,
+  ) {
     switch (currentFilter) {
       case 'expLevel':
         return _iconText(ImageAssets.xp, member.expLevel.toString());
@@ -235,14 +291,15 @@ class ClanMembersState extends State<ClanMembers> {
             ImageAssets.trophies, member.builderBaseTrophies.toString());
       case 'donations':
         return _iconTextWithIcon(
-            LucideIcons.chevronUp, member.donations.toString(), Colors.green);
+            LucideIcons.chevronUp, getDonated(member).toString(), Colors.green);
       case 'donationsReceived':
         return _iconTextWithIcon(LucideIcons.chevronDown,
-            member.donationsReceived.toString(), Colors.red);
+            getReceived(member).toString(), Colors.red);
       case 'donationsRatio':
-        double ratio = member.donations /
-            (member.donationsReceived == 0 ? 1 : member.donationsReceived);
-        String display = ratio > 100
+        final donated = getDonated(member);
+        final received = getReceived(member);
+        double ratio = donated / (received == 0 ? 1 : received);
+        final display = ratio > 100
             ? ratio.toInt().toString()
             : ratio > 10
                 ? ratio.toStringAsFixed(1)
@@ -318,5 +375,64 @@ class ClanMembersState extends State<ClanMembers> {
       default:
         return loc.clanRoleMember;
     }
+  }
+}
+
+class _SeasonSelector extends StatelessWidget {
+  final String clanTag;
+  final String? selectedSeason;
+  final void Function(String?) onSeasonChanged;
+
+  const _SeasonSelector({
+    required this.clanTag,
+    required this.selectedSeason,
+    required this.onSeasonChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final seasons = _recentSeasons();
+    return SizedBox(
+      height: 32,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        itemCount: seasons.length + 1,
+        separatorBuilder: (context, i) => const SizedBox(width: 6),
+        itemBuilder: (context, i) {
+          if (i == 0) {
+            final isCurrent = selectedSeason == null;
+            return ChoiceChip(
+              label: const Text('Current'),
+              selected: isCurrent,
+              onSelected: (_) => onSeasonChanged(null),
+              labelStyle: TextStyle(
+                fontSize: 11,
+                color: isCurrent
+                    ? Theme.of(context).colorScheme.onPrimary
+                    : Theme.of(context).colorScheme.onSurface,
+              ),
+            );
+          }
+          final season = seasons[i - 1];
+          final parts = season.split('-');
+          final label = parts.length == 2
+              ? DateFormat('MMM yy').format(DateTime(int.parse(parts[0]), int.parse(parts[1])))
+              : season;
+          final isSelected = selectedSeason == season;
+          return ChoiceChip(
+            label: Text(label),
+            selected: isSelected,
+            onSelected: (_) => onSeasonChanged(isSelected ? null : season),
+            labelStyle: TextStyle(
+              fontSize: 11,
+              color: isSelected
+                  ? Theme.of(context).colorScheme.onPrimary
+                  : Theme.of(context).colorScheme.onSurface,
+            ),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/features/clan/presentation/clan_info/clan_page.dart
+++ b/lib/features/clan/presentation/clan_info/clan_page.dart
@@ -1,26 +1,46 @@
+import 'package:clashkingapp/features/clan/data/clan_service.dart';
 import 'package:clashkingapp/features/clan/models/clan.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_header.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_members.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class ClanInfoScreen extends StatelessWidget {
+class ClanInfoScreen extends StatefulWidget {
   final Clan clanInfo;
 
-  const ClanInfoScreen(
-      {super.key, required this.clanInfo});
+  const ClanInfoScreen({super.key, required this.clanInfo});
+
+  @override
+  State<ClanInfoScreen> createState() => _ClanInfoScreenState();
+}
+
+class _ClanInfoScreenState extends State<ClanInfoScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<ClanService>().fetchClanRanking(widget.clanInfo.tag);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    final ranking = context
+        .watch<ClanService>()
+        .getClanRanking(widget.clanInfo.tag);
+
     return Scaffold(
       body: SingleChildScrollView(
         child: Column(
           children: [
             Container(
               color: Theme.of(context).colorScheme.surface,
-              child: ClanInfoHeaderCard(clanInfo: clanInfo),
+              child: ClanInfoHeaderCard(clanInfo: widget.clanInfo, ranking: ranking),
             ),
             const SizedBox(height: 8),
-            ClanMembers(clanInfo: clanInfo),
+            ClanMembers(clanInfo: widget.clanInfo),
           ],
         ),
       ),

--- a/lib/features/war_cwl/data/war_cwl_service.dart
+++ b/lib/features/war_cwl/data/war_cwl_service.dart
@@ -12,6 +12,7 @@ class WarCwlService extends ChangeNotifier {
 
   final ApiService _apiService;
   final Map<String, WarCwl> summaries = {};
+  final Map<String, List<Map<String, dynamic>>> _cwlRankingHistory = {};
 
   Future<void> loadAllWarData(List<String> clanTags,
       {bool notify = true, bool throwOnError = false}) async {
@@ -84,6 +85,27 @@ class WarCwlService extends ChangeNotifier {
 
   void notifyDataChanged() {
     notifyListeners();
+  }
+
+  List<Map<String, dynamic>>? getCwlRankingHistory(String clanTag) =>
+      _cwlRankingHistory[clanTag];
+
+  Future<void> fetchCwlRankingHistory(String clanTag) async {
+    try {
+      final response = await _apiService.getResponse(
+        '/cwl/$clanTag/ranking-history',
+        requiresAuth: true,
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(ApiService.decodeResponseBody(response));
+        final items = (data['items'] as List<dynamic>)
+            .cast<Map<String, dynamic>>();
+        _cwlRankingHistory[clanTag] = items;
+        notifyListeners();
+      }
+    } catch (e) {
+      Sentry.captureException(e);
+    }
   }
 
   static Future<WarInfo?> fetchWarDataFromTime(String tag, DateTime end) async {

--- a/lib/features/war_cwl/presentation/cwl/cwl.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl.dart
@@ -19,12 +19,14 @@ class CwlScreen extends StatefulWidget {
   final WarCwl warCwl;
   final String clanTag;
   final CwlClan clanInfo;
+  final String? warLeagueName;
 
   CwlScreen({
     super.key,
     required this.warCwl,
     required this.clanTag,
     required this.clanInfo,
+    this.warLeagueName,
   });
 
   @override
@@ -222,7 +224,7 @@ class CwlScreenState extends State<CwlScreen> {
               ],
               children: [
                 CwlRoundsTab(warCwl: widget.warCwl),
-                CwlTeamsTab(warCwl: widget.warCwl),
+                CwlTeamsTab(warCwl: widget.warCwl, warLeagueName: widget.warLeagueName),
                 CwlMembersTab(warCwl: widget.warCwl, clanTag: widget.clanTag),
                 CwlRankingHistoryTab(clanTag: widget.clanTag),
               ],

--- a/lib/features/war_cwl/presentation/cwl/cwl.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl.dart
@@ -4,6 +4,7 @@ import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_cwl.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/cwl/cwl_members_tab.dart';
+import 'package:clashkingapp/features/war_cwl/presentation/cwl/cwl_ranking_history_tab.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/cwl/cwl_rounds_tab.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/cwl/cwl_teams_tab.dart';
 import 'package:flutter/material.dart';
@@ -215,11 +216,15 @@ class CwlScreenState extends State<CwlScreen> {
                 Tab(
                   text: AppLocalizations.of(context)?.clanMembers ?? "Members",
                 ),
+                Tab(
+                  text: AppLocalizations.of(context)?.generalHistory ?? "History",
+                ),
               ],
               children: [
                 CwlRoundsTab(warCwl: widget.warCwl),
                 CwlTeamsTab(warCwl: widget.warCwl),
                 CwlMembersTab(warCwl: widget.warCwl, clanTag: widget.clanTag),
+                CwlRankingHistoryTab(clanTag: widget.clanTag),
               ],
             ),
           ],

--- a/lib/features/war_cwl/presentation/cwl/cwl_ranking_history_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_ranking_history_tab.dart
@@ -1,0 +1,172 @@
+import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:clashkingapp/core/constants/image_assets.dart';
+import 'package:clashkingapp/features/war_cwl/data/war_cwl_service.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+class CwlRankingHistoryTab extends StatefulWidget {
+  final String clanTag;
+
+  const CwlRankingHistoryTab({super.key, required this.clanTag});
+
+  @override
+  State<CwlRankingHistoryTab> createState() => _CwlRankingHistoryTabState();
+}
+
+class _CwlRankingHistoryTabState extends State<CwlRankingHistoryTab> {
+  bool _loading = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final service = context.read<WarCwlService>();
+    if (service.getCwlRankingHistory(widget.clanTag) != null) return;
+    setState(() { _loading = true; _error = null; });
+    try {
+      await service.fetchCwlRankingHistory(widget.clanTag);
+    } catch (_) {
+      if (mounted) setState(() => _error = 'Failed to load CWL history');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.all(32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_error != null) {
+      return Padding(
+        padding: const EdgeInsets.all(32),
+        child: Center(child: Text(_error!, style: Theme.of(context).textTheme.bodyMedium)),
+      );
+    }
+
+    final history = context
+        .watch<WarCwlService>()
+        .getCwlRankingHistory(widget.clanTag);
+
+    if (history == null || history.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(32),
+        child: Center(
+          child: Text(
+            'No CWL history available',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: history.length,
+      separatorBuilder: (context, i) => Divider(
+        height: 1,
+        color: Theme.of(context).colorScheme.onSurface.withAlpha(30),
+      ),
+      itemBuilder: (context, i) => _SeasonRow(entry: history[i]),
+    );
+  }
+}
+
+class _SeasonRow extends StatelessWidget {
+  final Map<String, dynamic> entry;
+  const _SeasonRow({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final season = entry['season'] as String? ?? '';
+    final leagueName = entry['league'] as String? ?? 'Unranked';
+    final rank = entry['rank'] as int?;
+    final stars = entry['stars'] as int?;
+    final roundsWon = entry['rounds_won'] as int?;
+    final roundsLost = entry['rounds_lost'] as int?;
+
+    // Format "2024-06" → "June 2024"
+    String seasonLabel = season;
+    try {
+      final parts = season.split('-');
+      if (parts.length == 2) {
+        final dt = DateTime(int.parse(parts[0]), int.parse(parts[1]));
+        seasonLabel = DateFormat('MMM yyyy').format(dt);
+      }
+    } catch (_) {}
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: MobileWebImage(
+              imageUrl: ImageAssets.getLeagueImage(leagueName),
+              fit: BoxFit.contain,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(seasonLabel, style: Theme.of(context).textTheme.bodyMedium),
+                Text(
+                  leagueName,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.withAlpha(160),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (rank != null)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                '#$rank',
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          if (stars != null) ...[
+            const SizedBox(width: 10),
+            Row(
+              children: [
+                Icon(Icons.star, size: 14, color: Colors.amber),
+                const SizedBox(width: 2),
+                Text('$stars', style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ],
+          if (roundsWon != null && roundsLost != null) ...[
+            const SizedBox(width: 10),
+            Text(
+              '$roundsWon-$roundsLost',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurface.withAlpha(160),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/war_cwl/presentation/cwl/cwl_teams_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_teams_tab.dart
@@ -7,10 +7,34 @@ import 'package:clashkingapp/features/war_cwl/presentation/cwl/widgets/cwl_team_
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 
+// Promotion / demotion positions for each CWL league (top N promoted, bottom N relegated).
+// Bronze III has no demotion. Champion I has no promotion.
+const Map<String, ({int promo, int demote})> _cwlThresholds = {
+  'Bronze League III':   (promo: 3, demote: 0),
+  'Bronze League II':    (promo: 3, demote: 8),
+  'Bronze League I':     (promo: 3, demote: 8),
+  'Silver League III':   (promo: 2, demote: 8),
+  'Silver League II':    (promo: 2, demote: 7),
+  'Silver League I':     (promo: 2, demote: 7),
+  'Gold League III':     (promo: 2, demote: 7),
+  'Gold League II':      (promo: 2, demote: 7),
+  'Gold League I':       (promo: 2, demote: 7),
+  'Crystal League III':  (promo: 2, demote: 7),
+  'Crystal League II':   (promo: 2, demote: 7),
+  'Crystal League I':    (promo: 2, demote: 7),
+  'Master League III':   (promo: 2, demote: 7),
+  'Master League II':    (promo: 2, demote: 7),
+  'Master League I':     (promo: 2, demote: 7),
+  'Champion League III': (promo: 2, demote: 7),
+  'Champion League II':  (promo: 2, demote: 7),
+  'Champion League I':   (promo: 0, demote: 7),
+};
+
 class CwlTeamsTab extends StatefulWidget {
   final WarCwl warCwl;
+  final String? warLeagueName;
 
-  const CwlTeamsTab({super.key, required this.warCwl});
+  const CwlTeamsTab({super.key, required this.warCwl, this.warLeagueName});
 
   @override
   CwlTeamsTabState createState() => CwlTeamsTabState();
@@ -93,8 +117,60 @@ class CwlTeamsTabState extends State<CwlTeamsTab> {
       clans.sort((a, b) => b.threeStarsDef.compareTo(a.threeStarsDef));
     }
 
+    final threshold = _cwlThresholds[widget.warLeagueName];
+
     return Column(
       children: [
+        if (threshold != null) ...[
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                if (threshold.promo > 0)
+                  Expanded(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: Colors.green.withAlpha(40),
+                        borderRadius: const BorderRadius.all(Radius.circular(8)),
+                        border: Border.all(color: Colors.green.withAlpha(100)),
+                      ),
+                      child: Text(
+                        '↑ Top ${threshold.promo} promoted',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.green,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                if (threshold.promo > 0 && threshold.demote > 0)
+                  const SizedBox(width: 8),
+                if (threshold.demote > 0)
+                  Expanded(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: Colors.red.withAlpha(40),
+                        borderRadius: const BorderRadius.all(Radius.circular(8)),
+                        border: Border.all(color: Colors.red.withAlpha(100)),
+                      ),
+                      child: Text(
+                        '↓ Bottom ${clans.length - threshold.demote + 1}+ relegated',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.red,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
         const SizedBox(height: 12),
         FilterDropdown(
             sortBy: sortBy,

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -3,6 +3,7 @@ What’s new
 - CWL screen has a new History tab showing the clan’s CWL ranking per season
 - CWL Teams tab now shows promotion and relegation zone indicators
 - Clan members list has a season selector when sorted by donations to view historical data
+- War history now loads up to 50 wars from ClashKing database (was limited to 20 via CoC API)
 - Tapping a troop, spell, hero, equipment or pet now shows a detailed popup with description and stats (housing space, attack speed, range, movement speed, upgrade resource, hero and rarity for equipment)
 - Item popup now shows DPS, HP/Heal at current level, targeting type (Ground/Air/Flying), and next-level upgrade cost & time
 - Player item sections now show two progress percentages: current TH max-level completion and overall max-level completion

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,4 +1,6 @@
 What’s new
+- Clan page now shows global and local rank chips in the header
+- CWL screen has a new History tab showing the clan’s CWL ranking per season
 - Tapping a troop, spell, hero, equipment or pet now shows a detailed popup with description and stats (housing space, attack speed, range, movement speed, upgrade resource, hero and rarity for equipment)
 - Item popup now shows DPS, HP/Heal at current level, targeting type (Ground/Air/Flying), and next-level upgrade cost & time
 - Player item sections now show two progress percentages: current TH max-level completion and overall max-level completion

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,6 +1,8 @@
 What’s new
 - Clan page now shows global and local rank chips in the header
 - CWL screen has a new History tab showing the clan’s CWL ranking per season
+- CWL Teams tab now shows promotion and relegation zone indicators
+- Clan members list has a season selector when sorted by donations to view historical data
 - Tapping a troop, spell, hero, equipment or pet now shows a detailed popup with description and stats (housing space, attack speed, range, movement speed, upgrade resource, hero and rarity for equipment)
 - Item popup now shows DPS, HP/Heal at current level, targeting type (Ground/Air/Flying), and next-level upgrade cost & time
 - Player item sections now show two progress percentages: current TH max-level completion and overall max-level completion


### PR DESCRIPTION
> ⚠️ This PR replaces #163, which was merged by mistake without a review. The merge commit was reverted on `main`. Please review before merging.

## Summary

- **Clan header**: global rank badge (#X) and local rank (flag + #X) via `GET /v2/clan/{tag}/ranking`
- **CWL Screen**: 4th tab "History" with `CwlRankingHistoryTab` — CWL season history (league, rank, stars, W/L) via `GET /v2/cwl/{tag}/ranking-history`
- **CWL Teams tab**: green/red promotion/relegation banners based on league (`warLeagueName` passed down from `ClanInfoHeaderCard`)
- **Clan members**: season selector for donations/received/ratio stats via `GET /v2/clan/{tag}/donations/{season}`
- **War history**: prioritizes v2 endpoint (`GET /v2/war/{tag}/previous?limit=50`) — 50 wars instead of 20; works even if the log is private

## Test Plan

- [ ] Open a clan page → check global/local rank badges in the header
- [ ] Open CWL → check the History tab for season history
- [ ] In CWL Teams → check promo/relegation banners
- [ ] In Members, sort by Donations → select a past season → verify figures update
- [ ] War History displays 50 wars (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)