### PR TITLE
refactor: align the home dashboard with the rest of the app

### DIFF
--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -4,6 +4,24 @@ This is the reference for the visual language shared by every detail screen in t
 
 The philosophy in one line: **one flat surface with rounded rows — never a card inside a card.**
 
+## Where the truth lives
+
+> **Tokens and cross-client primitives live in DevKit** (`design/` in the
+> `ClashKingInc/DevKit` repo, consumed here as the `clashking_design_system`
+> package). Colours, radii, spacing, opacity, typography roles and the `CK*`
+> widgets are defined there and must not be redefined here — see
+> `design/docs/components.md` and `design/docs/governance.md`.
+>
+> **This document covers what DevKit does not**: the app's layout patterns,
+> its local widget catalog, and the known gaps.
+>
+> When the two disagree, **the shipped app wins and the docs get fixed** — not
+> the other way round. This is not hypothetical: `components.md` presents
+> `CKMetricChip` as *the* answer for "compact label/value stats", but the
+> Player and Clan cards deliberately use a different, quieter shape (see
+> [Two chip roles](#two-chip-roles)). Reading the doc without reading the
+> screens produced a home dashboard that matched nothing, twice.
+
 ## Contents
 - [Tokens](#tokens)
 - [Component catalog](#component-catalog)
@@ -84,6 +102,38 @@ Two tiers, by what the icon represents:
 ## Component catalog
 
 All in `lib/common/widgets/`.
+
+### Two chip roles
+
+DevKit's `components.md` describes `CKMetricChip` as the shape for "compact
+label/value stats". That is true **inside a hero header's stats panel**, and
+misleading everywhere else. The app actually runs two distinct shapes, and
+picking the wrong one is the single easiest way to make a new screen look
+foreign:
+
+| | **Card tag** | **Header stat tile** |
+| --- | --- | --- |
+| Where | inside a list/summary card | in a hero header's stats panel |
+| Shape | pill (`999`), one or two lines | `CKRadius.control`, label over value |
+| Fill | quiet `surface @ 0.5`, hairline border | tinted by the stat's own colour |
+| Leading | bare game asset, no circle | asset in a 26px circle |
+| Examples | `players_page.dart`'s `_InfoChip`, `clan_page.dart`'s `_ClanChipShell`, `home_metric_pill.dart` | `MetricChip`/`MetricChipGrid` → `CKMetricChip` |
+
+Rule of thumb: **a card already is a surface, so its contents stay quiet; a
+hero header is artwork, so its stats need their own fill to read.** If you are
+adding a chip inside a `Card`, copy the pill; if you are adding one to a
+header panel, use `MetricChip`.
+
+### `home_metric_pill.dart`
+- **`HomeMetricPill`** — the card-tag pill used by all three home dashboard
+  cards. Label (+ optional `meta`) over a value, completion carried by the
+  value's colour rather than by any added badge or bar.
+
+### `home_account_rail.dart`
+- **`HomeAccountRail`** — account switcher shown in a home card's header in
+  place of pager dots. Only the selected entry expands to show its name; a
+  single-entry rail renders as a non-interactive label. Optional per-entry
+  status badge (filled = something pending, hollow = settled).
 
 ### `summary_chips.dart`
 - **`ClanSummaryChip`** — read-only stat pill: dot-or-icon, bold value, muted label. `color` tints the icon/value; omit it for a neutral chip. Optional `onTap` wraps it in a tooltip + ripple.
@@ -207,5 +257,7 @@ Never a bare `Card` with a single line of text. Reference: `clan_info/clan_page.
 - `clan_info/clan_page.dart` has a richer filter row than `ClanFilterRail`/`ClanFilterChip`: a private `_FilterBar`/`_FilterPill`/`_FilterActionButton` (icon toggle that reveals a `Wrap` of chips on demand, plus optional trailing action icons and a middle `ClanSummaryChips` slot) already shared internally between its War Log and Statistics tabs. It isn't promoted to `common/widgets/` yet, so `clan_capital`/`cwl` screens fall back to the simpler always-visible `ClanFilterRail`. Worth promoting if a screen needs the collapsible behavior.
 - Not every existing card/row in the app has been retrofitted to reference `AppRadius`/`AppOpacity` by name — some still repeat the literal numbers (16/20/0.28/0.32/etc). Prefer the token in new/touched code; a full retrofit hasn't been done.
 - **Bespoke chip reimplementations**: several screens hand-roll their own icon+value pill instead of `ClanSummaryChip`/`ClanFilterChip` — `clan_header.dart`'s `_ClanQuickChip`/`_ClanChipRows`, `clan_members.dart`'s `_SortValueChip`, `pages/clan_page.dart`'s `_AccountCountChip`/`_ClanImageChip`/`_ClanIconChip`/`_ClanChipShell`, `players_page.dart`'s `_InfoChip`, `player_war_stats_profile_tab.dart`'s `_WarTypeChip`. Most have a genuine reason (image-vs-icon leading slot, different sizing, a `Wrap`-based auto-layout `ClanSummaryChip` doesn't do) rather than being pure duplication — audit case by case before consolidating, don't blanket-replace.
+  **Partly resolved**: `_InfoChip`, `_ClanChipShell` and `home_metric_pill.dart` are now understood as one shape with three copies — the *card tag* documented in [Two chip roles](#two-chip-roles). They share a recipe (pill radius, `surface @ 0.5`, `outlineVariant @ 0.18`, bare leading asset) but no code. Per DevKit's `governance.md` — reusable visual vocabulary, no dependency on product state, three consumers already — this belongs upstream as a `CK*` primitive rather than being consolidated locally. Until that lands, copy the recipe; do not invent a fourth variant.
+- **`HomeMetricPill` and `HomeAccountRail` are candidates for DevKit**: both encode a reusable vocabulary with no product-state dependency. `HomeMetricPill` additionally wants a `progress`-free completion convention that DevKit has no primitive for yet.
 - **`Card` still used outside the migrated screens**: clan/CWL/capital/player-war-stats no longer use `Card` (the three instances found in `cwl_team_card.dart`/`cwl_member_card.dart`/`cwl_round_card.dart` were converted to the flat pattern). Plenty of `Card` usage remains elsewhere — auth flow dialogs (`forgot_password`, `reset_password`, `email_verification`, `account_management`), `clan_search_filters_dialog.dart`, and a handful of simple empty-state placeholders (`clan_war_log.dart`, `clan_members.dart`, `pages/clan_page.dart`, `player_legend_by_day.dart`). These are outside this system's current scope (mostly dialogs/simple lists, not the hero-header detail screens this document targets) — migrate opportunistically, not as a forced sweep.
 - This document currently covers the Flutter app only. If `ClashKingDashboard` (web) ever needs to share visual identity, only the token layer (color/radius/opacity values, not the Flutter widgets themselves) would be portable — see the "design system repo" discussion in project history for why a shared component library isn't feasible across Flutter and web.

--- a/lib/common/widgets/home_account_rail.dart
+++ b/lib/common/widgets/home_account_rail.dart
@@ -72,16 +72,43 @@ class HomeAccountRail extends StatelessWidget {
   Widget build(BuildContext context) {
     if (entries.isEmpty) return const SizedBox.shrink();
 
-    // A single account still gets its pill, just not as a control: hiding the
-    // rail outright left the card with no name and no town hall at all, since
-    // the ring had taken the artwork's place. It reads as a label rather than
-    // a switcher because there is nothing to switch to.
+    // A single account gets a plain subtitle, not a pill. A bordered pill
+    // announces a control, so on a card with nothing to switch to it sat
+    // there looking tappable and inert — and repeated the same name on all
+    // three cards. This is the subtitle the cards carried before the rail.
     if (entries.length == 1) {
-      return SizedBox(
-        height: height,
-        child: Align(
-          alignment: Alignment.centerLeft,
-          child: _RailItem(entry: entries.first, selected: true, onTap: null),
+      final entry = entries.first;
+      // Sized by its text, not by [height]: that height exists to give the
+      // pills a 44dp tap target, and a label has nothing to tap, so
+      // reserving it just left a hole under the title.
+      return Padding(
+        padding: const EdgeInsets.only(top: 1, bottom: 3),
+        child: Row(
+          children: [
+            if (entry.imageUrl != null)
+              Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: SizedBox.square(
+                  dimension: 20,
+                  child: MobileWebImage(
+                    imageUrl: entry.imageUrl!,
+                    fit: BoxFit.contain,
+                    errorWidget: (context, url, error) => const SizedBox(),
+                  ),
+                ),
+              ),
+            Flexible(
+              child: Text(
+                entry.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ],
         ),
       );
     }

--- a/lib/common/widgets/home_account_rail.dart
+++ b/lib/common/widgets/home_account_rail.dart
@@ -1,0 +1,222 @@
+import 'package:clashking_design_system/clashking_design_system.dart';
+import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:flutter/material.dart';
+
+/// One entry of a [HomeAccountRail].
+class HomeAccountRailEntry {
+  const HomeAccountRailEntry({
+    required this.label,
+    this.imageUrl,
+    this.fallbackIcon,
+    this.hasPendingActions,
+  });
+
+  /// Identifies the entry — shown when selected, and always exposed to
+  /// tooltips and screen readers.
+  final String label;
+
+  final String? imageUrl;
+  final IconData? fallbackIcon;
+
+  /// Drives the badge on the avatar: red when something is still expected of
+  /// this account, green when it's settled, nothing when unknown.
+  ///
+  /// This is the one place a status dot earns its keep — an avatar carries no
+  /// text, so the badge answers "who still has something to do" without
+  /// opening each account in turn, which is precisely what the pager could
+  /// never show.
+  final bool? hasPendingActions;
+}
+
+/// Account switcher in a home card's header, in place of pager dots.
+///
+/// Dots only said "there are 4 pages": finding a given account meant swiping
+/// through the others and back, and nothing said which page was whose. The
+/// rail names them and jumps straight there.
+///
+/// Only the selected entry expands to show its label. Several accounts
+/// commonly share a town hall level, so the artwork alone can't tell them
+/// apart — but a label under every avatar made the rail wide and ragged, so
+/// the unselected ones stay plain circles and are identified by tapping,
+/// which is how you switch account anyway.
+///
+/// Past a handful of entries the rail scrolls horizontally. That stays
+/// workable because the order is the one the user set in account management,
+/// so a given account's position is stable and learnable.
+class HomeAccountRail extends StatelessWidget {
+  const HomeAccountRail({
+    super.key,
+    required this.entries,
+    required this.selectedIndex,
+    required this.onSelect,
+  });
+
+  final List<HomeAccountRailEntry> entries;
+  final int selectedIndex;
+  final ValueChanged<int> onSelect;
+
+  /// Height the rail occupies — home cards size their headers against this.
+  static const double height = 28;
+
+  /// Keeps one long account name from pushing the rest of the rail off-screen.
+  static const double _maxLabelWidth = 92;
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.length < 2) return const SizedBox.shrink();
+
+    return SizedBox(
+      height: height,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        // Always accept the horizontal drag, even when every entry already
+        // fits. Otherwise the rail declines the gesture, it bubbles up to the
+        // app's main PageView, and trying to check for more accounts silently
+        // navigates to the Players tab instead.
+        physics: const AlwaysScrollableScrollPhysics(
+          parent: BouncingScrollPhysics(),
+        ),
+        itemCount: entries.length,
+        separatorBuilder: (context, index) => const SizedBox(width: 4),
+        itemBuilder: (context, index) => _RailItem(
+          entry: entries[index],
+          selected: index == selectedIndex,
+          onTap: () => onSelect(index),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small badge on an avatar's corner: red while the account still has
+/// something to do, green once it's settled.
+///
+/// Ringed in the card's own surface colour so it stays legible whatever the
+/// town hall artwork behind it looks like.
+class _PendingBadge extends StatelessWidget {
+  const _PendingBadge({required this.pending});
+
+  final bool pending;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      width: 9,
+      height: 9,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: pending ? CKColors.lossRed : CKColors.donationGreen,
+        border: Border.all(color: colorScheme.surface, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _RailItem extends StatelessWidget {
+  const _RailItem({
+    required this.entry,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final HomeAccountRailEntry entry;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final fallback = Icon(
+      entry.fallbackIcon ?? Icons.person_rounded,
+      size: 16,
+      color: colorScheme.onSurfaceVariant,
+    );
+
+    return Tooltip(
+      message: entry.label,
+      child: Semantics(
+        button: true,
+        selected: selected,
+        label: entry.label,
+        child: InkResponse(
+          onTap: onTap,
+          radius: HomeAccountRail.height * 0.7,
+          child: Container(
+            height: HomeAccountRail.height,
+            padding: EdgeInsets.only(right: selected ? 9 : 0),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(CKRadius.pill),
+              color: colorScheme.surfaceContainerHighest.withValues(
+                alpha: selected ? 0.55 : 0.25,
+              ),
+              border: Border.all(
+                color: selected
+                    ? colorScheme.primary
+                    : colorScheme.outlineVariant.withValues(alpha: 0.24),
+                width: selected ? 1.6 : 1,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox.square(
+                  dimension: HomeAccountRail.height - 2,
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: Opacity(
+                          // Unselected entries recede so the rail reads as one
+                          // control rather than a row of equal buttons.
+                          opacity: selected ? 1 : 0.5,
+                          child: Padding(
+                            padding: const EdgeInsets.all(3),
+                            child: entry.imageUrl != null
+                                ? MobileWebImage(
+                                    imageUrl: entry.imageUrl!,
+                                    fit: BoxFit.contain,
+                                    errorWidget: (context, url, error) =>
+                                        fallback,
+                                  )
+                                : fallback,
+                          ),
+                        ),
+                      ),
+                      if (entry.hasPendingActions != null)
+                        Positioned(
+                          right: 0,
+                          top: 0,
+                          child: _PendingBadge(
+                            pending: entry.hasPendingActions!,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (selected) ...[
+                  const SizedBox(width: 5),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxWidth: HomeAccountRail._maxLabelWidth,
+                    ),
+                    child: Text(
+                      entry.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w900,
+                        height: 1,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/home_account_rail.dart
+++ b/lib/common/widgets/home_account_rail.dart
@@ -70,7 +70,21 @@ class HomeAccountRail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (entries.length < 2) return const SizedBox.shrink();
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    // A single account still gets its pill, just not as a control: hiding the
+    // rail outright left the card with no name and no town hall at all, since
+    // the ring had taken the artwork's place. It reads as a label rather than
+    // a switcher because there is nothing to switch to.
+    if (entries.length == 1) {
+      return SizedBox(
+        height: height,
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: _RailItem(entry: entries.first, selected: true, onTap: null),
+        ),
+      );
+    }
 
     return SizedBox(
       height: height,
@@ -136,7 +150,10 @@ class _RailItem extends StatelessWidget {
 
   final HomeAccountRailEntry entry;
   final bool selected;
-  final VoidCallback onTap;
+
+  /// Null when the rail holds a single account: the pill is then a label, so
+  /// it must not advertise a tap that would do nothing.
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -150,7 +167,7 @@ class _RailItem extends StatelessWidget {
     return Tooltip(
       message: entry.label,
       child: Semantics(
-        button: true,
+        button: onTap != null,
         selected: selected,
         label: entry.label,
         child: InkResponse(

--- a/lib/common/widgets/home_account_rail.dart
+++ b/lib/common/widgets/home_account_rail.dart
@@ -56,7 +56,14 @@ class HomeAccountRail extends StatelessWidget {
   final ValueChanged<int> onSelect;
 
   /// Height the rail occupies — home cards size their headers against this.
-  static const double height = 28;
+  ///
+  /// The visible pill stays [_pillHeight]; the rest is invisible padding that
+  /// brings the tap target to the 44pt/48dp minimum. Sizing the row to the
+  /// pill alone made every account a 28px target, worse than the 42px
+  /// `HeaderIconButton` the design system already flags as too small.
+  static const double height = 44;
+
+  static const double _pillHeight = 28;
 
   /// Keeps one long account name from pushing the rest of the rail off-screen.
   static const double _maxLabelWidth = 92;
@@ -107,8 +114,14 @@ class _PendingBadge extends StatelessWidget {
       height: 9,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: pending ? CKColors.lossRed : CKColors.donationGreen,
-        border: Border.all(color: colorScheme.surface, width: 1.4),
+        // Filled when something is pending, hollow once settled: red and
+        // green sit on the commonest colour-blindness axis, so the state has
+        // to survive without the hue.
+        color: pending ? CKColors.lossRed : Colors.transparent,
+        border: Border.all(
+          color: pending ? colorScheme.surface : CKColors.donationGreen,
+          width: pending ? 1.4 : 2,
+        ),
       ),
     );
   }
@@ -143,76 +156,82 @@ class _RailItem extends StatelessWidget {
         child: InkResponse(
           onTap: onTap,
           radius: HomeAccountRail.height * 0.7,
-          child: Container(
+          child: SizedBox(
             height: HomeAccountRail.height,
-            padding: EdgeInsets.only(right: selected ? 9 : 0),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(CKRadius.pill),
-              color: colorScheme.surfaceContainerHighest.withValues(
-                alpha: selected ? 0.55 : 0.25,
-              ),
-              border: Border.all(
-                color: selected
-                    ? colorScheme.primary
-                    : colorScheme.outlineVariant.withValues(alpha: 0.24),
-                width: selected ? 1.6 : 1,
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SizedBox.square(
-                  dimension: HomeAccountRail.height - 2,
-                  child: Stack(
-                    children: [
-                      Positioned.fill(
-                        child: Opacity(
-                          // Unselected entries recede so the rail reads as one
-                          // control rather than a row of equal buttons.
-                          opacity: selected ? 1 : 0.5,
-                          child: Padding(
-                            padding: const EdgeInsets.all(3),
-                            child: entry.imageUrl != null
-                                ? MobileWebImage(
-                                    imageUrl: entry.imageUrl!,
-                                    fit: BoxFit.contain,
-                                    errorWidget: (context, url, error) =>
-                                        fallback,
-                                  )
-                                : fallback,
-                          ),
-                        ),
-                      ),
-                      if (entry.hasPendingActions != null)
-                        Positioned(
-                          right: 0,
-                          top: 0,
-                          child: _PendingBadge(
-                            pending: entry.hasPendingActions!,
-                          ),
-                        ),
-                    ],
+            child: Center(
+              child: Container(
+                height: HomeAccountRail._pillHeight,
+                padding: EdgeInsets.only(right: selected ? 9 : 0),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(CKRadius.pill),
+                  color: colorScheme.surfaceContainerHighest.withValues(
+                    alpha: selected ? 0.55 : 0.25,
+                  ),
+                  border: Border.all(
+                    color: selected
+                        ? colorScheme.primary
+                        : colorScheme.outlineVariant.withValues(alpha: 0.24),
+                    width: selected ? 1.6 : 1,
                   ),
                 ),
-                if (selected) ...[
-                  const SizedBox(width: 5),
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(
-                      maxWidth: HomeAccountRail._maxLabelWidth,
-                    ),
-                    child: Text(
-                      entry.label,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w900,
-                        height: 1,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox.square(
+                      dimension: HomeAccountRail._pillHeight - 2,
+                      child: Stack(
+                        children: [
+                          Positioned.fill(
+                            child: Opacity(
+                              // Unselected entries recede so the rail reads as one
+                              // control rather than a row of equal buttons.
+                              opacity: selected ? 1 : 0.5,
+                              child: Padding(
+                                padding: const EdgeInsets.all(3),
+                                child: entry.imageUrl != null
+                                    ? MobileWebImage(
+                                        imageUrl: entry.imageUrl!,
+                                        fit: BoxFit.contain,
+                                        errorWidget: (context, url, error) =>
+                                            fallback,
+                                      )
+                                    : fallback,
+                              ),
+                            ),
+                          ),
+                          if (entry.hasPendingActions != null)
+                            Positioned(
+                              right: 0,
+                              top: 0,
+                              child: _PendingBadge(
+                                pending: entry.hasPendingActions!,
+                              ),
+                            ),
+                        ],
                       ),
                     ),
-                  ),
-                ],
-              ],
+                    if (selected) ...[
+                      const SizedBox(width: 5),
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(
+                          maxWidth: HomeAccountRail._maxLabelWidth,
+                        ),
+                        child: Text(
+                          entry.label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelMedium
+                              ?.copyWith(
+                                color: colorScheme.onSurface,
+                                fontWeight: FontWeight.w900,
+                                height: 1,
+                              ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/common/widgets/home_metric_pill.dart
+++ b/lib/common/widgets/home_metric_pill.dart
@@ -1,0 +1,169 @@
+import 'package:clashking_design_system/clashking_design_system.dart';
+import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:flutter/material.dart';
+
+/// Home-card metric pill.
+///
+/// Shares its shell with the Player and Clan cards' chips (`_InfoChip` in
+/// `players_page.dart`, `_ClanChipShell` in `clan_page.dart`): pill radius,
+/// quiet `surface` fill, hairline `outlineVariant` border and a bare
+/// game-asset image with no icon circle. Those cards sit one bottom-nav tap
+/// away from the home dashboard, so the home cards have to read as the same
+/// family.
+///
+/// Completion is carried by the value's own color rather than by any added
+/// element. A progress bar, a proportional fill and a status dot were each
+/// tried and dropped: `0/3999` already says "not done" and `2/2` already says
+/// "done", so every extra device restated in a weaker form what the text was
+/// already saying — and a badge that lights up on almost every row stops
+/// being read at all.
+class HomeMetricPill extends StatelessWidget {
+  const HomeMetricPill({
+    super.key,
+    required this.label,
+    required this.value,
+    this.meta,
+    this.progress,
+    this.imageUrl,
+    this.fallbackIcon,
+    this.semanticLabel,
+  });
+
+  /// Two text lines plus padding. The home pagers need a deterministic height,
+  /// so it's pinned rather than measured — keep card height math expressed via
+  /// [gridHeight].
+  ///
+  /// Label and value are stacked rather than sharing a line because at two
+  /// pills per row there isn't room for `image + label + value + meta`: the
+  /// label was the one losing, ellipsising to "Clan Ga…" / "Build…".
+  static const double defaultHeight = 44;
+
+  /// Matches the Player/Clan cards' chip spacing.
+  static const double gap = CKSpacing.sm - 2;
+
+  /// Total height of [rows] stacked pills, gaps included.
+  static double gridHeight(int rows) =>
+      rows <= 0 ? 0 : rows * defaultHeight + (rows - 1) * gap;
+
+  final String label;
+  final String value;
+
+  /// Detail shown right of the label (a projected duration...).
+  final String? meta;
+
+  /// 0..1, or null when the metric has no known limit. Only used to decide
+  /// whether the value reads as settled; the ratio itself is already in
+  /// [value].
+  final double? progress;
+
+  final String? imageUrl;
+  final IconData? fallbackIcon;
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final progressValue = progress?.clamp(0.0, 1.0);
+    final isComplete = progressValue != null && progressValue >= 1;
+
+    return Semantics(
+      label: semanticLabel ?? '$label: $value',
+      excludeSemantics: true,
+      child: SizedBox(
+        height: defaultHeight,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colorScheme.surface.withValues(alpha: 0.5),
+            borderRadius: BorderRadius.circular(CKRadius.pill),
+            border: Border.all(
+              color: colorScheme.outlineVariant.withValues(alpha: 0.18),
+            ),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(CKRadius.pill),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 11),
+              child: Row(
+                children: [
+                  SizedBox.square(
+                    dimension: 20,
+                    child: imageUrl != null
+                        ? MobileWebImage(
+                            imageUrl: imageUrl!,
+                            fit: BoxFit.contain,
+                            errorWidget: (context, url, error) => Icon(
+                              fallbackIcon ?? Icons.circle_rounded,
+                              size: 16,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          )
+                        : Icon(
+                            fallbackIcon ?? Icons.circle_rounded,
+                            size: 16,
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                  ),
+                  const SizedBox(width: 7),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                label,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.labelMedium
+                                    ?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                      fontWeight: FontWeight.w700,
+                                      height: 1,
+                                    ),
+                              ),
+                            ),
+                            if (meta != null) ...[
+                              const SizedBox(width: 5),
+                              Text(
+                                meta!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.labelMedium
+                                    ?.copyWith(
+                                      color: colorScheme.onSurfaceVariant
+                                          .withValues(alpha: 0.7),
+                                      fontWeight: FontWeight.w700,
+                                      height: 1,
+                                    ),
+                              ),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          value,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: isComplete
+                                    ? CKColors.donationGreen
+                                    : colorScheme.onSurface,
+                                fontWeight: FontWeight.w900,
+                                height: 1,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/indicators/last_refresh_indicator.dart
+++ b/lib/common/widgets/indicators/last_refresh_indicator.dart
@@ -6,7 +6,15 @@ import 'package:intl/intl.dart';
 class LastRefreshIndicator extends StatefulWidget {
   final DateTime? lastRefresh;
 
-  const LastRefreshIndicator({super.key, required this.lastRefresh});
+  /// Optional: makes the indicator tappable. Without it the widget keeps its
+  /// original read-only behaviour.
+  final Future<void> Function()? onRefresh;
+
+  const LastRefreshIndicator({
+    super.key,
+    required this.lastRefresh,
+    this.onRefresh,
+  });
 
   @override
   State<LastRefreshIndicator> createState() => _LastRefreshIndicatorState();
@@ -69,28 +77,47 @@ class _LastRefreshIndicatorState extends State<LastRefreshIndicator> {
 
     final formattedTime = _formatRefreshTime(widget.lastRefresh!, context);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = AppLocalizations.of(
+      context,
+    )!.generalLastRefresh(formattedTime);
+
+    final row = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         children: [
           Icon(
             Icons.refresh,
             size: 12,
-            color: Theme.of(
-              context,
-            ).colorScheme.onSurface.withValues(alpha: 0.6),
+            color: colorScheme.onSurface.withValues(alpha: 0.6),
           ),
           const SizedBox(width: 4),
           Text(
-            AppLocalizations.of(context)!.generalLastRefresh(formattedTime),
+            label,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(
-                context,
-              ).colorScheme.onSurface.withValues(alpha: 0.6),
+              color: colorScheme.onSurface.withValues(alpha: 0.6),
             ),
           ),
         ],
+      ),
+    );
+
+    // The refresh glyph made this look actionable while it was inert, so the
+    // obvious tap did nothing and pull-to-refresh had to be discovered. When
+    // a caller wires [onRefresh] it becomes the button it already looked like.
+    if (widget.onRefresh == null) return Center(child: row);
+
+    return Center(
+      child: Semantics(
+        button: true,
+        label: label,
+        child: InkWell(
+          onTap: widget.onRefresh,
+          borderRadius: BorderRadius.circular(999),
+          child: row,
+        ),
       ),
     );
   }

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -1489,6 +1489,19 @@ class _UpgradeAccountPanel extends StatelessWidget {
                   active: account.petsActive ? 1 : 0,
                   total: 1,
                 ),
+              _UpgradeHomeMetricData(
+                imageUrl: ImageAssets.getHomeVillageBuildingImage('Wall', 1),
+                fallbackIcon: Icons.fence_rounded,
+                label: loc.dashboardUpgradeTrackerWalls,
+                meta: account.wallsLevelsRemaining > 0
+                    ? loc.todoItemsLeftShort(account.wallsLevelsRemaining)
+                    : null,
+                // Walls have no queue, so there is no active/total to show —
+                // the value is the completion ratio itself.
+                active: (account.wallsCompletion * 100).round(),
+                total: 100,
+                valueOverride: '${(account.wallsCompletion * 100).round()}%',
+              ),
             ],
           ),
         ],
@@ -1810,7 +1823,12 @@ class _UpgradeHomeMetricData {
     required this.active,
     required this.total,
     this.meta,
+    this.valueOverride,
   });
+
+  /// Set when the metric isn't a queue count — walls report a percentage
+  /// rather than "x of y slots busy".
+  final String? valueOverride;
 
   final String imageUrl;
   final IconData fallbackIcon;
@@ -1827,7 +1845,7 @@ class _UpgradeHomeMetricData {
   /// house): shown as a placeholder with no bar rather than a bogus `0/0`.
   bool get isKnown => total > 0;
 
-  String get value => isKnown ? '$active/$total' : '-';
+  String get value => valueOverride ?? (isKnown ? '$active/$total' : '-');
 
   double? get progress => isKnown ? (active / total).clamp(0.0, 1.0) : null;
 }
@@ -1982,6 +2000,8 @@ class _UpgradeHomeAccount {
     required this.name,
     required this.hallImageUrl,
     required this.completion,
+    required this.wallsCompletion,
+    required this.wallsLevelsRemaining,
     required this.projectedSeconds,
     required this.builderProjectedSeconds,
     required this.labProjectedSeconds,
@@ -1999,6 +2019,14 @@ class _UpgradeHomeAccount {
   final String name;
   final String hallImageUrl;
   final double completion;
+
+  /// Walls are reported as a completion ratio plus the levels still to buy,
+  /// not as `current/target`: those two are sums of levels (5764/5850 on a
+  /// near-maxed base), which means nothing to a player. `levelsRemaining` is
+  /// the count they actually think in — "86 walls left".
+  final double wallsCompletion;
+  final int wallsLevelsRemaining;
+
   final int projectedSeconds;
   final int builderProjectedSeconds;
   final int labProjectedSeconds;
@@ -2072,11 +2100,18 @@ class _UpgradeHomeAccount {
       queue: UpgradeQueue.pets,
     );
 
+    final walls = snapshot.summaryFor(
+      UpgradeCategory.walls,
+      village: UpgradeVillage.home,
+    );
+
     return _UpgradeHomeAccount(
       tag: snapshot.tag,
       name: snapshot.name,
       hallImageUrl: ImageAssets.townHall(snapshot.townHallLevel),
       completion: home.completion.clamp(0.0, 1.0),
+      wallsCompletion: walls.completion.clamp(0.0, 1.0),
+      wallsLevelsRemaining: walls.levelsRemaining,
       projectedSeconds: projectedSeconds,
       builderProjectedSeconds: builderProjectedSeconds,
       labProjectedSeconds: labProjectedSeconds,

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -1944,6 +1944,7 @@ class _UpgradeHomeAccount {
     required this.hallImageUrl,
     required this.completion,
     required this.needsUpdate,
+    required this.hasActionableQueueWork,
     required this.wallsAtMax,
     required this.wallsTotal,
     required this.projectedSeconds,
@@ -1970,19 +1971,20 @@ class _UpgradeHomeAccount {
   /// leave an idle account permanently flagged.
   final bool needsUpdate;
 
+  /// True when a queue slot is free and the snapshot still contains a
+  /// non-recurrent, unfinished item that is not already running. Idle slots by
+  /// themselves are not actionable on maxed accounts.
+  final bool hasActionableQueueWork;
+
   /// Wall segments already at their target level, out of the total. Counted
   /// per wall rather than per level, which is how players talk about them.
   final int wallsAtMax;
   final int wallsTotal;
 
-  /// Whether any build slot is sitting idle. This is what the rail badge
-  /// reports: the card exists to answer "do I need to go restart something",
-  /// so green means every builder, the lab and the pet house are all busy.
-  /// Walls are deliberately not part of it — they have no queue to start.
-  bool get hasIdleQueue =>
-      activeBuilders < totalBuilders ||
-      (hasLab && !labActive) ||
-      (hasPets && !petsActive);
+  /// Whether the rail should flag this account as needing attention. Stale
+  /// snapshots are actionable, as are idle queue slots with unfinished work to
+  /// start. Fully maxed accounts and wall-only leftovers stay settled.
+  bool get hasIdleQueue => needsUpdate || hasActionableQueueWork;
 
   final int projectedSeconds;
   final int builderProjectedSeconds;
@@ -2056,6 +2058,16 @@ class _UpgradeHomeAccount {
       village: UpgradeVillage.home,
       queue: UpgradeQueue.pets,
     );
+    final totalBuilders = snapshot.buildersFor(UpgradeVillage.home);
+    final labActive = isActive(UpgradeQueue.laboratory);
+    final petsActive = isActive(UpgradeQueue.pets);
+
+    bool hasIdleWork(Iterable<UpgradeTrackerItem> items) => items.any(
+      (item) =>
+          !item.recurrentHelper &&
+          !item.isComplete &&
+          snapshot.remainingActiveSeconds(item, now: now) <= 0,
+    );
 
     // Counted per wall, not per level: `summaryFor(walls)` reports sums of
     // levels (5764/5850 on a near-maxed base), which is not how anyone thinks
@@ -2078,6 +2090,10 @@ class _UpgradeHomeAccount {
         startedItems.every(
           (item) => snapshot.remainingActiveSeconds(item, now: now) <= 0,
         );
+    final hasActionableQueueWork =
+        (activeBuilders < totalBuilders && hasIdleWork(builderItems)) ||
+        (!labActive && hasIdleWork(labItems)) ||
+        (!petsActive && hasIdleWork(petItems));
 
     return _UpgradeHomeAccount(
       tag: snapshot.tag,
@@ -2085,6 +2101,7 @@ class _UpgradeHomeAccount {
       hallImageUrl: ImageAssets.townHall(snapshot.townHallLevel),
       completion: home.completion.clamp(0.0, 1.0),
       needsUpdate: needsUpdate,
+      hasActionableQueueWork: hasActionableQueueWork,
       wallsAtMax: wallsAtMax,
       wallsTotal: wallsTotal,
       projectedSeconds: projectedSeconds,
@@ -2092,10 +2109,10 @@ class _UpgradeHomeAccount {
       labProjectedSeconds: labProjectedSeconds,
       petProjectedSeconds: petProjectedSeconds,
       activeBuilders: activeBuilders,
-      totalBuilders: snapshot.buildersFor(UpgradeVillage.home),
-      labActive: isActive(UpgradeQueue.laboratory),
+      totalBuilders: totalBuilders,
+      labActive: labActive,
       hasLab: labItems.isNotEmpty,
-      petsActive: isActive(UpgradeQueue.pets),
+      petsActive: petsActive,
       hasPets: petItems.isNotEmpty,
       capturedAt: snapshot.capturedAt,
     );

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/home_account_rail.dart';
 import 'package:clashkingapp/common/widgets/home_metric_pill.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/app/my_app_state.dart';
@@ -92,7 +93,9 @@ class _HomeCardFrame extends StatelessWidget {
 class _HomeCardTappablePanel extends StatelessWidget {
   const _HomeCardTappablePanel({required this.onTap, required this.child});
 
-  final VoidCallback onTap;
+  /// Null on a combined "all accounts" view, which has no single destination
+  /// to open — the card then keeps its frame but stops being a button.
+  final VoidCallback? onTap;
   final Widget child;
 
   @override
@@ -577,31 +580,103 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
         final itemCount = summary.accounts.length + (hasSummaryPage ? 1 : 0);
         _clampIndex(itemCount);
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              // Panel chrome (padding, header, status row, gaps) + one pill row.
-              height: 120 + HomeMetricPill.gridHeight(1),
-              child: PageView.builder(
-                controller: _controller,
-                onPageChanged: (index) => setState(() => _index = index),
-                itemCount: itemCount,
-                itemBuilder: (context, index) =>
-                    _buildPage(summary, index, hasSummaryPage),
+        final loc = AppLocalizations.of(context)!;
+        final safeIndex = _index.clamp(0, itemCount - 1);
+        final isSummaryPage = hasSummaryPage && safeIndex == 0;
+        final account = isSummaryPage
+            ? null
+            : summary.accounts[safeIndex - (hasSummaryPage ? 1 : 0)];
+        // Attacks used, not defenses: attacks are the part the player can
+        // still act on, and it's what the status line underneath talks about.
+        final ringRatio = isSummaryPage
+            ? _rankedRatio(summary.totalAttacksDone, summary.totalAttacksMax)
+            : _rankedRatio(account!.attacksDone, account.maxBattles);
+
+        // Same split as the home to-do card: the frame, title and account
+        // rail stay put, only the status line and the pills ride the pager.
+        return _HomeCardTappablePanel(
+          onTap: account == null
+              ? null
+              : () => _openRankedLeague(account.player),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  SizedBox.square(
+                    dimension: 46,
+                    child: MobileWebImage(
+                      imageUrl: account?.tierIconUrl.isNotEmpty == true
+                          ? account!.tierIconUrl
+                          : ImageAssets.shieldWithArrow,
+                      fit: BoxFit.contain,
+                      errorWidget: (_, _, _) =>
+                          const Icon(Icons.emoji_events_rounded),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          loc.rankedLeagueTitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(fontWeight: FontWeight.w900),
+                        ),
+                        const SizedBox(height: 4),
+                        HomeAccountRail(
+                          selectedIndex: safeIndex,
+                          onSelect: (index) => _showPage(itemCount, index),
+                          entries: [
+                            if (hasSummaryPage)
+                              HomeAccountRailEntry(
+                                label: loc.todoAllAccounts,
+                                fallbackIcon: Icons.groups_rounded,
+                              ),
+                            for (final entry in summary.accounts)
+                              HomeAccountRailEntry(
+                                label: entry.name,
+                                imageUrl: entry.player.townHallPic,
+                                fallbackIcon: Icons.home_rounded,
+                                hasPendingActions:
+                                    _rankedRatio(
+                                      entry.attacksDone,
+                                      entry.maxBattles,
+                                    ) <
+                                    1,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  // The rank/trophy pill used to sit here and covered the rail
+                  // on a three-account row; it moved down to the status line,
+                  // where the ring can own the header's right edge like the
+                  // other two home cards.
+                  _UpgradeProgressRing(
+                    value: ringRatio,
+                    label: '${(ringRatio * 100).round()}%',
+                    size: _homeDashboardRingSize(context),
+                  ),
+                ],
               ),
-            ),
-            if (itemCount > 1) ...[
               const SizedBox(height: 8),
-              Center(
-                child: PageDotsIndicator(
-                  count: itemCount,
-                  index: _index,
-                  onDotTap: (index) => _showPage(itemCount, index),
+              SizedBox(
+                height: 22 + 10 + HomeMetricPill.gridHeight(1),
+                child: PageView.builder(
+                  controller: _controller,
+                  onPageChanged: (index) => setState(() => _index = index),
+                  itemCount: itemCount,
+                  itemBuilder: (context, index) =>
+                      _buildPage(summary, index, hasSummaryPage),
                 ),
               ),
             ],
-          ],
+          ),
         );
       },
     );
@@ -616,18 +691,16 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
       return _RankedAllAccountsPanel(summary: summary);
     }
     final account = summary.accounts[index - (hasSummaryPage ? 1 : 0)];
-    return _RankedAccountPanel(
-      account: account,
-      onTap: () => _openRankedLeague(account.player),
-    );
+    return _RankedAccountPanel(account: account);
   }
 }
 
+/// Pager body for one account: rank line plus its attack/defense pills. The
+/// card frame, title, account rail and trophy pill live in the card header.
 class _RankedAccountPanel extends StatelessWidget {
-  const _RankedAccountPanel({required this.account, required this.onTap});
+  const _RankedAccountPanel({required this.account});
 
   final _RankedHomeAccount account;
-  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -639,94 +712,51 @@ class _RankedAccountPanel extends StatelessWidget {
         ? loc.rankedLeagueNoGroup
         : '${loc.rankedLeagueGroupRank} #${formatter.format(account.rank)}';
 
-    return _HomeCardTappablePanel(
-      onTap: onTap,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              SizedBox.square(
-                dimension: 46,
-                child: account.tierIconUrl.isEmpty
-                    ? const Icon(Icons.emoji_events_rounded)
-                    : MobileWebImage(
-                        imageUrl: account.tierIconUrl,
-                        fit: BoxFit.contain,
-                        errorWidget: (_, _, _) =>
-                            const Icon(Icons.emoji_events_rounded),
-                      ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      loc.rankedLeagueTitle,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    Text(
-                      account.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                rankText,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              _RankedTrophyPill(value: formatter.format(account.trophies)),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  rankText,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Icon(
-                Icons.chevron_right_rounded,
-                size: 22,
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          _RankedHomeMetricBars(
-            metrics: [
-              _RankedHomeMetricData(
-                imageUrl: ImageAssets.sword,
-                fallbackIcon: Icons.sports_kabaddi_rounded,
-                label: loc.rankedLeagueAttacks,
-                done: account.attacksDone,
-                total: account.maxBattles,
-              ),
-              _RankedHomeMetricData(
-                imageUrl: ImageAssets.shieldWithArrow,
-                fallbackIcon: Icons.shield_rounded,
-                label: loc.rankedLeagueDefenses,
-                done: account.defensesDone,
-                total: account.maxBattles,
-              ),
-            ],
-          ),
-        ],
-      ),
+            ),
+            _RankedTrophyPill(value: formatter.format(account.trophies)),
+            const SizedBox(width: 6),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 22,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        _RankedHomeMetricBars(
+          metrics: [
+            _RankedHomeMetricData(
+              imageUrl: ImageAssets.sword,
+              fallbackIcon: Icons.sports_kabaddi_rounded,
+              label: loc.rankedLeagueAttacks,
+              done: account.attacksDone,
+              total: account.maxBattles,
+            ),
+            _RankedHomeMetricData(
+              imageUrl: ImageAssets.shieldWithArrow,
+              fallbackIcon: Icons.shield_rounded,
+              label: loc.rankedLeagueDefenses,
+              done: account.defensesDone,
+              total: account.maxBattles,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -743,87 +773,46 @@ class _RankedAllAccountsPanel extends StatelessWidget {
     final loc = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
 
-    return _HomeCardFrame(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              SizedBox.square(
-                dimension: 46,
-                child: MobileWebImage(
-                  imageUrl: ImageAssets.shieldWithArrow,
-                  fit: BoxFit.contain,
-                  errorWidget: (_, _, _) =>
-                      const Icon(Icons.emoji_events_rounded),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                _rankedSummaryStatus(context, summary),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      loc.rankedLeagueTitle,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    Text(
-                      _rankedSummarySubtitle(context, summary),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (summary.bestRank != null)
-                _RankedBestRankPill(rank: summary.bestRank!),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  _rankedSummaryStatus(context, summary),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          _RankedHomeMetricBars(
-            metrics: [
-              _RankedHomeMetricData(
-                imageUrl: ImageAssets.sword,
-                fallbackIcon: Icons.sports_kabaddi_rounded,
-                label: loc.rankedLeagueAttacks,
-                done: summary.totalAttacksDone,
-                total: summary.totalAttacksMax,
-              ),
-              _RankedHomeMetricData(
-                imageUrl: ImageAssets.shieldWithArrow,
-                fallbackIcon: Icons.shield_rounded,
-                label: loc.rankedLeagueDefenses,
-                done: summary.totalDefensesDone,
-                total: summary.totalDefensesMax,
-              ),
-            ],
-          ),
-        ],
-      ),
+            ),
+            if (summary.bestRank != null)
+              _RankedBestRankPill(rank: summary.bestRank!),
+          ],
+        ),
+        const SizedBox(height: 10),
+        _RankedHomeMetricBars(
+          metrics: [
+            _RankedHomeMetricData(
+              imageUrl: ImageAssets.sword,
+              fallbackIcon: Icons.sports_kabaddi_rounded,
+              label: loc.rankedLeagueAttacks,
+              done: summary.totalAttacksDone,
+              total: summary.totalAttacksMax,
+            ),
+            _RankedHomeMetricData(
+              imageUrl: ImageAssets.shieldWithArrow,
+              fallbackIcon: Icons.shield_rounded,
+              label: loc.rankedLeagueDefenses,
+              done: summary.totalDefensesDone,
+              total: summary.totalDefensesMax,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -1123,12 +1112,11 @@ class _RankedHomeAccount {
   }
 }
 
-String _rankedSummarySubtitle(
-  BuildContext context,
-  _RankedHomeSummary summary,
-) {
-  final loc = AppLocalizations.of(context)!;
-  return loc.todoAccountsNumber(summary.accounts.length);
+/// Share of ranked attacks already used. Zero when the limit is unknown —
+/// a fraction of an unknown total isn't meaningful.
+double _rankedRatio(int done, int? total) {
+  if (total == null || total <= 0) return 0;
+  return (done / total).clamp(0.0, 1.0);
 }
 
 /// Names the accounts that still have ranked attacks left today, falling

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -266,7 +266,10 @@ class DashboardPage extends StatelessWidget {
                   bottomPadding,
                 ),
                 children: [
-                  LastRefreshIndicator(lastRefresh: cocService.lastRefresh),
+                  LastRefreshIndicator(
+                    lastRefresh: cocService.lastRefresh,
+                    onRefresh: () => _refresh(context),
+                  ),
                   const SizedBox(height: 12),
                   const HomeEventBanner(),
                   SizedBox(height: isDesktopWeb ? 24 : 16),
@@ -457,7 +460,11 @@ class _HomeCardCache<T> {
   }
 }
 
-class _HomeRankedCardState extends State<HomeRankedCard> {
+class _HomeRankedCardState extends State<HomeRankedCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   static final _cache = _HomeCardCache<_RankedHomeSummary>();
 
   Future<_RankedHomeSummary>? _load;
@@ -560,6 +567,7 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return FutureBuilder<_RankedHomeSummary>(
       future: _load,
       builder: (context, snapshot) {
@@ -1122,7 +1130,11 @@ class HomeUpgradeTrackerCard extends StatefulWidget {
   State<HomeUpgradeTrackerCard> createState() => _HomeUpgradeTrackerCardState();
 }
 
-class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard> {
+class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   static final _cache = _HomeCardCache<_UpgradeHomeSummary>();
 
   final _repository = UpgradeTrackerRepository.shared;
@@ -1241,6 +1253,7 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return FutureBuilder<_UpgradeHomeSummary>(
       future: _load,
       builder: (context, snapshot) {

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -1310,26 +1310,18 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard>
             children: [
               Row(
                 children: [
-                  // Village completion took the town hall's slot, since the
-                  // rail right below already shows that artwork per account.
-                  // The combined page has no town hall to duplicate, so it
-                  // keeps the card's own icon instead.
-                  if (isSummaryPage)
-                    SizedBox.square(
-                      dimension: 46,
-                      child: MobileWebImage(
-                        imageUrl: ImageAssets.builderWave,
-                        fit: BoxFit.contain,
-                        errorWidget: (_, _, _) =>
-                            const Icon(Icons.construction_rounded, size: 28),
-                      ),
-                    )
-                  else
-                    _UpgradeProgressRing(
-                      value: ringRatio,
-                      label: '${(ringRatio * 100).round()}%',
-                      size: _homeDashboardRingSize(context),
+                  // The card's own icon always leads, so the three home cards
+                  // stay tellable apart while scrolling; the town hall lives
+                  // in the rail underneath, and completion owns the right.
+                  SizedBox.square(
+                    dimension: 46,
+                    child: MobileWebImage(
+                      imageUrl: ImageAssets.builderWave,
+                      fit: BoxFit.contain,
+                      errorWidget: (_, _, _) =>
+                          const Icon(Icons.construction_rounded, size: 28),
                     ),
+                  ),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Column(
@@ -1376,9 +1368,11 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard>
                       ],
                     ),
                   ),
-                  // Village completion moved into a pill of its own: unlike
-                  // the other two cards' rings it wasn't redundant, but it's
-                  // a metric like the rest, so it belongs with them.
+                  _UpgradeProgressRing(
+                    value: ringRatio,
+                    label: '${(ringRatio * 100).round()}%',
+                    size: _homeDashboardRingSize(context),
+                  ),
                 ],
               ),
               const SizedBox(height: 8),

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -586,11 +586,6 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
         final account = isSummaryPage
             ? null
             : summary.accounts[safeIndex - (hasSummaryPage ? 1 : 0)];
-        // Attacks used, not defenses: attacks are the part the player can
-        // still act on, and it's what the status line underneath talks about.
-        final ringRatio = isSummaryPage
-            ? _rankedRatio(summary.totalAttacksDone, summary.totalAttacksMax)
-            : _rankedRatio(account!.attacksDone, account.maxBattles);
 
         // Same split as the home to-do card: the frame, title and account
         // rail stay put, only the status line and the pills ride the pager.
@@ -653,20 +648,16 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
                       ],
                     ),
                   ),
-                  // The rank/trophy pill used to sit here and covered the rail
-                  // on a three-account row; it moved down to the status line,
-                  // where the ring can own the header's right edge like the
-                  // other two home cards.
-                  _UpgradeProgressRing(
-                    value: ringRatio,
-                    label: '${(ringRatio * 100).round()}%',
-                    size: _homeDashboardRingSize(context),
-                  ),
+                  // No ring: it showed attacksDone/maxBattles, which the
+                  // "Attacks 11/38" pill right below states exactly. The
+                  // rank and trophy pills live on the status line instead.
                 ],
               ),
               const SizedBox(height: 8),
               SizedBox(
-                height: 22 + 10 + HomeMetricPill.gridHeight(1),
+                // 30, not the text's height: the status row carries the rank
+                // or trophy pill, which is taller than its own label.
+                height: 30 + 10 + HomeMetricPill.gridHeight(1),
                 child: PageView.builder(
                   controller: _controller,
                   onPageChanged: (index) => setState(() => _index = index),
@@ -715,27 +706,33 @@ class _RankedAccountPanel extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                rankText,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w700,
+        // Pinned to the trophy pill's height so this page and the combined
+        // one line up: the pager gives both the same box, and a status row
+        // that shrank on one of them shifted all the content below it.
+        SizedBox(
+          height: _rankedStatusRowHeight,
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  rankText,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
-            ),
-            _RankedTrophyPill(value: formatter.format(account.trophies)),
-            const SizedBox(width: 6),
-            Icon(
-              Icons.chevron_right_rounded,
-              size: 22,
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ],
+              _RankedTrophyPill(value: formatter.format(account.trophies)),
+              const SizedBox(width: 6),
+              Icon(
+                Icons.chevron_right_rounded,
+                size: 22,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
         ),
         const SizedBox(height: 10),
         _RankedHomeMetricBars(
@@ -776,22 +773,23 @@ class _RankedAllAccountsPanel extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                _rankedSummaryStatus(context, summary),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w700,
+        SizedBox(
+          height: _rankedStatusRowHeight,
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _rankedSummaryStatus(context, summary),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
-            ),
-            if (summary.bestRank != null)
-              _RankedBestRankPill(rank: summary.bestRank!),
-          ],
+            ],
+          ),
         ),
         const SizedBox(height: 10),
         _RankedHomeMetricBars(
@@ -909,45 +907,6 @@ class _RankedTrophyPill extends StatelessWidget {
             Text(
               value,
               style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                color: colorScheme.onSurface,
-                fontWeight: FontWeight.w900,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RankedBestRankPill extends StatelessWidget {
-  const _RankedBestRankPill({required this.rank});
-
-  final int rank;
-
-  @override
-  Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-    final colorScheme = Theme.of(context).colorScheme;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: CKColors.warGold.withValues(alpha: 0.18),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 7),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(
-              Icons.leaderboard_rounded,
-              size: 16,
-              color: CKColors.warGold,
-            ),
-            const SizedBox(width: 5),
-            Text(
-              '${loc.rankedLeagueBestGroupRank} #$rank',
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: colorScheme.onSurface,
                 fontWeight: FontWeight.w900,
               ),
@@ -1111,6 +1070,10 @@ class _RankedHomeAccount {
     );
   }
 }
+
+/// Height of a ranked page's status row, set by the trophy pill rather than
+/// by the text, so every page in the pager aligns.
+const double _rankedStatusRowHeight = 30;
 
 /// Share of ranked attacks already used. Zero when the limit is unknown —
 /// a fraction of an unknown total isn't meaningful.
@@ -1309,37 +1272,120 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard> {
         }
         _clampIndex(itemCount);
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              // Panel chrome + the tallest page's two pill rows (builders,
-              // lab, and — when the account has one — pets).
-              height: 121 + HomeMetricPill.gridHeight(2),
-              child: PageView.builder(
-                controller: _controller,
-                onPageChanged: (index) => setState(() => _index = index),
-                itemCount: itemCount,
-                itemBuilder: (context, index) => _buildPage(
-                  summary,
-                  index,
-                  hasSummaryPage: hasSummaryPage,
-                  accountCount: accountCount,
-                  offset: offset,
-                ),
+        final loc = AppLocalizations.of(context)!;
+        final safeIndex = _index.clamp(0, itemCount - 1);
+        final localIndex = safeIndex - offset;
+        final isSummaryPage = hasSummaryPage && safeIndex == 0;
+        final account = !isSummaryPage && localIndex < accountCount
+            ? summary.accounts[localIndex]
+            : null;
+        final missing = !isSummaryPage && localIndex >= accountCount
+            ? summary.missingAccounts[localIndex - accountCount]
+            : null;
+        final ringRatio = isSummaryPage
+            ? summary.completion
+            : (account?.completion ?? 0);
+
+        // Same split as the other two home cards: frame, title and account
+        // rail stay put, only the status line and the pills ride the pager.
+        return _HomeCardTappablePanel(
+          onTap: isSummaryPage
+              ? null
+              : () => _openTracker(account?.tag ?? missing!.tag),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  // Village completion took the town hall's slot, since the
+                  // rail right below already shows that artwork per account.
+                  // The combined page has no town hall to duplicate, so it
+                  // keeps the card's own icon instead.
+                  if (isSummaryPage)
+                    SizedBox.square(
+                      dimension: 46,
+                      child: MobileWebImage(
+                        imageUrl: ImageAssets.builderWave,
+                        fit: BoxFit.contain,
+                        errorWidget: (_, _, _) =>
+                            const Icon(Icons.construction_rounded, size: 28),
+                      ),
+                    )
+                  else
+                    _UpgradeProgressRing(
+                      value: ringRatio,
+                      label: '${(ringRatio * 100).round()}%',
+                      size: _homeDashboardRingSize(context),
+                    ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          loc.drawerUpgradeTracker,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(fontWeight: FontWeight.w900),
+                        ),
+                        const SizedBox(height: 4),
+                        HomeAccountRail(
+                          selectedIndex: safeIndex,
+                          onSelect: (index) => _showPage(itemCount, index),
+                          entries: [
+                            if (hasSummaryPage)
+                              HomeAccountRailEntry(
+                                label: loc.todoAllAccounts,
+                                fallbackIcon: Icons.groups_rounded,
+                              ),
+                            for (final entry in summary.accounts)
+                              HomeAccountRailEntry(
+                                label: entry.name,
+                                imageUrl: entry.hallImageUrl,
+                                fallbackIcon: Icons.construction_rounded,
+                                hasPendingActions: entry.hasIdleQueue,
+                              ),
+                            // An account with no imported snapshot always
+                            // needs attention — that's the whole reason it
+                            // still gets a page instead of disappearing.
+                            for (final entry in summary.missingAccounts)
+                              HomeAccountRailEntry(
+                                label: entry.name,
+                                imageUrl: ImageAssets.townHall(
+                                  entry.townHallLevel,
+                                ),
+                                fallbackIcon: Icons.construction_rounded,
+                                hasPendingActions: true,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  // Village completion moved into a pill of its own: unlike
+                  // the other two cards' rings it wasn't redundant, but it's
+                  // a metric like the rest, so it belongs with them.
+                ],
               ),
-            ),
-            if (itemCount > 1) ...[
               const SizedBox(height: 8),
-              Center(
-                child: PageDotsIndicator(
-                  count: itemCount,
-                  index: _index,
-                  onDotTap: (index) => _showPage(itemCount, index),
+              SizedBox(
+                height: 22 + 10 + HomeMetricPill.gridHeight(2),
+                child: PageView.builder(
+                  controller: _controller,
+                  onPageChanged: (index) => setState(() => _index = index),
+                  itemCount: itemCount,
+                  itemBuilder: (context, index) => _buildPage(
+                    summary,
+                    index,
+                    hasSummaryPage: hasSummaryPage,
+                    accountCount: accountCount,
+                    offset: offset,
+                  ),
                 ),
               ),
             ],
-          ],
+          ),
         );
       },
     );
@@ -1357,155 +1403,96 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard> {
     }
     final localIndex = index - offset;
     if (localIndex < accountCount) {
-      final account = summary.accounts[localIndex];
-      return _UpgradeAccountPanel(
-        account: account,
-        onTap: () => _openTracker(account.tag),
-      );
+      return _UpgradeAccountPanel(account: summary.accounts[localIndex]);
     }
-    final player = summary.missingAccounts[localIndex - accountCount];
     return _UpgradeMissingDataPanel(
-      player: player,
-      onTap: () => _openTracker(player.tag),
+      player: summary.missingAccounts[localIndex - accountCount],
     );
   }
 }
 
+/// Pager body for one account: snapshot freshness plus its queue pills. The
+/// card frame, title, account rail and completion ring live in the header.
 class _UpgradeAccountPanel extends StatelessWidget {
-  const _UpgradeAccountPanel({required this.account, required this.onTap});
+  const _UpgradeAccountPanel({required this.account});
 
   final _UpgradeHomeAccount account;
-  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
-    final progress = '${(account.completion * 100).round()}%';
 
-    return _HomeCardTappablePanel(
-      onTap: onTap,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              SizedBox.square(
-                dimension: 46,
-                child: MobileWebImage(
-                  imageUrl: account.hallImageUrl,
-                  fit: BoxFit.contain,
-                  errorWidget: (_, _, _) =>
-                      const Icon(Icons.construction_rounded),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                _upgradeSnapshotAgeLabel(context, account.capturedAt),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      loc.drawerUpgradeTracker,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    Text(
-                      account.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
-                ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 22,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        _UpgradeHomeMetricBars(
+          metrics: [
+            _UpgradeHomeMetricData(
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                "Builder's Hut",
+                1,
               ),
-              _UpgradeProgressRing(
-                value: account.completion,
-                label: progress,
-                size: _homeDashboardRingSize(context),
+              fallbackIcon: Icons.construction_rounded,
+              label: loc.dashboardUpgradeTrackerBuilders,
+              meta: _formatDuration(account.builderProjectedSeconds),
+              active: account.activeBuilders,
+              total: account.totalBuilders,
+            ),
+            _UpgradeHomeMetricData(
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                'Laboratory',
+                1,
               ),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  _upgradeSnapshotAgeLabel(context, account.capturedAt),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Icon(
-                Icons.chevron_right_rounded,
-                size: 22,
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          _UpgradeHomeMetricBars(
-            metrics: [
+              fallbackIcon: Icons.science_rounded,
+              label: loc.dashboardUpgradeTrackerLab,
+              meta: _formatDuration(account.labProjectedSeconds),
+              active: account.labActive ? 1 : 0,
+              total: account.hasLab ? 1 : 0,
+            ),
+            if (account.hasPets)
               _UpgradeHomeMetricData(
                 imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                  "Builder's Hut",
+                  'Pet House',
                   1,
                 ),
-                fallbackIcon: Icons.construction_rounded,
-                label: loc.dashboardUpgradeTrackerBuilders,
-                meta: _formatDuration(account.builderProjectedSeconds),
-                active: account.activeBuilders,
-                total: account.totalBuilders,
+                fallbackIcon: Icons.pets_rounded,
+                label: loc.dashboardUpgradeTrackerPets,
+                meta: _formatDuration(account.petProjectedSeconds),
+                active: account.petsActive ? 1 : 0,
+                total: 1,
               ),
-              _UpgradeHomeMetricData(
-                imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                  'Laboratory',
-                  1,
-                ),
-                fallbackIcon: Icons.science_rounded,
-                label: loc.dashboardUpgradeTrackerLab,
-                meta: _formatDuration(account.labProjectedSeconds),
-                active: account.labActive ? 1 : 0,
-                total: account.hasLab ? 1 : 0,
-              ),
-              if (account.hasPets)
-                _UpgradeHomeMetricData(
-                  imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                    'Pet House',
-                    1,
-                  ),
-                  fallbackIcon: Icons.pets_rounded,
-                  label: loc.dashboardUpgradeTrackerPets,
-                  meta: _formatDuration(account.petProjectedSeconds),
-                  active: account.petsActive ? 1 : 0,
-                  total: 1,
-                ),
-              _UpgradeHomeMetricData(
-                imageUrl: ImageAssets.getHomeVillageBuildingImage('Wall', 1),
-                fallbackIcon: Icons.fence_rounded,
-                label: loc.dashboardUpgradeTrackerWalls,
-                meta: account.wallsLevelsRemaining > 0
-                    ? loc.todoItemsLeftShort(account.wallsLevelsRemaining)
-                    : null,
-                // Walls have no queue, so there is no active/total to show —
-                // the value is the completion ratio itself.
-                active: (account.wallsCompletion * 100).round(),
-                total: 100,
-                valueOverride: '${(account.wallsCompletion * 100).round()}%',
-              ),
-            ],
-          ),
-        ],
-      ),
+            _UpgradeHomeMetricData(
+              imageUrl: ImageAssets.getHomeVillageBuildingImage('Wall', 1),
+              fallbackIcon: Icons.fence_rounded,
+              label: loc.dashboardUpgradeTrackerWalls,
+              active: account.wallsAtMax,
+              total: account.wallsTotal,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -1513,29 +1500,33 @@ class _UpgradeAccountPanel extends StatelessWidget {
 /// Page shown for a configured account that has no imported Upgrade Tracker
 /// data yet, instead of silently dropping it from the pager.
 class _UpgradeMissingDataPanel extends StatelessWidget {
-  const _UpgradeMissingDataPanel({required this.player, required this.onTap});
+  const _UpgradeMissingDataPanel({required this.player});
 
   final Player player;
-  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
 
-    return _HomeCardTappablePanel(
-      onTap: onTap,
-      child: _UpgradeEmptyContent(
-        imageUrl: ImageAssets.townHall(player.townHallLevel),
-        title: loc.drawerUpgradeTracker,
-        subtitle: player.name,
-        status: loc.dashboardUpgradeTrackerNoData,
-        trailing: _UpgradeProgressRing(
-          value: 0,
-          label: '0%',
-          size: _homeDashboardRingSize(context),
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            AppLocalizations.of(context)!.dashboardUpgradeTrackerNoData,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
         ),
-        showChevron: true,
-      ),
+        Icon(
+          Icons.chevron_right_rounded,
+          size: 22,
+          color: colorScheme.onSurfaceVariant,
+        ),
+      ],
     );
   }
 }
@@ -1551,112 +1542,65 @@ class _UpgradeAllAccountsPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
-    final progress = '${(summary.completion * 100).round()}%';
 
-    return _HomeCardFrame(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              SizedBox.square(
-                dimension: 46,
-                child: MobileWebImage(
-                  imageUrl: ImageAssets.builderWave,
-                  fit: BoxFit.contain,
-                  errorWidget: (_, _, _) =>
-                      const Icon(Icons.construction_rounded, size: 28),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                _upgradeSummaryStatus(context, summary),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      loc.drawerUpgradeTracker,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    Text(
-                      loc.todoAccountsNumber(summary.accounts.length),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
-                ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        _UpgradeHomeMetricBars(
+          metrics: [
+            _UpgradeHomeMetricData(
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                "Builder's Hut",
+                1,
               ),
-              _UpgradeProgressRing(
-                value: summary.completion,
-                label: progress,
-                size: _homeDashboardRingSize(context),
+              fallbackIcon: Icons.construction_rounded,
+              label: loc.dashboardUpgradeTrackerBuilders,
+              meta: _formatDuration(summary.builderProjectedSeconds),
+              active: summary.activeBuilders,
+              total: summary.totalBuilders,
+            ),
+            _UpgradeHomeMetricData(
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                'Laboratory',
+                1,
               ),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  _upgradeSummaryStatus(context, summary),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          _UpgradeHomeMetricBars(
-            metrics: [
+              fallbackIcon: Icons.science_rounded,
+              label: loc.dashboardUpgradeTrackerLab,
+              meta: _formatDuration(summary.labProjectedSeconds),
+              active: summary.activeLabs,
+              total: summary.totalLabs,
+            ),
+            if (summary.hasPets)
               _UpgradeHomeMetricData(
                 imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                  "Builder's Hut",
+                  'Pet House',
                   1,
                 ),
-                fallbackIcon: Icons.construction_rounded,
-                label: loc.dashboardUpgradeTrackerBuilders,
-                meta: _formatDuration(summary.builderProjectedSeconds),
-                active: summary.activeBuilders,
-                total: summary.totalBuilders,
+                fallbackIcon: Icons.pets_rounded,
+                label: loc.dashboardUpgradeTrackerPets,
+                meta: _formatDuration(summary.petProjectedSeconds),
+                active: summary.activePets,
+                total: summary.totalPets,
               ),
-              _UpgradeHomeMetricData(
-                imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                  'Laboratory',
-                  1,
-                ),
-                fallbackIcon: Icons.science_rounded,
-                label: loc.dashboardUpgradeTrackerLab,
-                meta: _formatDuration(summary.labProjectedSeconds),
-                active: summary.activeLabs,
-                total: summary.totalLabs,
-              ),
-              if (summary.hasPets)
-                _UpgradeHomeMetricData(
-                  imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                    'Pet House',
-                    1,
-                  ),
-                  fallbackIcon: Icons.pets_rounded,
-                  label: loc.dashboardUpgradeTrackerPets,
-                  meta: _formatDuration(summary.petProjectedSeconds),
-                  active: summary.activePets,
-                  total: summary.totalPets,
-                ),
-            ],
-          ),
-        ],
-      ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -1686,20 +1630,16 @@ class _UpgradeHomeEmpty extends StatelessWidget {
 
 class _UpgradeEmptyContent extends StatelessWidget {
   const _UpgradeEmptyContent({
-    this.imageUrl,
     required this.title,
     required this.subtitle,
     required this.status,
     required this.trailing,
-    this.showChevron = false,
   });
 
-  final String? imageUrl;
   final String title;
   final String subtitle;
   final String status;
   final Widget trailing;
-  final bool showChevron;
 
   @override
   Widget build(BuildContext context) {
@@ -1713,7 +1653,7 @@ class _UpgradeEmptyContent extends StatelessWidget {
             SizedBox.square(
               dimension: 46,
               child: MobileWebImage(
-                imageUrl: imageUrl ?? ImageAssets.builderWave,
+                imageUrl: ImageAssets.builderWave,
                 fit: BoxFit.contain,
                 errorWidget: (_, _, _) =>
                     const Icon(Icons.construction_rounded, size: 28),
@@ -1761,12 +1701,6 @@ class _UpgradeEmptyContent extends StatelessWidget {
                 ),
               ),
             ),
-            if (showChevron)
-              Icon(
-                Icons.chevron_right_rounded,
-                size: 22,
-                color: colorScheme.onSurfaceVariant,
-              ),
           ],
         ),
         const SizedBox(height: 8),
@@ -1823,12 +1757,7 @@ class _UpgradeHomeMetricData {
     required this.active,
     required this.total,
     this.meta,
-    this.valueOverride,
   });
-
-  /// Set when the metric isn't a queue count — walls report a percentage
-  /// rather than "x of y slots busy".
-  final String? valueOverride;
 
   final String imageUrl;
   final IconData fallbackIcon;
@@ -1845,7 +1774,7 @@ class _UpgradeHomeMetricData {
   /// house): shown as a placeholder with no bar rather than a bogus `0/0`.
   bool get isKnown => total > 0;
 
-  String get value => valueOverride ?? (isKnown ? '$active/$total' : '-');
+  String get value => isKnown ? '$active/$total' : '-';
 
   double? get progress => isKnown ? (active / total).clamp(0.0, 1.0) : null;
 }
@@ -1906,7 +1835,9 @@ class _UpgradeProgressRing extends StatelessWidget {
       child: CustomPaint(
         painter: ProgressRingPainter(
           value: value,
-          color: CKColors.donationGreen,
+          color: value >= 1
+              ? CKUpgradeColors.completion
+              : CKColors.donationGreen,
           trackColor: colorScheme.surfaceContainerHighest,
         ),
         child: Center(
@@ -2000,8 +1931,9 @@ class _UpgradeHomeAccount {
     required this.name,
     required this.hallImageUrl,
     required this.completion,
-    required this.wallsCompletion,
-    required this.wallsLevelsRemaining,
+    required this.needsUpdate,
+    required this.wallsAtMax,
+    required this.wallsTotal,
     required this.projectedSeconds,
     required this.builderProjectedSeconds,
     required this.labProjectedSeconds,
@@ -2020,12 +1952,25 @@ class _UpgradeHomeAccount {
   final String hallImageUrl;
   final double completion;
 
-  /// Walls are reported as a completion ratio plus the levels still to buy,
-  /// not as `current/target`: those two are sums of levels (5764/5850 on a
-  /// near-maxed base), which means nothing to a player. `levelsRemaining` is
-  /// the count they actually think in — "86 walls left".
-  final double wallsCompletion;
-  final int wallsLevelsRemaining;
+  /// True once every upgrade the snapshot knew about has finished, so the
+  /// tracker is describing work that is already done. Recurrent helper tasks
+  /// are excluded: they restart on their own, and letting them count would
+  /// leave an idle account permanently flagged.
+  final bool needsUpdate;
+
+  /// Wall segments already at their target level, out of the total. Counted
+  /// per wall rather than per level, which is how players talk about them.
+  final int wallsAtMax;
+  final int wallsTotal;
+
+  /// Whether any build slot is sitting idle. This is what the rail badge
+  /// reports: the card exists to answer "do I need to go restart something",
+  /// so green means every builder, the lab and the pet house are all busy.
+  /// Walls are deliberately not part of it — they have no queue to start.
+  bool get hasIdleQueue =>
+      activeBuilders < totalBuilders ||
+      (hasLab && !labActive) ||
+      (hasPets && !petsActive);
 
   final int projectedSeconds;
   final int builderProjectedSeconds;
@@ -2100,18 +2045,36 @@ class _UpgradeHomeAccount {
       queue: UpgradeQueue.pets,
     );
 
-    final walls = snapshot.summaryFor(
-      UpgradeCategory.walls,
+    // Counted per wall, not per level: `summaryFor(walls)` reports sums of
+    // levels (5764/5850 on a near-maxed base), which is not how anyone thinks
+    // about walls — players count segments still behind.
+    final wallItems = snapshot.itemsFor(
       village: UpgradeVillage.home,
+      category: UpgradeCategory.walls,
     );
+    final wallsTotal = wallItems.fold<int>(0, (sum, item) => sum + item.count);
+    final wallsAtMax = wallItems
+        .where((item) => item.currentLevel >= item.targetLevel)
+        .fold<int>(0, (sum, item) => sum + item.count);
+
+    final trackedItems = snapshot.itemsFor(village: UpgradeVillage.home);
+    final startedItems = trackedItems.where(
+      (item) => !item.recurrentHelper && (item.activeSeconds ?? 0) > 0,
+    );
+    final needsUpdate =
+        startedItems.isNotEmpty &&
+        startedItems.every(
+          (item) => snapshot.remainingActiveSeconds(item, now: now) <= 0,
+        );
 
     return _UpgradeHomeAccount(
       tag: snapshot.tag,
       name: snapshot.name,
       hallImageUrl: ImageAssets.townHall(snapshot.townHallLevel),
       completion: home.completion.clamp(0.0, 1.0),
-      wallsCompletion: walls.completion.clamp(0.0, 1.0),
-      wallsLevelsRemaining: walls.levelsRemaining,
+      needsUpdate: needsUpdate,
+      wallsAtMax: wallsAtMax,
+      wallsTotal: wallsTotal,
       projectedSeconds: projectedSeconds,
       builderProjectedSeconds: builderProjectedSeconds,
       labProjectedSeconds: labProjectedSeconds,
@@ -2132,23 +2095,27 @@ String _upgradeSummaryStatus(
   _UpgradeHomeSummary summary,
 ) {
   final loc = AppLocalizations.of(context)!;
-  if (summary.missingAccounts.isEmpty) {
+  // An imported account goes stale too, not just a missing one: once every
+  // timer in its snapshot has run out, the tracker is showing work that has
+  // since finished. Naming only the accounts with no snapshot at all meant a
+  // five-day-old import still read as up to date.
+  final staleNames = [
+    ...summary.missingAccounts.map((player) => player.name),
+    ...summary.accounts
+        .where((account) => account.needsUpdate)
+        .map((account) => account.name),
+  ].map((name) => name.trim()).where((name) => name.isNotEmpty).toList();
+
+  if (staleNames.isEmpty) {
     return loc.dashboardUpgradeTrackerCombinedAcrossAccounts;
   }
 
-  final visibleNames = summary.missingAccounts
-      .take(3)
-      .map((player) => player.name.trim())
-      .where((name) => name.isNotEmpty)
-      .toList(growable: false);
-  final remaining = summary.missingAccounts.length - visibleNames.length;
+  final visibleNames = staleNames.take(3).toList(growable: false);
+  final remaining = staleNames.length - visibleNames.length;
   final suffix = remaining > 0 ? ', +$remaining' : '';
-  final subject = visibleNames.isEmpty
-      ? loc.todoAccountsNumber(summary.missingAccounts.length)
-      : '${visibleNames.join(', ')}$suffix';
   return loc.dashboardUpgradeTrackerNeedsUpdate(
-    subject,
-    summary.missingAccounts.length,
+    '${visibleNames.join(', ')}$suffix',
+    staleNames.length,
   );
 }
 

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -644,12 +644,14 @@ class _HomeRankedCardState extends State<HomeRankedCard>
                                 label: entry.name,
                                 imageUrl: entry.player.townHallPic,
                                 fallbackIcon: Icons.home_rounded,
-                                hasPendingActions:
-                                    _rankedRatio(
-                                      entry.attacksDone,
-                                      entry.maxBattles,
-                                    ) <
-                                    1,
+                                // Null, not false, when the cap is unknown:
+                                // `_rankedRatio` floors to 0 there, which
+                                // would paint a pending badge on an account
+                                // the app cannot actually judge. The rest of
+                                // this card already treats an unknown cap as
+                                // "no verdict" — a plain count, and excluded
+                                // from the combined "attacks left" status.
+                                hasPendingActions: entry.hasPendingBattles,
                               ),
                           ],
                         ),
@@ -1054,6 +1056,16 @@ class _RankedHomeAccount {
   final int defensesDone;
   final int? maxBattles;
 
+  /// Whether attacks are still owed, or null when the cap is unknown and the
+  /// question has no answer. Callers must not fall back to a ratio here: a
+  /// missing cap floors it to 0, which reads as "nothing done" rather than
+  /// "not known".
+  bool? get hasPendingBattles {
+    final cap = maxBattles;
+    if (cap == null || cap <= 0) return null;
+    return attacksDone < cap;
+  }
+
   factory _RankedHomeAccount.fromData(
     RankedLeagueData data, {
     required Player player,
@@ -1082,13 +1094,6 @@ class _RankedHomeAccount {
 /// Height of a ranked page's status row, set by the trophy pill rather than
 /// by the text, so every page in the pager aligns.
 const double _rankedStatusRowHeight = 30;
-
-/// Share of ranked attacks already used. Zero when the limit is unknown —
-/// a fraction of an unknown total isn't meaningful.
-double _rankedRatio(int done, int? total) {
-  if (total == null || total <= 0) return 0;
-  return (done / total).clamp(0.0, 1.0);
-}
 
 /// Names the accounts that still have ranked attacks left today, falling
 /// back to a generic combined label once every account is caught up.

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/home_metric_pill.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/app/my_app_state.dart';
 import 'package:clashkingapp/core/config/app_feature_flags.dart';
@@ -175,14 +176,14 @@ class _HomeCardSkeleton extends StatelessWidget {
             children: [
               Expanded(
                 child: SkeletonLoader(
-                  height: 46,
+                  height: HomeMetricPill.defaultHeight,
                   borderRadius: BorderRadius.circular(AppRadius.control),
                 ),
               ),
               const SizedBox(width: 7),
               Expanded(
                 child: SkeletonLoader(
-                  height: 46,
+                  height: HomeMetricPill.defaultHeight,
                   borderRadius: BorderRadius.circular(AppRadius.control),
                 ),
               ),
@@ -580,7 +581,8 @@ class _HomeRankedCardState extends State<HomeRankedCard> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SizedBox(
-              height: 158,
+              // Panel chrome (padding, header, status row, gaps) + one pill row.
+              height: 120 + HomeMetricPill.gridHeight(1),
               child: PageView.builder(
                 controller: _controller,
                 onPageChanged: (index) => setState(() => _index = index),
@@ -713,7 +715,6 @@ class _RankedAccountPanel extends StatelessWidget {
                 label: loc.rankedLeagueAttacks,
                 done: account.attacksDone,
                 total: account.maxBattles,
-                color: CKColors.lossRed,
               ),
               _RankedHomeMetricData(
                 imageUrl: ImageAssets.shieldWithArrow,
@@ -721,7 +722,6 @@ class _RankedAccountPanel extends StatelessWidget {
                 label: loc.rankedLeagueDefenses,
                 done: account.defensesDone,
                 total: account.maxBattles,
-                color: CKColors.legendBlue,
               ),
             ],
           ),
@@ -812,7 +812,6 @@ class _RankedAllAccountsPanel extends StatelessWidget {
                 label: loc.rankedLeagueAttacks,
                 done: summary.totalAttacksDone,
                 total: summary.totalAttacksMax,
-                color: CKColors.lossRed,
               ),
               _RankedHomeMetricData(
                 imageUrl: ImageAssets.shieldWithArrow,
@@ -820,7 +819,6 @@ class _RankedAllAccountsPanel extends StatelessWidget {
                 label: loc.rankedLeagueDefenses,
                 done: summary.totalDefensesDone,
                 total: summary.totalDefensesMax,
-                color: CKColors.legendBlue,
               ),
             ],
           ),
@@ -979,7 +977,6 @@ class _RankedHomeMetricData {
     required this.label,
     required this.done,
     required this.total,
-    required this.color,
   });
 
   final String imageUrl;
@@ -991,13 +988,12 @@ class _RankedHomeMetricData {
   /// instead of a `done/total` ratio, since a nonzero count is not the
   /// same as "fully done" when the actual limit is unknown.
   final int? total;
-  final Color color;
 
-  bool get isDone => total != null && done >= total!;
-
-  double get ratio {
+  /// Null when the limit is unknown — the pill then draws no bar rather than
+  /// an empty one, which would read as "nothing done yet".
+  double? get progress {
     final total = this.total;
-    if (total == null || total <= 0) return 0;
+    if (total == null || total <= 0) return null;
     return (done / total).clamp(0.0, 1.0);
   }
 
@@ -1014,29 +1010,10 @@ class _RankedHomeMetricBars extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rows = <Widget>[];
-    for (var i = 0; i < metrics.length; i += 2) {
-      if (i + 1 < metrics.length) {
-        rows.add(
-          Row(
-            children: [
-              Expanded(child: _RankedHomeMetricBar(metric: metrics[i])),
-              const SizedBox(width: 7),
-              Expanded(child: _RankedHomeMetricBar(metric: metrics[i + 1])),
-            ],
-          ),
-        );
-      } else {
-        rows.add(_RankedHomeMetricBar(metric: metrics[i]));
-      }
-    }
-
-    return Column(
-      children: [
-        for (var i = 0; i < rows.length; i++) ...[
-          if (i > 0) const SizedBox(height: 7),
-          rows[i],
-        ],
+    return CKMetricChipGrid(
+      spacing: HomeMetricPill.gap,
+      chips: [
+        for (final metric in metrics) _RankedHomeMetricBar(metric: metric),
       ],
     );
   }
@@ -1049,89 +1026,13 @@ class _RankedHomeMetricBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fillColor = metric.isDone ? Colors.green : metric.color;
-
-    return SizedBox(
-      height: 38,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: fillColor.withValues(alpha: isDark ? 0.28 : 0.34),
-          borderRadius: BorderRadius.circular(AppRadius.control),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(AppRadius.control),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              FractionallySizedBox(
-                alignment: Alignment.centerLeft,
-                widthFactor: metric.ratio,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: fillColor.withValues(alpha: isDark ? 0.38 : 0.48),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 9),
-                child: Row(
-                  children: [
-                    DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: colorScheme.surface.withValues(alpha: 0.72),
-                        shape: BoxShape.circle,
-                      ),
-                      child: SizedBox.square(
-                        dimension: 26,
-                        child: Padding(
-                          padding: const EdgeInsets.all(4),
-                          child: MobileWebImage(
-                            imageUrl: metric.imageUrl,
-                            fit: BoxFit.contain,
-                            errorWidget: (context, url, error) => Icon(
-                              metric.fallbackIcon,
-                              size: 18,
-                              color: metric.color,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 7),
-                    Expanded(
-                      child: Semantics(
-                        label: '${metric.label}, ${metric.valueLabel}',
-                        child: ExcludeSemantics(
-                          child: Text(
-                            metric.label,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.labelLarge
-                                ?.copyWith(
-                                  color: colorScheme.onSurface,
-                                  fontWeight: FontWeight.w900,
-                                  height: 1.1,
-                                ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Text(
-                      metric.valueLabel,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: fillColor,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+    return HomeMetricPill(
+      label: metric.label,
+      value: metric.valueLabel,
+      progress: metric.progress,
+      imageUrl: metric.imageUrl,
+      fallbackIcon: metric.fallbackIcon,
+      semanticLabel: '${metric.label}, ${metric.valueLabel}',
     );
   }
 }
@@ -1424,7 +1325,9 @@ class _HomeUpgradeTrackerCardState extends State<HomeUpgradeTrackerCard> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SizedBox(
-              height: 220,
+              // Panel chrome + the tallest page's two pill rows (builders,
+              // lab, and — when the account has one — pets).
+              height: 121 + HomeMetricPill.gridHeight(2),
               child: PageView.builder(
                 controller: _controller,
                 onPageChanged: (index) => setState(() => _index = index),
@@ -1533,7 +1436,11 @@ class _UpgradeAccountPanel extends StatelessWidget {
                   ],
                 ),
               ),
-              _UpgradeProgressRing(value: account.completion, label: progress),
+              _UpgradeProgressRing(
+                value: account.completion,
+                label: progress,
+                size: _homeDashboardRingSize(context),
+              ),
             ],
           ),
           const SizedBox(height: 6),
@@ -1561,35 +1468,38 @@ class _UpgradeAccountPanel extends StatelessWidget {
           _UpgradeHomeMetricBars(
             metrics: [
               _UpgradeHomeMetricData(
-                icon: Icons.construction_rounded,
-                label: loc.dashboardUpgradeTrackerBuilders,
-                description: _formatDuration(account.builderProjectedSeconds),
-                value: _formatUpgradeQueueProgress(
-                  account.activeBuilders,
-                  account.totalBuilders,
+                imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                  "Builder's Hut",
+                  1,
                 ),
-                color: CKColors.donationGreen,
+                fallbackIcon: Icons.construction_rounded,
+                label: loc.dashboardUpgradeTrackerBuilders,
+                meta: _formatDuration(account.builderProjectedSeconds),
+                active: account.activeBuilders,
+                total: account.totalBuilders,
               ),
               _UpgradeHomeMetricData(
-                icon: Icons.science_rounded,
-                label: loc.dashboardUpgradeTrackerLab,
-                description: _formatDuration(account.labProjectedSeconds),
-                value: _formatUpgradeQueueProgress(
-                  account.labActive ? 1 : 0,
-                  account.hasLab ? 1 : 0,
+                imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                  'Laboratory',
+                  1,
                 ),
-                color: CKColors.warGold,
+                fallbackIcon: Icons.science_rounded,
+                label: loc.dashboardUpgradeTrackerLab,
+                meta: _formatDuration(account.labProjectedSeconds),
+                active: account.labActive ? 1 : 0,
+                total: account.hasLab ? 1 : 0,
               ),
               if (account.hasPets)
                 _UpgradeHomeMetricData(
-                  icon: Icons.pets_rounded,
-                  label: loc.dashboardUpgradeTrackerPets,
-                  description: _formatDuration(account.petProjectedSeconds),
-                  value: _formatUpgradeQueueProgress(
-                    account.petsActive ? 1 : 0,
+                  imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                    'Pet House',
                     1,
                   ),
-                  color: CKColors.capitalPurple,
+                  fallbackIcon: Icons.pets_rounded,
+                  label: loc.dashboardUpgradeTrackerPets,
+                  meta: _formatDuration(account.petProjectedSeconds),
+                  active: account.petsActive ? 1 : 0,
+                  total: 1,
                 ),
             ],
           ),
@@ -1618,7 +1528,11 @@ class _UpgradeMissingDataPanel extends StatelessWidget {
         title: loc.drawerUpgradeTracker,
         subtitle: player.name,
         status: loc.dashboardUpgradeTrackerNoData,
-        trailing: const _UpgradeProgressRing(value: 0, label: '0%'),
+        trailing: _UpgradeProgressRing(
+          value: 0,
+          label: '0%',
+          size: _homeDashboardRingSize(context),
+        ),
         showChevron: true,
       ),
     );
@@ -1678,7 +1592,11 @@ class _UpgradeAllAccountsPanel extends StatelessWidget {
                   ],
                 ),
               ),
-              _UpgradeProgressRing(value: summary.completion, label: progress),
+              _UpgradeProgressRing(
+                value: summary.completion,
+                label: progress,
+                size: _homeDashboardRingSize(context),
+              ),
             ],
           ),
           const SizedBox(height: 6),
@@ -1701,35 +1619,38 @@ class _UpgradeAllAccountsPanel extends StatelessWidget {
           _UpgradeHomeMetricBars(
             metrics: [
               _UpgradeHomeMetricData(
-                icon: Icons.construction_rounded,
-                label: loc.dashboardUpgradeTrackerBuilders,
-                description: _formatDuration(summary.builderProjectedSeconds),
-                value: _formatUpgradeQueueProgress(
-                  summary.activeBuilders,
-                  summary.totalBuilders,
+                imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                  "Builder's Hut",
+                  1,
                 ),
-                color: CKColors.donationGreen,
+                fallbackIcon: Icons.construction_rounded,
+                label: loc.dashboardUpgradeTrackerBuilders,
+                meta: _formatDuration(summary.builderProjectedSeconds),
+                active: summary.activeBuilders,
+                total: summary.totalBuilders,
               ),
               _UpgradeHomeMetricData(
-                icon: Icons.science_rounded,
-                label: loc.dashboardUpgradeTrackerLab,
-                description: _formatDuration(summary.labProjectedSeconds),
-                value: _formatUpgradeQueueProgress(
-                  summary.activeLabs,
-                  summary.totalLabs,
+                imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                  'Laboratory',
+                  1,
                 ),
-                color: CKColors.warGold,
+                fallbackIcon: Icons.science_rounded,
+                label: loc.dashboardUpgradeTrackerLab,
+                meta: _formatDuration(summary.labProjectedSeconds),
+                active: summary.activeLabs,
+                total: summary.totalLabs,
               ),
               if (summary.hasPets)
                 _UpgradeHomeMetricData(
-                  icon: Icons.pets_rounded,
-                  label: loc.dashboardUpgradeTrackerPets,
-                  description: _formatDuration(summary.petProjectedSeconds),
-                  value: _formatUpgradeQueueProgress(
-                    summary.activePets,
-                    summary.totalPets,
+                  imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                    'Pet House',
+                    1,
                   ),
-                  color: CKColors.capitalPurple,
+                  fallbackIcon: Icons.pets_rounded,
+                  label: loc.dashboardUpgradeTrackerPets,
+                  meta: _formatDuration(summary.petProjectedSeconds),
+                  active: summary.activePets,
+                  total: summary.totalPets,
                 ),
             ],
           ),
@@ -1753,7 +1674,11 @@ class _UpgradeHomeEmpty extends StatelessWidget {
           ? loc.todoAccountsNumber(configuredCount)
           : loc.upgradeTrackerSubtitle,
       status: loc.dashboardUpgradeTrackerNoData,
-      trailing: const _UpgradeProgressRing(value: 0, label: '0%'),
+      trailing: _UpgradeProgressRing(
+        value: 0,
+        label: '0%',
+        size: _homeDashboardRingSize(context),
+      ),
     );
   }
 }
@@ -1847,22 +1772,31 @@ class _UpgradeEmptyContent extends StatelessWidget {
         _UpgradeHomeMetricBars(
           metrics: [
             _UpgradeHomeMetricData(
-              icon: Icons.construction_rounded,
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                "Builder's Hut",
+                1,
+              ),
+              fallbackIcon: Icons.construction_rounded,
               label: loc.dashboardUpgradeTrackerBuilders,
-              value: '-',
-              color: CKColors.donationGreen,
+              active: 0,
+              total: 0,
             ),
             _UpgradeHomeMetricData(
-              icon: Icons.science_rounded,
+              imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                'Laboratory',
+                1,
+              ),
+              fallbackIcon: Icons.science_rounded,
               label: loc.dashboardUpgradeTrackerLab,
-              value: '-',
-              color: CKColors.warGold,
+              active: 0,
+              total: 0,
             ),
             _UpgradeHomeMetricData(
-              icon: Icons.pets_rounded,
+              imageUrl: ImageAssets.getHomeVillageBuildingImage('Pet House', 1),
+              fallbackIcon: Icons.pets_rounded,
               label: loc.dashboardUpgradeTrackerPets,
-              value: '-',
-              color: CKColors.capitalPurple,
+              active: 0,
+              total: 0,
             ),
           ],
         ),
@@ -1882,18 +1816,32 @@ class _UpgradeHomeSkeleton extends StatelessWidget {
 
 class _UpgradeHomeMetricData {
   const _UpgradeHomeMetricData({
-    required this.icon,
+    required this.imageUrl,
+    required this.fallbackIcon,
     required this.label,
-    required this.value,
-    required this.color,
-    this.description,
+    required this.active,
+    required this.total,
+    this.meta,
   });
 
-  final IconData icon;
+  final String imageUrl;
+  final IconData fallbackIcon;
   final String label;
-  final String value;
-  final Color color;
-  final String? description;
+
+  /// Queue slots currently running, out of [total] available.
+  final int active;
+  final int total;
+
+  /// Projected time until the queue frees up.
+  final String? meta;
+
+  /// A zero total means the account has no such queue yet (no lab, no pet
+  /// house): shown as a placeholder with no bar rather than a bogus `0/0`.
+  bool get isKnown => total > 0;
+
+  String get value => isKnown ? '$active/$total' : '-';
+
+  double? get progress => isKnown ? (active / total).clamp(0.0, 1.0) : null;
 }
 
 class _UpgradeHomeMetricBars extends StatelessWidget {
@@ -1903,29 +1851,10 @@ class _UpgradeHomeMetricBars extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rows = <Widget>[];
-    for (var i = 0; i < metrics.length; i += 2) {
-      if (i + 1 < metrics.length) {
-        rows.add(
-          Row(
-            children: [
-              Expanded(child: _UpgradeHomeMetricBar(metric: metrics[i])),
-              const SizedBox(width: 7),
-              Expanded(child: _UpgradeHomeMetricBar(metric: metrics[i + 1])),
-            ],
-          ),
-        );
-      } else {
-        rows.add(_UpgradeHomeMetricBar(metric: metrics[i]));
-      }
-    }
-
-    return Column(
-      children: [
-        for (var i = 0; i < rows.length; i++) ...[
-          if (i > 0) const SizedBox(height: 7),
-          rows[i],
-        ],
+    return CKMetricChipGrid(
+      spacing: HomeMetricPill.gap,
+      chips: [
+        for (final metric in metrics) _UpgradeHomeMetricBar(metric: metric),
       ],
     );
   }
@@ -1938,88 +1867,36 @@ class _UpgradeHomeMetricBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    return SizedBox(
-      height: 46,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: metric.color.withValues(alpha: isDark ? 0.28 : 0.34),
-          borderRadius: BorderRadius.circular(AppRadius.control),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 9),
-          child: Row(
-            children: [
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  color: colorScheme.surface.withValues(alpha: 0.72),
-                  shape: BoxShape.circle,
-                ),
-                child: SizedBox.square(
-                  dimension: 26,
-                  child: Icon(metric.icon, size: 18, color: metric.color),
-                ),
-              ),
-              const SizedBox(width: 7),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      metric.label,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w900,
-                        height: 1.05,
-                      ),
-                    ),
-                    if (metric.description != null) ...[
-                      const SizedBox(height: 1),
-                      Text(
-                        metric.description!,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                          fontWeight: FontWeight.w700,
-                          height: 1,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                metric.value,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: metric.color,
-                  fontWeight: FontWeight.w900,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+    return HomeMetricPill(
+      label: metric.label,
+      value: metric.value,
+      meta: metric.meta,
+      progress: metric.progress,
+      imageUrl: metric.imageUrl,
+      fallbackIcon: metric.fallbackIcon,
+      semanticLabel: metric.meta == null
+          ? '${metric.label}, ${metric.value}'
+          : '${metric.label}, ${metric.meta}, ${metric.value}',
     );
   }
 }
 
 class _UpgradeProgressRing extends StatelessWidget {
-  const _UpgradeProgressRing({required this.value, required this.label});
+  const _UpgradeProgressRing({
+    required this.value,
+    required this.label,
+    required this.size,
+  });
 
   final double value;
   final String label;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return SizedBox.square(
-      dimension: 54,
+      dimension: size,
       child: CustomPaint(
         painter: ProgressRingPainter(
           value: value,
@@ -2030,7 +1907,7 @@ class _UpgradeProgressRing extends StatelessWidget {
           child: Text(
             label,
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontSize: 54 * 0.26,
+              fontSize: size * 0.26,
               fontWeight: FontWeight.w900,
             ),
           ),
@@ -2039,6 +1916,9 @@ class _UpgradeProgressRing extends StatelessWidget {
     );
   }
 }
+
+double _homeDashboardRingSize(BuildContext context) =>
+    kIsWeb && MediaQuery.sizeOf(context).width >= 900 ? 54 : 46;
 
 class _UpgradeHomeSummary {
   const _UpgradeHomeSummary({
@@ -2223,9 +2103,6 @@ class _UpgradeHomeAccount {
     );
   }
 }
-
-String _formatUpgradeQueueProgress(int active, int total) =>
-    total <= 0 ? '-' : '$active/$total';
 
 String _upgradeSummaryStatus(
   BuildContext context,

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:clashking_design_system/clashking_design_system.dart';
+import 'package:clashkingapp/common/widgets/home_account_rail.dart';
 import 'package:clashkingapp/common/widgets/home_metric_pill.dart';
 import 'package:clashkingapp/common/widgets/indicators/progress_ring_painter.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
@@ -230,9 +231,13 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
       0,
       (acc, summary) => math.max(acc, (summary.metrics.length + 1) ~/ 2),
     );
-    // Panel chrome: padding + border + header row + status row + gaps.
     final barsHeight = maxRows == 0 ? 64.0 : HomeMetricPill.gridHeight(maxRows);
-    final height = 116.0 + barsHeight;
+    // Header is the taller of the town-hall image and the title-over-rail
+    // column; the rest is the card's own padding plus the body's status row
+    // and gaps. Spelled out rather than left as one number so adding to the
+    // header can't silently overflow the card again.
+    final headerHeight = math.max(46.0, 19 + 4 + HomeAccountRail.height);
+    final height = 14 + headerHeight + 8 + _bodyHeight(barsHeight) + 14;
     final useDesktopPager = _usesDesktopHomePager(context);
 
     if (useDesktopPager) {
@@ -251,63 +256,95 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
       );
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          height: height,
-          child: PageView.builder(
-            controller: _controller,
-            onPageChanged: (index) => setState(() => _index = index),
-            itemCount: itemCount,
-            itemBuilder: (context, index) => _buildTodoPanel(
-              context,
-              index,
-              mockups,
-              hasSummaryPage,
-              summaries,
-              warCwlService,
+    if (_showTodoMockups) {
+      return SizedBox(
+        height: height,
+        child: PageView.builder(
+          controller: _controller,
+          onPageChanged: (index) => setState(() => _index = index),
+          itemCount: itemCount,
+          itemBuilder: (context, index) =>
+              _TodoPreviewPanel(preview: mockups[index]),
+        ),
+      );
+    }
+
+    final safeIndex = _index.clamp(0, itemCount - 1);
+    final summary = summaries[safeIndex];
+    final isSummaryPage = hasSummaryPage && safeIndex == 0;
+    final player = isSummaryPage
+        ? null
+        : widget.players[safeIndex - (hasSummaryPage ? 1 : 0)];
+
+    // The card frame, its title and the account rail stay put — only the
+    // status line and the metric pills live in the pager. Sliding the whole
+    // card meant animating a "To-do list" title that is the same on every
+    // page, and pushed the account rail out with it.
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => _openTodo(context, warCwlService!),
+        borderRadius: BorderRadius.circular(28),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(
+              color: Theme.of(
+                context,
+              ).colorScheme.outlineVariant.withValues(alpha: 0.32),
             ),
           ),
-        ),
-        if (itemCount > 1) ...[
-          const SizedBox(height: 10),
-          if (useDesktopPager)
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                PageDotsIndicator(
-                  count: itemCount,
-                  index: _index,
-                  onDotTap: (index) => _showTodoPage(itemCount, index),
-                  tooltipForIndex: (index) => 'Card ${index + 1}',
-                ),
-                const SizedBox(width: 12),
-                _PagerArrowButton(
-                  icon: Icons.chevron_left_rounded,
-                  tooltip: 'Previous card',
-                  onPressed: () => _showTodoPage(
-                    itemCount,
-                    (_index - 1 + itemCount) % itemCount,
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: _TodoCardHeader(
+                      player: player,
+                      players: widget.players,
+                      hasSummaryPage: hasSummaryPage,
+                      selectedIndex: safeIndex,
+                      onSelect: (index) => _showTodoPage(itemCount, index),
+                      summaries: summaries,
+                    ),
+                  ),
+                  _TodoRing(summary: summary, size: 46),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: _bodyHeight(barsHeight),
+                child: PageView.builder(
+                  controller: _controller,
+                  onPageChanged: (index) => setState(() => _index = index),
+                  itemCount: itemCount,
+                  itemBuilder: (context, index) => _TodoCardBody(
+                    status: hasSummaryPage && index == 0
+                        ? _todoAllAccountsStatus(
+                            context,
+                            widget.players,
+                            summaries.sublist(1),
+                          )
+                        : summaries[index].lastActiveText(context),
+                    summary: summaries[index],
                   ),
                 ),
-                const SizedBox(width: 6),
-                _PagerArrowButton(
-                  icon: Icons.chevron_right_rounded,
-                  tooltip: 'Next card',
-                  onPressed: () =>
-                      _showTodoPage(itemCount, (_index + 1) % itemCount),
-                ),
-              ],
-            )
-          else
-            Center(
-              child: PageDotsIndicator(count: itemCount, index: _index),
-            ),
-        ],
-      ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
+
+  /// Status row + its gap + the metric pills — everything inside the pager.
+  ///
+  /// The status row is as tall as its chevron (22), not as its text: budgeting
+  /// for the text is what overflowed the card by 4px.
+  static double _bodyHeight(double barsHeight) => 22 + 10 + barsHeight;
 
   Widget _buildTodoPanel(
     BuildContext context,
@@ -442,6 +479,138 @@ class _HomeTodoDesktopGrid extends StatelessWidget {
           children: children,
         );
       },
+    );
+  }
+}
+
+/// Card title plus the account rail that replaced the pager dots.
+///
+/// Dots said only "there are 4 pages" — not which account each one was, so
+/// finding a given account meant swiping through the others and back. The
+/// rail names them and jumps straight there. It scrolls horizontally past a
+/// handful of accounts, which stays workable because the order is the one the
+/// user set in account management: position is stable and learnable.
+class _TodoCardHeader extends StatelessWidget {
+  const _TodoCardHeader({
+    required this.player,
+    required this.players,
+    required this.hasSummaryPage,
+    required this.selectedIndex,
+    required this.onSelect,
+    required this.summaries,
+  });
+
+  /// Null on the combined page.
+  final Player? player;
+  final List<Player> players;
+  final bool hasSummaryPage;
+  final int selectedIndex;
+  final ValueChanged<int> onSelect;
+
+  /// One per page, in page order — drives each avatar's pending badge.
+  final List<_TodoSummary> summaries;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final loc = AppLocalizations.of(context)!;
+
+    return Row(
+      children: [
+        SizedBox.square(
+          dimension: 46,
+          child: MobileWebImage(
+            imageUrl: player?.townHallPic ?? ImageAssets.iconBuilderPotion,
+            fit: BoxFit.contain,
+            errorWidget: (context, url, error) => Icon(
+              Icons.checklist_rounded,
+              size: 24,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                loc.todoTitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w900),
+              ),
+              const SizedBox(height: 4),
+              HomeAccountRail(
+                selectedIndex: selectedIndex,
+                onSelect: onSelect,
+                entries: [
+                  if (hasSummaryPage)
+                    HomeAccountRailEntry(
+                      label: loc.todoAllAccounts,
+                      fallbackIcon: Icons.groups_rounded,
+                      hasPendingActions: !summaries.first.isDone,
+                    ),
+                  for (var i = 0; i < players.length; i++)
+                    HomeAccountRailEntry(
+                      label: players[i].name,
+                      imageUrl: players[i].townHallPic,
+                      fallbackIcon: Icons.home_rounded,
+                      hasPendingActions:
+                          !summaries[i + (hasSummaryPage ? 1 : 0)].isDone,
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Everything that actually changes between accounts: the status line and the
+/// metric pills. The card frame, title and account rail stay outside the
+/// pager, so switching account no longer slides a "To-do list" title that is
+/// identical on every page.
+class _TodoCardBody extends StatelessWidget {
+  const _TodoCardBody({required this.status, required this.summary});
+
+  final String status;
+  final _TodoSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                status,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 22,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        _MetricBars(metrics: summary.metrics),
+      ],
     );
   }
 }

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:clashking_design_system/clashking_design_system.dart';
-import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/home_metric_pill.dart';
 import 'package:clashkingapp/common/widgets/indicators/progress_ring_painter.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/navigation/page_dots_indicator.dart';
@@ -231,9 +231,7 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
       (acc, summary) => math.max(acc, (summary.metrics.length + 1) ~/ 2),
     );
     // Panel chrome: padding + border + header row + status row + gaps.
-    final barsHeight = maxRows == 0
-        ? 64.0
-        : maxRows * 38.0 + (maxRows - 1) * 7.0;
+    final barsHeight = maxRows == 0 ? 64.0 : HomeMetricPill.gridHeight(maxRows);
     final height = 116.0 + barsHeight;
     final useDesktopPager = _usesDesktopHomePager(context);
 
@@ -921,31 +919,9 @@ class _MetricBars extends StatelessWidget {
       );
     }
 
-    // Two metrics per row; a metric alone on its row spans the full width.
-    final rows = <Widget>[];
-    for (var i = 0; i < metrics.length; i += 2) {
-      if (i + 1 < metrics.length) {
-        rows.add(
-          Row(
-            children: [
-              Expanded(child: _MetricBar(metric: metrics[i])),
-              const SizedBox(width: 7),
-              Expanded(child: _MetricBar(metric: metrics[i + 1])),
-            ],
-          ),
-        );
-      } else {
-        rows.add(_MetricBar(metric: metrics[i]));
-      }
-    }
-
-    return Column(
-      children: [
-        for (var i = 0; i < rows.length; i++) ...[
-          if (i > 0) const SizedBox(height: 7),
-          rows[i],
-        ],
-      ],
+    return CKMetricChipGrid(
+      spacing: HomeMetricPill.gap,
+      chips: [for (final metric in metrics) _MetricBar(metric: metric)],
     );
   }
 }
@@ -957,98 +933,13 @@ class _MetricBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final done = metric.done >= metric.total;
-    final fillColor = done ? Colors.green : metric.color;
-
-    return SizedBox(
-      height: 38,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: fillColor.withValues(alpha: isDark ? 0.28 : 0.34),
-          borderRadius: BorderRadius.circular(AppRadius.control),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(AppRadius.control),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              FractionallySizedBox(
-                alignment: Alignment.centerLeft,
-                widthFactor: metric.ratio,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: fillColor.withValues(alpha: isDark ? 0.38 : 0.48),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 9),
-                child: Row(
-                  children: [
-                    _MetricIcon(metric: metric),
-                    const SizedBox(width: 7),
-                    Expanded(
-                      child: Semantics(
-                        label: '${metric.label}, ${metric.detail}',
-                        child: ExcludeSemantics(
-                          child: Text(
-                            metric.label,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.labelLarge
-                                ?.copyWith(
-                                  color: colorScheme.onSurface,
-                                  fontWeight: FontWeight.w900,
-                                  height: 1.1,
-                                ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Text(
-                      '${metric.done}/${metric.total}',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: fillColor,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _MetricIcon extends StatelessWidget {
-  const _MetricIcon({required this.metric});
-
-  final _TodoMetric metric;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.72),
-        shape: BoxShape.circle,
-      ),
-      child: SizedBox.square(
-        dimension: 26,
-        child: Padding(
-          padding: const EdgeInsets.all(4),
-          child: MobileWebImage(
-            imageUrl: metric.imageUrl,
-            fit: BoxFit.contain,
-            errorWidget: (context, url, error) =>
-                Icon(metric.fallbackIcon, size: 18, color: metric.color),
-          ),
-        ),
-      ),
+    return HomeMetricPill(
+      label: metric.label,
+      value: '${metric.done}/${metric.total}',
+      progress: metric.ratio,
+      imageUrl: metric.imageUrl,
+      fallbackIcon: metric.fallbackIcon,
+      semanticLabel: '${metric.label}, ${metric.detail}',
     );
   }
 }

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -299,10 +299,33 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // No ring here: it showed the average of metrics that can't be
+              // averaged (war attacks vs. 6288 pass points), so a finished
+              // war still read as 13%. The chips below say it precisely.
               Row(
                 children: [
                   Expanded(
                     child: _TodoCardHeader(
+                      // The ring only replaces the town hall on an account
+                      // page, where that artwork is already in the rail. The
+                      // combined page has no town hall to duplicate, so it
+                      // keeps the card's own icon.
+                      leading: isSummaryPage
+                          ? SizedBox.square(
+                              dimension: 46,
+                              child: MobileWebImage(
+                                imageUrl: ImageAssets.iconBuilderPotion,
+                                fit: BoxFit.contain,
+                                errorWidget: (context, url, error) => Icon(
+                                  Icons.checklist_rounded,
+                                  size: 24,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            )
+                          : _TodoRing(summary: summary, size: 46),
                       player: player,
                       players: widget.players,
                       hasSummaryPage: hasSummaryPage,
@@ -311,7 +334,6 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
                       summaries: summaries,
                     ),
                   ),
-                  _TodoRing(summary: summary, size: 46),
                 ],
               ),
               const SizedBox(height: 8),
@@ -492,6 +514,7 @@ class _HomeTodoDesktopGrid extends StatelessWidget {
 /// user set in account management: position is stable and learnable.
 class _TodoCardHeader extends StatelessWidget {
   const _TodoCardHeader({
+    required this.leading,
     required this.player,
     required this.players,
     required this.hasSummaryPage,
@@ -499,6 +522,11 @@ class _TodoCardHeader extends StatelessWidget {
     required this.onSelect,
     required this.summaries,
   });
+
+  /// Occupies the slot the town hall image used to: the rail right below
+  /// already shows that artwork for every account, so repeating it for the
+  /// selected one said nothing and wasted the card's most prominent spot.
+  final Widget leading;
 
   /// Null on the combined page.
   final Player? player;
@@ -512,23 +540,11 @@ class _TodoCardHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     final loc = AppLocalizations.of(context)!;
 
     return Row(
       children: [
-        SizedBox.square(
-          dimension: 46,
-          child: MobileWebImage(
-            imageUrl: player?.townHallPic ?? ImageAssets.iconBuilderPotion,
-            fit: BoxFit.contain,
-            errorWidget: (context, url, error) => Icon(
-              Icons.checklist_rounded,
-              size: 24,
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ),
+        leading,
         const SizedBox(width: 10),
         Expanded(
           child: Column(
@@ -548,10 +564,12 @@ class _TodoCardHeader extends StatelessWidget {
                 onSelect: onSelect,
                 entries: [
                   if (hasSummaryPage)
+                    // No badge on the combined entry: it could only ever say
+                    // "at least one account has something left", which the
+                    // per-account badges next to it already say precisely.
                     HomeAccountRailEntry(
                       label: loc.todoAllAccounts,
                       fallbackIcon: Icons.groups_rounded,
-                      hasPendingActions: !summaries.first.isDone,
                     ),
                   for (var i = 0; i < players.length; i++)
                     HomeAccountRailEntry(
@@ -1041,8 +1059,14 @@ class _TodoRing extends StatelessWidget {
       dimension: size,
       child: CustomPaint(
         painter: ProgressRingPainter(
+          // Same colour rule as the ranked and upgrade rings: brand red is
+          // the app's CTA colour, not a progress colour, and it made an
+          // ordinary "nothing done yet" morning look like an error. Raw
+          // `Colors.green` was also a token the design system doesn't own.
           value: summary.ratio,
-          color: summary.isDone ? Colors.green : colorScheme.primary,
+          color: summary.isDone
+              ? CKUpgradeColors.completion
+              : CKColors.donationGreen,
           trackColor: colorScheme.surfaceContainerHighest,
         ),
         child: Center(

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -315,26 +315,24 @@ class _HomeTodoCardState extends State<HomeTodoCard>
                 children: [
                   Expanded(
                     child: _TodoCardHeader(
-                      // The ring only replaces the town hall on an account
-                      // page, where that artwork is already in the rail. The
-                      // combined page has no town hall to duplicate, so it
-                      // keeps the card's own icon.
-                      leading: isSummaryPage
-                          ? SizedBox.square(
-                              dimension: 46,
-                              child: MobileWebImage(
-                                imageUrl: ImageAssets.iconBuilderPotion,
-                                fit: BoxFit.contain,
-                                errorWidget: (context, url, error) => Icon(
-                                  Icons.checklist_rounded,
-                                  size: 24,
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            )
-                          : _TodoRing(summary: summary, size: 46),
+                      // The card's own icon always leads, so the three home
+                      // cards stay tellable apart while scrolling; the town
+                      // hall lives in the rail underneath, and progress owns
+                      // the right edge.
+                      leading: SizedBox.square(
+                        dimension: 46,
+                        child: MobileWebImage(
+                          imageUrl: ImageAssets.iconBuilderPotion,
+                          fit: BoxFit.contain,
+                          errorWidget: (context, url, error) => Icon(
+                            Icons.checklist_rounded,
+                            size: 24,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
                       player: player,
                       players: widget.players,
                       hasSummaryPage: hasSummaryPage,
@@ -343,6 +341,7 @@ class _HomeTodoCardState extends State<HomeTodoCard>
                       summaries: summaries,
                     ),
                   ),
+                  _TodoRing(summary: summary, size: 46),
                 ],
               ),
               const SizedBox(height: 8),

--- a/lib/features/pages/widgets/home_todo_card.dart
+++ b/lib/features/pages/widgets/home_todo_card.dart
@@ -164,7 +164,15 @@ class HomeTodoCard extends StatefulWidget {
   State<HomeTodoCard> createState() => _HomeTodoCardState();
 }
 
-class _HomeTodoCardState extends State<HomeTodoCard> {
+/// Kept alive so the selected account survives a trip to another tab: the
+/// app's main navigation is a `PageView`, which unmounts the pages either
+/// side, and picking an account is now a deliberate act rather than an
+/// incidental swipe position.
+class _HomeTodoCardState extends State<HomeTodoCard>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   late final PageController _controller;
   int _index = 0;
 
@@ -197,6 +205,7 @@ class _HomeTodoCardState extends State<HomeTodoCard> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final loc = AppLocalizations.of(context)!;
     final warCwlService = _showTodoMockups
         ? null

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2604,6 +2604,7 @@
   "dashboardUpgradeTrackerLab": "Lab",
   "dashboardUpgradeTrackerPets": "Pets",
   "dashboardUpgradeTrackerWalls": "Walls",
+  "dashboardUpgradeTrackerVillage": "Village",
   "dashboardRankedNoData": "Open Ranked League to see this account's standing.",
   "dashboardRankedAccounts": "{loaded}/{total} accounts tracked",
   "@dashboardRankedAccounts": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2603,6 +2603,7 @@
   "dashboardUpgradeTrackerBuilders": "Builders",
   "dashboardUpgradeTrackerLab": "Lab",
   "dashboardUpgradeTrackerPets": "Pets",
+  "dashboardUpgradeTrackerWalls": "Walls",
   "dashboardRankedNoData": "Open Ranked League to see this account's standing.",
   "dashboardRankedAccounts": "{loaded}/{total} accounts tracked",
   "@dashboardRankedAccounts": {


### PR DESCRIPTION
## Why

The home dashboard had drifted away from the rest of the app. Its three cards
each stacked their own carousel of anonymous pager dots, and their metric chips
used a shape that appears nowhere else — neither the Player/Clan cards' pills
nor DevKit's `CKMetricChip`.

Three independent carousels also meant three independent selections of the same
variable (which account), with nothing on screen saying which page was whose.
Answering "does Julien still have attacks left?" took up to twelve swipes.

## What changed

**Metric chips now match the Player and Clan cards.** `HomeMetricPill` adopts
their exact recipe — pill radius, `surface @ 0.5`, `outlineVariant @ 0.18`
hairline, bare game asset with no icon circle. Completion is carried by the
value's own colour rather than by an added bar, fill or badge: `0/3999` already
says "not done", so every extra device restated it more weakly.

**Pager dots are replaced by an account rail.** Only the selected entry expands
to show its name; the others stay circles, since several accounts commonly share
a town hall level and a label under each made the rail wide and ragged. Past a
handful of accounts it scrolls, which stays workable because the order is the one
set in account management. Each avatar carries a status badge — filled when the
account still needs attention, hollow once settled.

**Card frames and headers left the pager.** Previously a swipe slid the whole
card, including a title identical on every page. Now only the status line and the
pills move, which is also what lets the rail stay put.

**Three duplicated copies of the "two pills per row" layout** collapsed into
`CKMetricChipGrid`, the DevKit primitive that already did exactly that.

### Upgrade Tracker

- Queue chips gained the progress they never had: `_UpgradeHomeMetricData` now
  carries `active`/`total` instead of a preformatted string.
- Added a Walls chip, counted per wall rather than per level — `summaryFor(walls)`
  reports sums of levels (`5764/5850` on a near-maxed base), which is not how
  players think about them.
- An account is flagged as needing an update once every timer in its snapshot has
  run out, not only when the snapshot is missing entirely. Recurrent helper tasks
  are excluded: they restart on their own and would leave idle accounts flagged
  forever.

## Fixes

- **Horizontal drags on the rail no longer navigate to the Players tab.** The rail
  declined the gesture when every entry fitted, and it bubbled up to the app's
  main `PageView`.
- **Rail entries meet the 44pt/48dp tap minimum.** The pill stays 28px; the rest
  is invisible padding.
- **The selected account survives switching tabs**, via
  `AutomaticKeepAliveClientMixin` on the three card states.
- **`LastRefreshIndicator` is tappable** where a caller wires `onRefresh`. It
  carried a refresh glyph while being inert, so the obvious tap did nothing.
- **Status badges no longer encode state by colour alone** — filled versus
  hollow — since red/green sits on the commonest colour-blindness axis.
- Several card-height miscalculations that overflowed by a few pixels: budgets
  were written against text heights while the rows were actually sized by a
  chevron or a pill.

## Docs

`docs/design_system.md` gains a "where the truth lives" note and a **Two chip
roles** section. DevKit's `components.md` presents `CKMetricChip` as *the* shape
for compact label/value stats; that is true inside a hero header's stats panel and
misleading anywhere else, where cards use the quieter pill. Following the doc
without reading the screens produced a dashboard that matched nothing — twice —
so the distinction is now written down, along with the rule that the shipped app
wins and the docs get fixed.

## Notes

- `HomeMetricPill` and `HomeAccountRail` are candidates for DevKit: both encode a
  reusable vocabulary with no product-state dependency, and the card-tag pill
  already has three consumers. Recorded under known gaps rather than consolidated
  locally.
- `dashboard_page.dart` is **126 lines shorter** despite everything added to it,
  mostly from removing the duplicated grid logic and the per-page card frames.
  The overall `+501` is the two new shared widgets and the docs.

## Testing

`flutter analyze` clean, 744 tests passing. Verified on a physical device
(Android, arm64) across single-account and multi-account configurations.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8FPFP2E4snPSXWbfsh9R7

