### PR TITLE
fix: show already-linked accounts when none are verified yet

### DIFF
--- a/lib/features/coc_accounts/presentation/coc_account_management_page.dart
+++ b/lib/features/coc_accounts/presentation/coc_account_management_page.dart
@@ -39,17 +39,14 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
   @override
   void initState() {
     super.initState();
-    final CocAccountService cocService = context.read<CocAccountService>();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       DeepLinkHandler.tryHandlePendingDeepLink(context);
     });
-    if (!cocService.hasVerifiedAccounts) {
-      setState(() {
-        _isFirstConnection = true;
-      });
-    } else {
-      _syncTempAccountsWithPlayerService();
-    }
+    // Always sync — it already sets _isFirstConnection from
+    // hasVerifiedAccounts itself. Skipping it when there were no verified
+    // accounts left _tempUserAccounts empty, so already-linked-but-
+    // unverified accounts silently vanished from the list below.
+    _syncTempAccountsWithPlayerService();
   }
 
   Future<void> _loadAllAccountData() async {


### PR DESCRIPTION
## Summary
- `AddCocAccountPageState.initState()` skipped calling `_syncTempAccountsWithPlayerService()` whenever the user had no verified accounts yet, leaving `_tempUserAccounts` empty for the lifetime of the page.
- The empty-state check (`userAccounts.isEmpty`) reads from `cocService.cocAccounts` directly, while the actual `ReorderableListView` renders from `_tempUserAccounts` — so already-linked-but-unverified accounts silently disappeared from the account management screen instead of showing up with a "verify" prompt.
- Now `initState()` always calls `_syncTempAccountsWithPlayerService()`, which already derives `_isFirstConnection` from `hasVerifiedAccounts` internally, so both code paths are unified into one.

## Test plan
- [x] `flutter analyze` passes with no issues
- [ ] Confirm previously-linked, unverified accounts now appear in the account management list with the "verify" badge
- [ ] Confirm the first-connection (no linked accounts at all) empty state still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AK4LJvDDSNCNX7sEM1H1o