### PR TITLE
fix: remove notification opened snackbar

### DIFF
--- a/e2e/tests/email_verification.spec.ts
+++ b/e2e/tests/email_verification.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { enableFlutterSemantics, hasFlutterSemantics } from './helpers';
+import { authSegment, clickAuthSegment, enableFlutterSemantics, hasFlutterSemantics } from './helpers';
 
 // Reaches EmailVerificationPage by registering a fresh throwaway account.
 // Each test creates one unique account (timestamp-based email) — expected in a test env.
@@ -19,10 +19,8 @@ async function registerAndNavigateToVerification(page: any): Promise<string | nu
     // enableFlutterSemantics calls waitForFlutter internally — no need to call it separately
     await enableFlutterSemantics(page);
 
-    // Switch to Email tab — explicit waitFor prevents 30 s default action timeout
-    const emailTab = page.getByRole('tab', { name: /email/i });
-    await emailTab.waitFor({ state: 'attached', timeout: 8_000 });
-    await emailTab.click({ timeout: 8_000 });
+    // Switch to Email auth segment — explicit waitFor prevents 30 s default action timeout
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(400);
 
     // Navigate to Register page
@@ -195,11 +193,7 @@ test.describe('Email verification page', () => {
     await backBtn.click({ timeout: 8_000 });
     await page.waitForTimeout(800);
 
-    // Login page: Discord/Email tabs visible
-    await expect(
-      page.getByRole('tab', { name: /email/i })
-        .or(page.locator('flt-semantics[aria-label*="Email" i]'))
-        .first()
-    ).toBeAttached({ timeout: 8_000 });
+    // Login page: Discord/Email auth segments visible
+    await expect(authSegment(page, /email/i)).toBeAttached({ timeout: 8_000 });
   });
 });

--- a/e2e/tests/forgot_password.spec.ts
+++ b/e2e/tests/forgot_password.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
+import { authSegment, clickAuthSegment, enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
 
 async function openForgotPassword(page: any) {
   await page.goto('/');
@@ -7,7 +7,7 @@ async function openForgotPassword(page: any) {
   await enableFlutterSemantics(page);
 
   // Switch to Email tab
-  await page.getByRole('tab', { name: /email/i }).click();
+  await clickAuthSegment(page, /email/i);
   await page.waitForTimeout(500);
 
   // Click "Forgot password?" link
@@ -144,10 +144,6 @@ test.describe('Forgot password page', () => {
     await backBtn.click();
     await page.waitForTimeout(600);
 
-    await expect(
-      page.getByRole('tab', { name: /email/i })
-        .or(page.locator('flt-semantics[aria-label*="Email" i]'))
-        .first()
-    ).toBeAttached({ timeout: 8_000 });
+    await expect(authSegment(page, /email/i)).toBeAttached({ timeout: 8_000 });
   });
 });

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 /** Wait until Flutter finishes its initial frame render */
 export async function waitForFlutter(page: Page) {
@@ -74,6 +74,39 @@ export async function enableFlutterSemantics(page: Page) {
 export async function hasFlutterSemantics(page: Page): Promise<boolean> {
   const count = await page.locator('flt-semantics').count();
   return count > 0;
+}
+
+/**
+ * Locate an auth segmented-control item.
+ *
+ * The login UI used to expose Material tabs, but it now renders a custom
+ * LiquidGlass segmented control. Flutter web may expose those segments as
+ * buttons or plain semantics nodes depending on renderer/accessibility state,
+ * so tests should not hard-code ARIA tab roles for this control.
+ */
+export function authSegment(page: Page, name: RegExp): Locator {
+  const exactName = /email/i.test(name.source)
+    ? /^email$/i
+    : /discord/i.test(name.source)
+      ? /^discord$/i
+      : name;
+
+  return page
+    .getByRole('tab', { name: exactName })
+    .or(page.getByRole('button', { name: exactName }))
+    .or(page.locator('flt-semantics').filter({ hasText: exactName }))
+    .first();
+}
+
+export async function clickAuthSegment(page: Page, name: RegExp) {
+  const segment = authSegment(page, name);
+  await segment.waitFor({ state: 'attached', timeout: 8_000 });
+  const box = await segment.boundingBox();
+  if (box) {
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    return;
+  }
+  await segment.click({ timeout: 8_000, force: true });
 }
 
 /**

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
+import { authSegment, clickAuthSegment, enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
 
 test.describe('Login page — UI', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,22 +8,21 @@ test.describe('Login page — UI', () => {
     await enableFlutterSemantics(page);
   });
 
-  test('shows Discord and Email tabs', async ({ page }) => {
+  test('shows Discord and Email auth segments', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
-    await expect(page.getByRole('tab', { name: /discord/i })).toBeVisible();
-    await expect(page.getByRole('tab', { name: /email/i })).toBeVisible();
+    await expect(authSegment(page, /discord/i)).toBeAttached();
+    await expect(authSegment(page, /email/i)).toBeAttached();
   });
 
-  test('Discord tab is selected by default', async ({ page }) => {
+  test('Discord auth segment is selected by default', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
-    await expect(page.getByRole('tab', { name: /discord/i }))
-      .toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('button', { name: /continue with discord/i })).toBeVisible();
   });
 
   test('Email tab shows email input, password input and Login button', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     // Flutter creates real <input> elements in the accessibility layer
@@ -35,7 +34,7 @@ test.describe('Login page — UI', () => {
   test('Forgot password and Sign up links are visible on Email tab', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     // These TextButtons may be below the fold inside the 320px tab container.
@@ -53,7 +52,7 @@ test.describe('Login page — UI', () => {
   test('submitting empty form stays on login page', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     await page.getByRole('button', { name: 'Login', exact: true }).click();
@@ -70,7 +69,7 @@ test.describe('Login page — UI', () => {
     const password = process.env.TEST_PASSWORD;
     if (!email || !password) test.skip(true, 'TEST_EMAIL / TEST_PASSWORD not set');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     const emailInput = page.getByRole('textbox', { name: 'Email' });
@@ -102,7 +101,7 @@ test.describe('Login page — UI', () => {
     const email = process.env.TEST_EMAIL;
     if (!email) test.skip(true, 'TEST_EMAIL not set');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     const emailInput = page.getByRole('textbox', { name: 'Email' });
@@ -129,7 +128,7 @@ test.describe('Login page — UI', () => {
   test('malformed email in login form is caught by client-side validation', async ({ page }) => {
     if (!(await hasFlutterSemantics(page))) test.skip(true, 'Flutter semantics unavailable');
 
-    await page.getByRole('tab', { name: /email/i }).click();
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     const emailInput = page.getByRole('textbox', { name: 'Email' });

--- a/e2e/tests/logout.spec.ts
+++ b/e2e/tests/logout.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { hasFlutterSemantics, enableFlutterSemantics } from './helpers';
+import { authSegment, clickAuthSegment, hasFlutterSemantics, enableFlutterSemantics } from './helpers';
 
 // This spec runs with saved auth state (chromium-auth project).
 // It tests the logout flow available from the top app bar.
@@ -92,11 +92,7 @@ test.describe('Logout', () => {
     );
 
     // Confirm the login page is shown
-    await expect(
-      page.getByText(/Discord/i)
-        .or(page.getByRole('tab', { name: /discord/i }))
-        .first()
-    ).toBeAttached({ timeout: 5_000 });
+    await expect(authSegment(page, /discord/i)).toBeAttached({ timeout: 5_000 });
   });
 
   test('after logout, local auth state is cleared (login button visible)', async ({ page }) => {
@@ -114,7 +110,7 @@ test.describe('Logout', () => {
 
     // Switch to Email tab and verify Login button is visible (user is now unauthenticated)
     await page.waitForTimeout(2_000);
-    await page.getByRole('tab', { name: /email/i }).click({ timeout: 8_000 });
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     await expect(

--- a/e2e/tests/register.spec.ts
+++ b/e2e/tests/register.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
+import { authSegment, clickAuthSegment, enableFlutterSemantics, hasFlutterSemantics, waitForFlutter } from './helpers';
 
 async function openRegisterPage(page: any) {
   await page.goto('/');
@@ -7,7 +7,7 @@ async function openRegisterPage(page: any) {
   await enableFlutterSemantics(page);
 
   // Switch to Email tab on the login page
-  await page.getByRole('tab', { name: /email/i }).click();
+  await clickAuthSegment(page, /email/i);
   await page.waitForTimeout(500);
 
   // Click the "Sign up" TextButton
@@ -116,11 +116,7 @@ test.describe('Register page', () => {
     await page.waitForTimeout(600);
 
     // Back on login page — Email tab should be visible
-    await expect(
-      page.getByRole('tab', { name: /email/i })
-        .or(page.locator('flt-semantics[aria-label*="Email" i]'))
-        .first()
-    ).toBeAttached({ timeout: 8_000 });
+    await expect(authSegment(page, /email/i)).toBeAttached({ timeout: 8_000 });
   });
 
   // §3.8 — password missing uppercase
@@ -233,8 +229,8 @@ test.describe('Register page', () => {
     await page.waitForTimeout(6_000);
 
     const onLoginPage =
-      (await page.getByRole('tab', { name: /email/i }).count()) > 0 ||
-      (await page.getByRole('tab', { name: /discord/i }).count()) > 0;
+      (await authSegment(page, /email/i).count()) > 0 ||
+      (await authSegment(page, /discord/i).count()) > 0;
 
     const hasError =
       (await page.locator('flt-semantics[aria-label*="already" i]').count()) > 0 ||

--- a/e2e/tests/reset_password.spec.ts
+++ b/e2e/tests/reset_password.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { enableFlutterSemantics, hasFlutterSemantics } from './helpers';
+import { authSegment, clickAuthSegment, enableFlutterSemantics, hasFlutterSemantics } from './helpers';
 
 // Navigates to ResetPasswordPage via the forgot-password flow.
 // Requires TEST_EMAIL to be set — all tests skip gracefully otherwise.
@@ -18,10 +18,8 @@ async function navigateToResetPage(page: any): Promise<boolean> {
     // enableFlutterSemantics calls waitForFlutter internally — no need to call it separately
     await enableFlutterSemantics(page);
 
-    // Switch to Email tab — explicit waitFor caps the timeout at 8 s instead of 30 s default
-    const emailTab = page.getByRole('tab', { name: /email/i });
-    await emailTab.waitFor({ state: 'attached', timeout: 8_000 });
-    await emailTab.click({ timeout: 8_000 });
+    // Switch to Email auth segment — explicit waitFor caps the timeout at 8 s instead of 30 s default
+    await clickAuthSegment(page, /email/i);
     await page.waitForTimeout(500);
 
     // Open forgot password page
@@ -249,11 +247,7 @@ test.describe('Reset password page', () => {
     await backBtn.click({ timeout: 8_000 });
     await page.waitForTimeout(800);
 
-    // Login page: Email/Discord tabs should appear
-    await expect(
-      page.getByRole('tab', { name: /email/i })
-        .or(page.locator('flt-semantics[aria-label*="Email" i]'))
-        .first()
-    ).toBeAttached({ timeout: 8_000 });
+    // Login page: Email/Discord auth segments should appear
+    await expect(authSegment(page, /email/i)).toBeAttached({ timeout: 8_000 });
   });
 });

--- a/lib/core/services/push_notification_service.dart
+++ b/lib/core/services/push_notification_service.dart
@@ -503,12 +503,7 @@ class PushNotificationService {
     if (route == null || route.isEmpty) return;
 
     // Route handling will be expanded when backend payload contracts are final.
-    final context = globalNavigatorKey.currentContext;
-    if (context == null) return;
-
-    ScaffoldMessenger.maybeOf(
-      context,
-    )?.showSnackBar(SnackBar(content: Text('Notification opened: $route')));
+    DebugUtils.debugInfo('Push route not handled yet: $route');
   }
 
   Future<void> _openAdminPost(String postID) async {


### PR DESCRIPTION
## Summary
- remove the user-facing snackbar shown when opening route-based notifications
- keep an internal debug log until route navigation is implemented

## Validation
- flutter gen-l10n
- flutter analyze