### PR TITLE
fix(web): avoid blurred mobile tab content

### DIFF
--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -37,6 +37,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class MyHomePageState extends State<MyHomePage> {
+  static const _mainPages = <Widget>[
+    DashboardPage(),
+    PlayersPage(),
+    ClanPage(),
+    WarCwlPage(),
+  ];
+
   int _selectedIndex = 0;
   late PageController _pageController;
   late final AnnouncementService _announcementService;
@@ -193,16 +200,13 @@ class MyHomePageState extends State<MyHomePage> {
         onSearchTap: _openSearchOverlay,
         onProfileTap: () => _scaffoldKey.currentState?.openDrawer(),
       ),
-      body: PageView(
-        controller: _pageController,
-        onPageChanged: _onPageChanged,
-        children: const [
-          DashboardPage(),
-          PlayersPage(),
-          ClanPage(),
-          WarCwlPage(),
-        ],
-      ),
+      body: kIsWeb
+          ? IndexedStack(index: _selectedIndex, children: _mainPages)
+          : PageView(
+              controller: _pageController,
+              onPageChanged: _onPageChanged,
+              children: _mainPages,
+            ),
       bottomNavigationBar: usesNativeGlassPlatform
           ? _NativeIOSTabBar(
               selectedIndex: _selectedIndex,


### PR DESCRIPTION
## Summary
- render narrow Web tabs with an IndexedStack instead of a transformed PageView
- keep all tab pages mounted for smooth switching
- preserve swipe-based PageView navigation on native Android and iOS

## Why
On Chrome mobile, the blur is confined exactly to the PageView body while the app header and bottom navigation remain sharp. The API is responding and the underlying Home data is already rendered, so this targets the Web rasterization layer rather than data loading.

## Validation
- dart analyze lib/core/app/my_home_page.dart
- flutter build web --release