### PR TITLE
fix(web): prevent empty announcement overlay

### DIFF
--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -82,7 +82,11 @@ class MyHomePageState extends State<MyHomePage> {
       return;
     }
 
-    await openAnnouncementStory(context, announcement: openingAnnouncement);
+    final displayed = await openAnnouncementStory(
+      context,
+      announcement: openingAnnouncement,
+    );
+    if (!displayed) return;
     await _announcementPresentationService.markDismissed(openingAnnouncement);
   }
 

--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -61,7 +61,9 @@ class MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _showOpeningAnnouncement() async {
-    if (!mounted || ModalRoute.of(context)?.isCurrent != true) {
+    if (!mounted ||
+        !supportsEmbeddedAnnouncementStories(isWeb: kIsWeb) ||
+        ModalRoute.of(context)?.isCurrent != true) {
       return;
     }
     if (!context.read<MyAppState>().isFeatureEnabled(

--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -85,6 +85,7 @@ class MyHomePageState extends State<MyHomePage> {
     final displayed = await openAnnouncementStory(
       context,
       announcement: openingAnnouncement,
+      canDisplay: () => mounted && ModalRoute.of(context)?.isCurrent == true,
     );
     if (!displayed) return;
     await _announcementPresentationService.markDismissed(openingAnnouncement);

--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -12,7 +12,6 @@ import 'package:clashkingapp/features/coc_accounts/presentation/coc_account_mana
 import 'package:clashkingapp/features/pages/presentation/dashboard_page.dart';
 import 'package:clashkingapp/features/pages/data/announcement_presentation_service.dart';
 import 'package:clashkingapp/features/pages/data/announcement_service.dart';
-import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
 import 'package:clashkingapp/features/pages/presentation/players_page.dart';
@@ -79,21 +78,11 @@ class MyHomePageState extends State<MyHomePage> {
         )) {
       return;
     }
-    final storyFilePath = await AnnouncementStoryCacheService().prepare(
-      openingAnnouncement,
-    );
-    if (storyFilePath == null) {
-      return;
-    }
     if (!mounted || ModalRoute.of(context)?.isCurrent != true) {
       return;
     }
 
-    await showAnnouncementStoryDialog(
-      context,
-      announcement: openingAnnouncement,
-      preparedFilePath: storyFilePath,
-    );
+    await openAnnouncementStory(context, announcement: openingAnnouncement);
     await _announcementPresentationService.markDismissed(openingAnnouncement);
   }
 

--- a/lib/core/services/push_notification_service.dart
+++ b/lib/core/services/push_notification_service.dart
@@ -12,7 +12,6 @@ import 'package:clashkingapp/core/utils/debug_utils.dart';
 import 'package:clashkingapp/common/widgets/dialogs/open_clash_dialog.dart';
 import 'package:clashkingapp/firebase_options.dart';
 import 'package:clashkingapp/features/pages/data/announcement_service.dart';
-import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
 import 'package:clashkingapp/features/pages/presentation/posts_page.dart';
@@ -681,20 +680,9 @@ class PushNotificationService {
     }
     if (navigator == null) return;
     if (announcement.storyUrl?.isNotEmpty == true) {
-      final preparedFilePath = await AnnouncementStoryCacheService().prepare(
-        announcement,
-      );
-      if (preparedFilePath == null) {
-        DebugUtils.debugWarning('Push story could not be prepared: $postID');
-        return;
-      }
       final storyContext = globalNavigatorKey.currentContext;
       if (storyContext == null || !storyContext.mounted) return;
-      await showAnnouncementStoryDialog(
-        storyContext,
-        announcement: announcement,
-        preparedFilePath: preparedFilePath,
-      );
+      await openAnnouncementStory(storyContext, announcement: announcement);
       return;
     }
     await navigator.push(

--- a/lib/features/pages/data/announcement_service.dart
+++ b/lib/features/pages/data/announcement_service.dart
@@ -29,11 +29,10 @@ class AnnouncementService {
   Future<List<AppAnnouncement>> getActiveAnnouncements() async {
     try {
       final locale = await GameDataService.resolvePreferredLocale();
-      final target = switch (defaultTargetPlatform) {
-        TargetPlatform.iOS => 'ios',
-        TargetPlatform.android => 'android',
-        _ => 'all',
-      };
+      final target = announcementTarget(
+        isWeb: kIsWeb,
+        platform: defaultTargetPlatform,
+      );
       final response = await _apiService.get(
         '/app/announcements/active?target=$target&locale=${Uri.encodeQueryComponent(locale.languageCode)}',
         requiresAuth: false,
@@ -91,11 +90,10 @@ class AnnouncementService {
     int offset = 0,
   }) async {
     final locale = await GameDataService.resolvePreferredLocale();
-    final target = switch (defaultTargetPlatform) {
-      TargetPlatform.iOS => 'ios',
-      TargetPlatform.android => 'android',
-      _ => 'all',
-    };
+    final target = announcementTarget(
+      isWeb: kIsWeb,
+      platform: defaultTargetPlatform,
+    );
     final response = await _apiService.get(
       '/app/posts?target=$target&limit=$limit&offset=$offset&locale=${Uri.encodeQueryComponent(locale.languageCode)}',
       requiresAuth: false,
@@ -119,4 +117,16 @@ class AnnouncementService {
           (response['next_offset'] as num?)?.toInt() ?? offset + items.length,
     );
   }
+}
+
+String announcementTarget({
+  required bool isWeb,
+  required TargetPlatform platform,
+}) {
+  if (isWeb) return 'all';
+  return switch (platform) {
+    TargetPlatform.iOS => 'ios',
+    TargetPlatform.android => 'android',
+    _ => 'all',
+  };
 }

--- a/lib/features/pages/presentation/announcement_story_dialog.dart
+++ b/lib/features/pages/presentation/announcement_story_dialog.dart
@@ -4,16 +4,22 @@ import 'dart:math' as math;
 
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 enum AnnouncementStoryResult { closed, completed }
+
+bool supportsEmbeddedAnnouncementStories({required bool isWeb}) => !isWeb;
 
 Future<AnnouncementStoryResult?> showAnnouncementStoryDialog(
   BuildContext context, {
   required AppAnnouncement announcement,
   required String preparedFilePath,
 }) {
+  if (!supportsEmbeddedAnnouncementStories(isWeb: kIsWeb)) {
+    return Future.value(null);
+  }
   return showGeneralDialog<AnnouncementStoryResult>(
     context: context,
     useRootNavigator: true,

--- a/lib/features/pages/presentation/announcement_story_dialog.dart
+++ b/lib/features/pages/presentation/announcement_story_dialog.dart
@@ -24,27 +24,25 @@ Uri? announcementStoryWebUri(AppAnnouncement announcement) {
   return null;
 }
 
-Future<AnnouncementStoryResult?> openAnnouncementStory(
+Future<bool> openAnnouncementStory(
   BuildContext context, {
   required AppAnnouncement announcement,
 }) async {
   if (kIsWeb) {
     final uri = announcementStoryWebUri(announcement);
-    if (uri != null) {
-      await launchUrl(uri, webOnlyWindowName: '_blank');
-    }
-    return null;
+    return uri != null && await launchUrl(uri, webOnlyWindowName: '_blank');
   }
 
   final preparedFilePath = await AnnouncementStoryCacheService().prepare(
     announcement,
   );
-  if (!context.mounted || preparedFilePath == null) return null;
-  return showAnnouncementStoryDialog(
+  if (!context.mounted || preparedFilePath == null) return false;
+  await showAnnouncementStoryDialog(
     context,
     announcement: announcement,
     preparedFilePath: preparedFilePath,
   );
+  return true;
 }
 
 Future<AnnouncementStoryResult?> showAnnouncementStoryDialog(

--- a/lib/features/pages/presentation/announcement_story_dialog.dart
+++ b/lib/features/pages/presentation/announcement_story_dialog.dart
@@ -27,6 +27,7 @@ Uri? announcementStoryWebUri(AppAnnouncement announcement) {
 Future<bool> openAnnouncementStory(
   BuildContext context, {
   required AppAnnouncement announcement,
+  bool Function()? canDisplay,
 }) async {
   if (kIsWeb) {
     final uri = announcementStoryWebUri(announcement);
@@ -36,7 +37,11 @@ Future<bool> openAnnouncementStory(
   final preparedFilePath = await AnnouncementStoryCacheService().prepare(
     announcement,
   );
-  if (!context.mounted || preparedFilePath == null) return false;
+  if (!context.mounted ||
+      preparedFilePath == null ||
+      (canDisplay != null && !canDisplay())) {
+    return false;
+  }
   await showAnnouncementStoryDialog(
     context,
     announcement: announcement,

--- a/lib/features/pages/presentation/announcement_story_dialog.dart
+++ b/lib/features/pages/presentation/announcement_story_dialog.dart
@@ -2,15 +2,50 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 enum AnnouncementStoryResult { closed, completed }
 
 bool supportsEmbeddedAnnouncementStories({required bool isWeb}) => !isWeb;
+
+Uri? announcementStoryWebUri(AppAnnouncement announcement) {
+  for (final candidate in [announcement.storyUrl, announcement.htmlUrl]) {
+    final uri = Uri.tryParse(candidate ?? '');
+    if (uri != null && uri.scheme == 'https' && uri.host.isNotEmpty) {
+      return uri;
+    }
+  }
+  return null;
+}
+
+Future<AnnouncementStoryResult?> openAnnouncementStory(
+  BuildContext context, {
+  required AppAnnouncement announcement,
+}) async {
+  if (kIsWeb) {
+    final uri = announcementStoryWebUri(announcement);
+    if (uri != null) {
+      await launchUrl(uri, webOnlyWindowName: '_blank');
+    }
+    return null;
+  }
+
+  final preparedFilePath = await AnnouncementStoryCacheService().prepare(
+    announcement,
+  );
+  if (!context.mounted || preparedFilePath == null) return null;
+  return showAnnouncementStoryDialog(
+    context,
+    announcement: announcement,
+    preparedFilePath: preparedFilePath,
+  );
+}
 
 Future<AnnouncementStoryResult?> showAnnouncementStoryDialog(
   BuildContext context, {

--- a/lib/features/pages/presentation/posts_page.dart
+++ b/lib/features/pages/presentation/posts_page.dart
@@ -1,7 +1,6 @@
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/features/pages/data/announcement_service.dart';
-import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
@@ -161,13 +160,7 @@ class _PostArchiveCard extends StatelessWidget {
 
   Future<void> _open(BuildContext context) async {
     if (post.isStory) {
-      final path = await AnnouncementStoryCacheService().prepare(post);
-      if (!context.mounted || path == null) return;
-      await showAnnouncementStoryDialog(
-        context,
-        announcement: post,
-        preparedFilePath: path,
-      );
+      await openAnnouncementStory(context, announcement: post);
       return;
     }
     if (!context.mounted) return;

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -5,7 +5,6 @@ import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/functions/functions.dart';
 import 'package:clashkingapp/features/pages/data/announcement_service.dart';
-import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
@@ -1161,17 +1160,7 @@ VoidCallback? _bannerItemOnTap(BuildContext context, _BannerItem item) {
   return () async {
     if (hasStory) {
       final announcement = item.announcement!;
-      final storyFilePath = await AnnouncementStoryCacheService().prepare(
-        announcement,
-      );
-      if (!context.mounted || storyFilePath == null) {
-        return;
-      }
-      await showAnnouncementStoryDialog(
-        context,
-        announcement: announcement,
-        preparedFilePath: storyFilePath,
-      );
+      await openAnnouncementStory(context, announcement: announcement);
       return;
     }
     Navigator.of(context).push(
@@ -1517,16 +1506,7 @@ class _BannerTileState extends State<_BannerTile>
         : () async {
             if (hasStory) {
               final announcement = item.announcement!;
-              final storyFilePath = await AnnouncementStoryCacheService()
-                  .prepare(announcement);
-              if (!context.mounted || storyFilePath == null) {
-                return;
-              }
-              await showAnnouncementStoryDialog(
-                context,
-                announcement: announcement,
-                preparedFilePath: storyFilePath,
-              );
+              await openAnnouncementStory(context, announcement: announcement);
               return;
             }
             Navigator.of(context).push(

--- a/test/features/pages/data/announcement_service_test.dart
+++ b/test/features/pages/data/announcement_service_test.dart
@@ -2,11 +2,34 @@ import 'dart:convert';
 
 import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:clashkingapp/features/pages/data/announcement_service.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
 void main() {
+  test('web requests announcements for all platforms', () {
+    expect(
+      announcementTarget(isWeb: true, platform: TargetPlatform.android),
+      'all',
+    );
+    expect(
+      announcementTarget(isWeb: true, platform: TargetPlatform.iOS),
+      'all',
+    );
+  });
+
+  test('native requests announcements for its platform', () {
+    expect(
+      announcementTarget(isWeb: false, platform: TargetPlatform.android),
+      'android',
+    );
+    expect(
+      announcementTarget(isWeb: false, platform: TargetPlatform.iOS),
+      'ios',
+    );
+  });
+
   test('loads a paginated archive of current and past posts', () async {
     final client = MockClient((request) async {
       expect(request.url.path, endsWith('/app/posts'));

--- a/test/features/pages/presentation/announcement_story_dialog_test.dart
+++ b/test/features/pages/presentation/announcement_story_dialog_test.dart
@@ -1,9 +1,31 @@
 import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
+import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('embedded announcement stories are disabled on web', () {
     expect(supportsEmbeddedAnnouncementStories(isWeb: true), isFalse);
     expect(supportsEmbeddedAnnouncementStories(isWeb: false), isTrue);
+  });
+
+  test('web stories open only trusted HTTPS URLs', () {
+    const story = AppAnnouncement(
+      id: 'story',
+      title: 'Story',
+      subtitle: 'Details',
+      storyUrl: 'https://cdn.example.com/story.html',
+    );
+    const unsafeStory = AppAnnouncement(
+      id: 'unsafe',
+      title: 'Unsafe',
+      subtitle: 'Details',
+      storyUrl: 'javascript:alert(1)',
+    );
+
+    expect(
+      announcementStoryWebUri(story),
+      Uri.parse('https://cdn.example.com/story.html'),
+    );
+    expect(announcementStoryWebUri(unsafeStory), isNull);
   });
 }

--- a/test/features/pages/presentation/announcement_story_dialog_test.dart
+++ b/test/features/pages/presentation/announcement_story_dialog_test.dart
@@ -1,0 +1,9 @@
+import 'package:clashkingapp/features/pages/presentation/announcement_story_dialog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('embedded announcement stories are disabled on web', () {
+    expect(supportsEmbeddedAnnouncementStories(isWeb: true), isFalse);
+    expect(supportsEmbeddedAnnouncementStories(isWeb: false), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- prevent native WebView announcement stories from opening on Flutter Web
- request platform-neutral announcements on Web instead of inheriting the browser OS
- add regression tests for Web targeting and embedded-story support

## Validation
- flutter analyze
- flutter test (626 tests)
- flutter build web --release