### PR TITLE
feat: align settings selection screens

### DIFF
--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/dialogs/logout_dialog.dart';
 import 'package:clashkingapp/common/widgets/dialogs/snackbar.dart';
@@ -313,41 +314,30 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
   }
 
   Future<void> _showLanguageSelection(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final currentLocale = Provider.of<MyAppState>(
+      context,
+      listen: false,
+    ).locale;
     final selectedLocale = await showModalBottomSheet<Locale>(
       context: context,
+      isScrollControlled: true,
       showDragHandle: true,
       builder: (context) {
-        return SafeArea(
-          child: ListView.separated(
-            shrinkWrap: true,
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
-            itemBuilder: (context, index) {
-              final locale = supportedLocales[index];
-              return ListTile(
-                leading: MobileWebImage(
-                  imageUrl: locale.flagUrl,
-                  width: 32,
-                  height: 32,
-                  placeholder: (context, url) =>
-                      const CircularProgressIndicator(),
-                  errorWidget: (context, url, error) =>
-                      const Icon(Icons.error_outline),
-                ),
-                title: Text(locale.languageName),
-                onTap: () {
-                  Navigator.pop(
-                    context,
-                    Locale.fromSubtags(
-                      languageCode: locale.languageCode,
-                      countryCode: locale.countryCode,
-                      scriptCode: locale.scriptCode,
-                    ),
-                  );
-                },
-              );
-            },
-            separatorBuilder: (context, index) => const Divider(height: 1),
-            itemCount: supportedLocales.length,
+        return FractionallySizedBox(
+          heightFactor: 0.82,
+          child: _SettingsSelectionSheet(
+            title: l10n.settingsLanguage,
+            subtitle: l10n.settingsSelectLanguage,
+            child: _SettingsChoiceGroup(
+              children: [
+                for (final locale in supportedLocales)
+                  _LanguageChoiceTile(
+                    locale: locale,
+                    selected: _isSelectedLocale(locale, currentLocale),
+                  ),
+              ],
+            ),
           ),
         );
       },
@@ -361,6 +351,20 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
     }
   }
 
+  bool _isSelectedLocale(LocaleInfo locale, Locale currentLocale) {
+    if (locale.languageCode != currentLocale.languageCode) return false;
+    if (currentLocale.countryCode == null && currentLocale.scriptCode == null) {
+      return supportedLocales
+              .where(
+                (entry) => entry.languageCode == currentLocale.languageCode,
+              )
+              .firstOrNull ==
+          locale;
+    }
+    return locale.countryCode == currentLocale.countryCode &&
+        locale.scriptCode == currentLocale.scriptCode;
+  }
+
   Future<void> _showThemeModeSelection(
     BuildContext context,
     ThemeNotifier themeNotifier,
@@ -371,33 +375,30 @@ class _SettingsInfoScreenState extends State<SettingsInfoScreen> {
       showDragHandle: true,
       builder: (context) {
         final current = themeNotifier.themeMode;
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
-            child: _SettingsSection(
-              title: l10n.settingsAppearance,
-              children: [
-                _ThemeModeTile(
-                  title: l10n.settingsThemeSystem,
-                  subtitle: l10n.settingsThemeMatchDevice,
-                  icon: Icons.brightness_auto_outlined,
-                  selected: current == ThemeMode.system,
-                  value: ThemeMode.system,
-                ),
-                _ThemeModeTile(
-                  title: l10n.settingsThemeLight,
-                  icon: Icons.light_mode_outlined,
-                  selected: current == ThemeMode.light,
-                  value: ThemeMode.light,
-                ),
-                _ThemeModeTile(
-                  title: l10n.settingsThemeDark,
-                  icon: Icons.dark_mode_outlined,
-                  selected: current == ThemeMode.dark,
-                  value: ThemeMode.dark,
-                ),
-              ],
-            ),
+        return _SettingsSelectionSheet(
+          title: l10n.settingsAppearance,
+          child: _SettingsChoiceGroup(
+            children: [
+              _ThemeModeTile(
+                title: l10n.settingsThemeSystem,
+                subtitle: l10n.settingsThemeMatchDevice,
+                icon: Icons.brightness_auto_outlined,
+                selected: current == ThemeMode.system,
+                value: ThemeMode.system,
+              ),
+              _ThemeModeTile(
+                title: l10n.settingsThemeLight,
+                icon: Icons.light_mode_outlined,
+                selected: current == ThemeMode.light,
+                value: ThemeMode.light,
+              ),
+              _ThemeModeTile(
+                title: l10n.settingsThemeDark,
+                icon: Icons.dark_mode_outlined,
+                selected: current == ThemeMode.dark,
+                value: ThemeMode.dark,
+              ),
+            ],
           ),
         );
       },
@@ -762,13 +763,15 @@ class _SettingsSection extends StatelessWidget {
           DecoratedBox(
             decoration: BoxDecoration(
               color: Theme.of(context).cardTheme.color ?? colorScheme.surface,
-              borderRadius: BorderRadius.circular(17),
+              borderRadius: BorderRadius.circular(AppRadius.chip),
               border: Border.all(
-                color: colorScheme.outlineVariant.withValues(alpha: 0.28),
+                color: colorScheme.outlineVariant.withValues(
+                  alpha: AppOpacity.border,
+                ),
               ),
             ),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(17),
+              borderRadius: BorderRadius.circular(AppRadius.chip),
               child: Column(
                 children: [
                   for (var index = 0; index < children.length; index++) ...[
@@ -902,14 +905,241 @@ class _ThemeModeTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    return _SettingsTile(
-      icon: icon,
+    return _SettingsChoiceTile(
+      leading: _SettingsChoiceIcon(icon: icon, selected: selected),
       title: title,
       subtitle: subtitle,
-      showChevron: false,
-      trailingText: selected ? l10n.settingsThemeSelected : null,
+      selected: selected,
       onTap: () => Navigator.pop(context, value),
+    );
+  }
+}
+
+class _SettingsSelectionSheet extends StatelessWidget {
+  const _SettingsSelectionSheet({
+    required this.title,
+    required this.child,
+    this.subtitle,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                subtitle!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const SizedBox(height: 14),
+            Flexible(child: child),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsChoiceGroup extends StatelessWidget {
+  const _SettingsChoiceGroup({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardTheme.color ?? colorScheme.surface,
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+        border: Border.all(
+          color: colorScheme.outlineVariant.withValues(
+            alpha: AppOpacity.border,
+          ),
+        ),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemBuilder: (context, index) => children[index],
+          separatorBuilder: (context, index) => Divider(
+            height: 1,
+            indent: 58,
+            color: colorScheme.outlineVariant.withValues(
+              alpha: AppOpacity.borderStrong,
+            ),
+          ),
+          itemCount: children.length,
+        ),
+      ),
+    );
+  }
+}
+
+class _LanguageChoiceTile extends StatelessWidget {
+  const _LanguageChoiceTile({required this.locale, required this.selected});
+
+  final LocaleInfo locale;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsChoiceTile(
+      leading: ClipOval(
+        child: MobileWebImage(
+          imageUrl: locale.flagUrl,
+          width: 34,
+          height: 34,
+          fit: BoxFit.cover,
+          placeholder: (context, url) => const SizedBox.square(
+            dimension: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          errorWidget: (context, url, error) =>
+              const Icon(Icons.error_outline, size: 20),
+        ),
+      ),
+      title: locale.languageName,
+      selected: selected,
+      onTap: () {
+        Navigator.pop(
+          context,
+          Locale.fromSubtags(
+            languageCode: locale.languageCode,
+            countryCode: locale.countryCode,
+            scriptCode: locale.scriptCode,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SettingsChoiceTile extends StatelessWidget {
+  const _SettingsChoiceTile({
+    required this.leading,
+    required this.title,
+    required this.selected,
+    required this.onTap,
+    this.subtitle,
+  });
+
+  final Widget leading;
+  final String title;
+  final String? subtitle;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: selected
+          ? colorScheme.primary.withValues(alpha: 0.08)
+          : Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: subtitle == null ? 56 : 66,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14),
+            child: Row(
+              children: [
+                SizedBox.square(dimension: 34, child: Center(child: leading)),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: colorScheme.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 17,
+                        ),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          subtitle!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                                fontSize: 13,
+                              ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                SizedBox.square(
+                  dimension: 20,
+                  child: selected
+                      ? Icon(
+                          LucideIcons.check,
+                          color: colorScheme.primary,
+                          size: 20,
+                        )
+                      : null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsChoiceIcon extends StatelessWidget {
+  const _SettingsChoiceIcon({required this.icon, required this.selected});
+
+  final IconData icon;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = selected ? colorScheme.primary : colorScheme.onSurfaceVariant;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: selected ? 0.12 : 0.08),
+        borderRadius: BorderRadius.circular(AppRadius.control),
+      ),
+      child: Center(child: Icon(icon, color: color, size: 21)),
     );
   }
 }

--- a/lib/features/settings/presentation/translation_page.dart
+++ b/lib/features/settings/presentation/translation_page.dart
@@ -1,150 +1,292 @@
-import 'package:flutter/material.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class TranslationScreen extends StatelessWidget {
   const TranslationScreen({super.key});
 
+  static final Uri _crowdinUrl = Uri.parse(
+    'https://crowdin.com/project/clashkingapp/invite?h=87a407268713f1cb79724a2e0c00a5d52098842',
+  );
+  static final Uri _discordUrl = Uri.parse('https://discord.gg/clashking');
+  static const String _translatorGifUrl =
+      'https://www.icegif.com/wp-content/uploads/2023/06/icegif-202.gif';
+
+  static const List<String> _translators = [
+    'AlejandroMoc',
+    'athype',
+    'bhatzuhaib',
+    'ColinSchmale',
+    'DeafToDeath',
+    'Dinki/Krakakus',
+    'dobryakoff',
+    'GodOfGods',
+    'Joelsuperstar',
+    'lucaschuab2015',
+    'mango_wz',
+    'MixxStar',
+    'MechanicaL',
+    'MRocha01',
+    'Nemo_64',
+    'niklas312',
+    'niku998',
+    'Pottmichel',
+    'retrock',
+    'SamGo',
+    'SudetiZ',
+    'Wraxu',
+    'zombie23304',
+  ];
+
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+
     return Scaffold(
+      backgroundColor: colorScheme.surface,
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.translationHelpUsTranslate),
+        title: Text(l10n.translationHelpUsTranslate),
+        centerTitle: false,
+        backgroundColor: colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                AppLocalizations.of(context)!.translationThankYou,
-                style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                  color: Theme.of(context).colorScheme.primary,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              SizedBox(height: 16),
-              Text(
-                AppLocalizations.of(context)!.translationThankYouContent,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              SizedBox(height: 16),
-              Center(
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(16.0),
-                  child: MobileWebImage(
-                    errorWidget: (context, url, error) => Icon(Icons.error),
-                    imageUrl:
-                        "https://www.icegif.com/wp-content/uploads/2023/06/icegif-202.gif", // remplacez par votre URL d'image
-                    height: 200,
-                    width: 200,
-                    fit: BoxFit.cover,
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(24, 6, 24, 28),
+        children: [
+          _TranslationHeader(
+            gifUrl: _translatorGifUrl,
+            title: l10n.translationThankYou,
+            body: l10n.translationThankYouContent,
+          ),
+          const SizedBox(height: 30),
+          Text(
+            l10n.translationHelpUsTranslate,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 7),
+          Text(
+            l10n.translationHelpTranslateContent,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              height: 1.3,
+            ),
+          ),
+          const SizedBox(height: 10),
+          _TranslationActionRow(
+            icon: Icons.translate_rounded,
+            label: l10n.translationHelpTranslateButton,
+            onTap: () => launchUrl(_crowdinUrl),
+          ),
+          _TranslationActionRow(
+            icon: Icons.discord,
+            label: l10n.faqJoinDiscord,
+            onTap: () => launchUrl(_discordUrl),
+          ),
+          const SizedBox(height: 26),
+          _TranslatorList(
+            title: l10n.translationCurrentTranslators,
+            translators: _translators,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TranslationHeader extends StatelessWidget {
+  const _TranslationHeader({
+    required this.gifUrl,
+    required this.title,
+    required this.body,
+  });
+
+  final String gifUrl;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 14),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final gif = ClipRRect(
+              borderRadius: BorderRadius.circular(18),
+              child: SizedBox(
+                width: 128,
+                height: 128,
+                child: MobileWebImage(
+                  imageUrl: gifUrl,
+                  fit: BoxFit.cover,
+                  errorWidget: (context, url, error) => ColoredBox(
+                    color: colorScheme.surfaceContainerHighest,
+                    child: Icon(
+                      Icons.translate_rounded,
+                      color: colorScheme.onSurfaceVariant,
+                      size: 34,
+                    ),
                   ),
                 ),
               ),
-              SizedBox(height: 24),
-              Text(
-                AppLocalizations.of(context)!.translationHelpUsTranslate,
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.primary,
+            );
+            final text = Text(
+              body,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+                height: 1.3,
+              ),
+            );
+
+            if (constraints.maxWidth < 330) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [gif, const SizedBox(height: 14), text],
+              );
+            }
+
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                gif,
+                const SizedBox(width: 16),
+                Expanded(child: text),
+              ],
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _TranslationActionRow extends StatelessWidget {
+  const _TranslationActionRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 52),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 28,
+                  child: Icon(icon, color: colorScheme.primary, size: 22),
                 ),
-              ),
-              SizedBox(height: 16),
-              Text(
-                AppLocalizations.of(context)!.translationHelpTranslateContent,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              SizedBox(height: 16),
-              Center(
-                child: ElevatedButton.icon(
-                  onPressed: () async {
-                    await launchUrl(
-                      Uri.parse(
-                        "https://crowdin.com/project/clashkingapp/invite?h=87a407268713f1cb79724a2e0c00a5d52098842",
-                      ),
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.primary,
-                  ),
-                  icon: Icon(Icons.language),
-                  label: Text(
-                    AppLocalizations.of(
-                      context,
-                    )!.translationHelpTranslateButton,
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(color: Colors.white),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
-              ),
-              SizedBox(height: 8),
-              Center(
-                child: ElevatedButton.icon(
-                  onPressed: () async {
-                    await launchUrl(Uri.parse("https://discord.gg/clashking"));
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Color(0xFF5865F2),
-                  ),
-                  icon: Icon(Icons.discord),
-                  label: Text(
-                    AppLocalizations.of(context)!.faqJoinDiscord,
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(color: Colors.white),
-                  ),
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  color: colorScheme.onSurfaceVariant,
+                  size: 22,
                 ),
-              ),
-              SizedBox(height: 16),
-              Text(
-                AppLocalizations.of(context)!.translationCurrentTranslators,
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-              ),
-              SizedBox(height: 16),
-              Text('''
-  • AlejandroMoc
-  • athype
-  • bhatzuhaib
-  • ColinSchmale
-  • DeafToDeath
-  • Dinki/Krakakus
-  • dobryakoff
-  • GodOfGods
-  • Joelsuperstar
-  • lucaschuab2015
-  • mango_wz
-  • MixxStar
-  • MechanicaL
-  • MRocha01
-  • Nemo_64
-  • niklas312
-  • niku998
-  • Pottmichel
-  • retrock
-  • SamGo
-  • SudetiZ
-  • Wraxu
-  • zombie23304
-                ''', style: Theme.of(context).textTheme.bodyMedium),
-            ],
+              ],
+            ),
           ),
         ),
       ),
     );
   }
+}
 
-  void launchURL(String url) async {
-    if (await canLaunchUrl(Uri(path: url))) {
-      await launchUrl(Uri(path: url));
-    } else {
-      throw 'Could not launch $url';
-    }
+class _TranslatorList extends StatelessWidget {
+  const _TranslatorList({required this.title, required this.translators});
+
+  final String title;
+  final List<String> translators;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 9),
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        Wrap(
+          spacing: 7,
+          runSpacing: 7,
+          children: [
+            for (final translator in translators)
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest.withValues(
+                    alpha: 0.35,
+                  ),
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.32),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 5,
+                  ),
+                  child: Text(
+                    translator,
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
+    );
   }
 }

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "’n Groot dankie aan al ons wonderlike vertalers wat ons help om hierdie app vir meer mense regoor die wêreld toeganklik te maak!",
   "translationHelpTranslateContent": "Jy kan ons help om die app op Crowdin te vertaal. As jou taal nie op Crowdin beskikbaar is nie, vra gerus daarvoor in ons Discord-bediener. Baie dankie vir jou hulp!",
   "translationHelpTranslateButton": "Help vertaal op Crowdin",
-  "translationCurrentTranslators": "Huidige vertalers",
+  "translationCurrentTranslators": "Vertalers",
   "filtersTimeFilters": "Tydfilters",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "شكر جزيل لكل مترجمينا الرائعين الذين يساعدوننا في جعل هذا التطبيق متاحًا لعدد أكبر من الناس حول العالم!",
   "translationHelpTranslateContent": "يمكنك مساعدتنا في ترجمة التطبيق على Crowdin. إذا لم تكن لغتك متاحة على Crowdin، فلا تتردد في طلبها في خادم Discord الخاص بنا. شكرًا جزيلًا لمساعدتك!",
   "translationHelpTranslateButton": "المساعدة في الترجمة على Crowdin",
-  "translationCurrentTranslators": "المترجمون الحاليون",
+  "translationCurrentTranslators": "المترجمون",
   "filtersTimeFilters": "عوامل تصفية الوقت",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Moltes gràcies a tots els nostres traductors increïbles que ens ajuden a fer aquesta app accessible a més persones arreu del món!",
   "translationHelpTranslateContent": "Pots ajudar-nos a traduir l'app a Crowdin. Si el teu idioma no està disponible a Crowdin, demana'l al nostre servidor de Discord. Moltes gràcies per la teva ajuda!",
   "translationHelpTranslateButton": "Ajuda a traduir a Crowdin",
-  "translationCurrentTranslators": "Traductors actuals",
+  "translationCurrentTranslators": "Traductors",
   "filtersTimeFilters": "Filtres de temps",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Velice vám děkuji všem našim úžasným překladatelům, kteří nám pomáhají zpřístupnit tuto aplikaci více lidí po celém světě!",
   "translationHelpTranslateContent": "Můžete nám pomoci přeložit aplikaci na Crowdin. Pokud tvůj jazyk není k dispozici na Crowdinu, neváhej se o něj požádat na našem Discord serveru. Mnohokrát ti děkujeme za pomoc!",
   "translationHelpTranslateButton": "Pomozte přeložit na Crowdin",
-  "translationCurrentTranslators": "Aktuální překladatelé",
+  "translationCurrentTranslators": "Překladatelé",
   "filtersTimeFilters": "Časové filtry",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "En stor tak til alle vores fantastiske oversættere, der hjælper os med at gøre denne app tilgængelig for flere mennesker rundt om i verden!",
   "translationHelpTranslateContent": "Du kan hjælpe os med at oversætte appen på Crowdin. Hvis dit sprog ikke er tilgængeligt på Crowdin, er du velkommen til at anmode om det i vores Discord Server. Tak for din hjælp!",
   "translationHelpTranslateButton": "Hjælp med at oversætte til Crowdin",
-  "translationCurrentTranslators": "Nuværende Oversættere",
+  "translationCurrentTranslators": "Oversættere",
   "filtersTimeFilters": "Tidsfiltre",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Ein großes Dankeschön an all unsere großartigen Übersetzer, die uns helfen, diese App mehr Menschen auf der ganzen Welt zugänglich zu machen!",
   "translationHelpTranslateContent": "Du kannst uns helfen, die App auf Crowdin zu übersetzen. Wenn deine Sprache auf Crowdin nicht verfügbar ist, kannst du diese gerne auf unserem Discord-Server anfordern. Vielen Dank für deine Hilfe!",
   "translationHelpTranslateButton": "Hilf bei der Übersetzung auf Crowdin",
-  "translationCurrentTranslators": "Aktuelle Übersetzer",
+  "translationCurrentTranslators": "Übersetzer",
   "filtersTimeFilters": "Zeitfilter",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Ένα τεράστιο ευχαριστώ σε όλους τους εξαιρετικούς μεταφραστές μας που μας βοηθάνε να κάνουμε την εφαρμογή προσβάσιμη σε περισσότερους ανθρώπους σε όλο τον κόσμο!",
   "translationHelpTranslateContent": "Μπορείτε να μας βοηθήσετε να μεταφράσουμε την εφαρμογή στο Crowdin. Εάν η γλώσσα σας δεν είναι διαθέσιμη στο Crowdin, παρακαλώ ζητείστε το στην ομάδα μας στο Discord. Σας ευχαριστούμε πολύ για τη βοήθεια!",
   "translationHelpTranslateButton": "Βοηθήστε μας στη μετάφραση στο Crowdin",
-  "translationCurrentTranslators": "Τωρινοί μεταφραστές",
+  "translationCurrentTranslators": "Μεταφραστές",
   "filtersTimeFilters": "Φίλτρα χρόνου",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1648,10 +1648,10 @@
   "translationHelpUsTranslate": "Help us translate",
   "translationSuggestFeatures": "Suggest features",
   "translationThankYou": "Thank you!",
-  "translationThankYouContent": "A huge thank you to all our amazing translators who help us make this app accessible to more people around the world!",
-  "translationHelpTranslateContent": "You can help us translate the app on Crowdin. If your language is not available on Crowdin, feel free to request it in our Discord Server. Thank you so much for your help!",
-  "translationHelpTranslateButton": "Help Translate on Crowdin",
-  "translationCurrentTranslators": "Current Translators",
+  "translationThankYouContent": "Thank you to everyone who reviews, corrects, and improves ClashKing translations. Your contributions make the app feel clearer, more natural, and easier to use for players around the world.",
+  "translationHelpTranslateContent": "Spot a missing, awkward, or incorrect translation? You can suggest a correction on Crowdin, or reach us on Discord if your language is missing or you are not sure where to start.",
+  "translationHelpTranslateButton": "Edit on Crowdin",
+  "translationCurrentTranslators": "Translators",
   "filtersTimeFilters": "Time Filters",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -1488,10 +1488,10 @@
   "translationHelpUsTranslate": "Help us translate",
   "translationSuggestFeatures": "Suggest features",
   "translationThankYou": "Thank you!",
-  "translationThankYouContent": "A huge thank you to all our amazing translators who help us make this app accessible to more people around the world!",
-  "translationHelpTranslateContent": "You can help us translate the app on Crowdin. If your language is not available on Crowdin, feel free to request it in our Discord Server. Thank you so much for your help!",
-  "translationHelpTranslateButton": "Help Translate on Crowdin",
-  "translationCurrentTranslators": "Current Translators",
+  "translationThankYouContent": "Thank you to everyone who reviews, corrects, and improves ClashKing translations. Your contributions make the app feel clearer, more natural, and easier to use for players around the world.",
+  "translationHelpTranslateContent": "Spot a missing, awkward, or incorrect translation? You can suggest a correction on Crowdin, or reach us on Discord if your language is missing or you are not sure where to start.",
+  "translationHelpTranslateButton": "Edit on Crowdin",
+  "translationCurrentTranslators": "Translators",
   "filtersTimeFilters": "Time Filters",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -1488,10 +1488,10 @@
   "translationHelpUsTranslate": "Help us translate",
   "translationSuggestFeatures": "Suggest features",
   "translationThankYou": "Thank you!",
-  "translationThankYouContent": "A huge thank you to all our amazing translators who help us make this app accessible to more people around the world!",
-  "translationHelpTranslateContent": "You can help us translate the app on Crowdin. If your language is not available on Crowdin, feel free to request it in our Discord Server. Thank you so much for your help!",
-  "translationHelpTranslateButton": "Help Translate on Crowdin",
-  "translationCurrentTranslators": "Current Translators",
+  "translationThankYouContent": "Thank you to everyone who reviews, corrects, and improves ClashKing translations. Your contributions make the app feel clearer, more natural, and easier to use for players around the world.",
+  "translationHelpTranslateContent": "Spot a missing, awkward, or incorrect translation? You can suggest a correction on Crowdin, or reach us on Discord if your language is missing or you are not sure where to start.",
+  "translationHelpTranslateButton": "Edit on Crowdin",
+  "translationCurrentTranslators": "Translators",
   "filtersTimeFilters": "Time Filters",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1615,7 +1615,7 @@
   "translationThankYouContent": "¡Un enorme agradecimiento a todos nuestros increíbles traductores que nos ayudan a hacer que esta aplicación sea accesible para más personas en todo el mundo!",
   "translationHelpTranslateContent": "Puedes ayudarnos a traducir la app en Crowdin. Si tu idioma no está disponible en Crowdin, puedes solicitarlo en nuestro servidor de Discord. ¡Muchas gracias por tu ayuda!",
   "translationHelpTranslateButton": "Ayuda a traducir en Crowdin",
-  "translationCurrentTranslators": "Traductores Actuales",
+  "translationCurrentTranslators": "Traductores",
   "filtersTimeFilters": "Filtros de tiempo",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_es_ES.arb
+++ b/lib/l10n/app_es_ES.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "¡Un enorme agradecimiento a todos nuestros increíbles traductores que nos ayudan a hacer que esta aplicación sea accesible para más personas en todo el mundo!",
   "translationHelpTranslateContent": "Puedes ayudarnos a traducir la app en Crowdin. Si tu idioma no está disponible en Crowdin, puedes solicitarlo en nuestro servidor de Discord. ¡Muchas gracias por tu ayuda!",
   "translationHelpTranslateButton": "Ayuda a traducir en Crowdin",
-  "translationCurrentTranslators": "Traductores Actuales",
+  "translationCurrentTranslators": "Traductores",
   "filtersTimeFilters": "Filtros de tiempo",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Valtava kiitos kaikille uskomattomille kääntäjille, jotka auttavat meitä tekemään tämän sovelluksen useampien ihmisten saataville ympäri maailmaa!",
   "translationHelpTranslateContent": "Voit auttaa meitä kääntämään sovelluksen Crowdinissa. Jos kielesi ei ole käytettävissä Crowdinissa, voit vapaasti pyytää sitä meidän Discord-palvelimella. Kiitos paljon avustasi!",
   "translationHelpTranslateButton": "Auta kääntämään Crowdinia",
-  "translationCurrentTranslators": "Nykyiset Kääntäjät",
+  "translationCurrentTranslators": "Kääntäjät",
   "filtersTimeFilters": "Aikasuodattimet",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1552,10 +1552,10 @@
   "translationHelpUsTranslate": "Nous aider à traduire",
   "translationSuggestFeatures": "Proposer des fonctionnalités",
   "translationThankYou": "Merci !",
-  "translationThankYouContent": "Un grand merci à tous nos incroyables traducteurs qui nous aident à rendre cette application accessible à plus de personnes à travers le monde !",
-  "translationHelpTranslateContent": "Vous pouvez nous aider à traduire l'application sur Crowdin. Si votre langue n'est pas disponible sur Crowdin, n'hésitez pas à la demander sur notre serveur Discord. Merci beaucoup pour votre aide !",
-  "translationHelpTranslateButton": "Aider à traduire sur Crowdin",
-  "translationCurrentTranslators": "Traducteurs actuels",
+  "translationThankYouContent": "Merci à toutes les personnes qui relisent, corrigent et améliorent les traductions de ClashKing. Vos contributions rendent l'app plus claire, plus naturelle et plus agréable à utiliser pour les joueurs du monde entier.",
+  "translationHelpTranslateContent": "Tu vois une traduction manquante, maladroite ou incorrecte ? Tu peux proposer une correction sur Crowdin, ou nous rejoindre sur Discord si ta langue manque ou si tu ne sais pas par où commencer.",
+  "translationHelpTranslateButton": "Corriger sur Crowdin",
+  "translationCurrentTranslators": "Traducteurs",
   "filtersTimeFilters": "Filtres temporels",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "תודה ענקית לכל המתרגמים הנהדרים שלנו שעוזרים לנו להפוך את האפליקציה לזמינה ליותר אנשים ברחבי העולם!",
   "translationHelpTranslateContent": "אפשר לעזור לנו לתרגם את האפליקציה ב-Crowdin. אם השפה שלך אינה זמינה ב-Crowdin, אפשר לבקש אותה בשרת ה-Discord שלנו. תודה רבה על העזרה!",
   "translationHelpTranslateButton": "עזור לתרגם ב-Crowdin",
-  "translationCurrentTranslators": "מתרגמים נוכחיים",
+  "translationCurrentTranslators": "מתרגמים",
   "filtersTimeFilters": "מסנני זמן",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "हमारे सभी अद्भुत अनुवादकों को बहुत-बहुत धन्यवाद, जो इस ऐप को दुनिया भर के अधिक लोगों तक पहुंचाने में हमारी मदद करते हैं!",
   "translationHelpTranslateContent": "आप क्राउडिन पर ऐप का अनुवाद करने में हमारी मदद कर सकते हैं। अगर आपकी भाषा क्राउडिन पर उपलब्ध नहीं है, तो बेझिझक हमारे डिस्कॉर्ड सर्वर पर इसका अनुरोध करें। आपकी मदद के लिए बहुत-बहुत धन्यवाद!",
   "translationHelpTranslateButton": "क्राउडिन पर अनुवाद में सहायता करें",
-  "translationCurrentTranslators": "वर्तमान अनुवादक",
+  "translationCurrentTranslators": "अनुवादक",
   "filtersTimeFilters": "समय फ़िल्टर",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Hatalmas köszönet a rendkívüli fordítóknak, akik segítenek hogy az app minél több embernek világszerte elérhető legyen!",
   "translationHelpTranslateContent": "Segíthetsz a fordításban Crowdin-en. Ha a nyelved nem elérhető Crowdin-en, nyugodtan kérd a Discord szerverünkön. Nagyon köszönjük a segítségedet!",
   "translationHelpTranslateButton": "Segíts fordítani Crowdin-en",
-  "translationCurrentTranslators": "Jelenlegi Fordítók",
+  "translationCurrentTranslators": "Fordítók",
   "filtersTimeFilters": "Időszűrők",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Un grazie enorme a tutti i nostri incredibili traduttori che ci aiutano a rendere questa app accessibile a più persone in tutto il mondo!",
   "translationHelpTranslateContent": "Puoi aiutarci a tradurre l'app su Crowdin. Se la tua lingua non è disponibile su Crowdin, sentiti libero di richiederla nel nostro Server Discord. Grazie mille per il tuo aiuto!",
   "translationHelpTranslateButton": "Aiuta a tradurre su Crowdin",
-  "translationCurrentTranslators": "Traduttori Attuali",
+  "translationCurrentTranslators": "Traduttori",
   "filtersTimeFilters": "Filtri temporali",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "このアプリを世界中のより多くの人に届けるために協力してくれる素晴らしい翻訳者の皆さんに、心から感謝します！",
   "translationHelpTranslateContent": "Crowdinでアプリの翻訳に協力できます。あなたの言語がCrowdinにない場合は、Discordサーバーでリクエストしてください。ご協力本当にありがとうございます！",
   "translationHelpTranslateButton": "Crowdinで翻訳を手伝う",
-  "translationCurrentTranslators": "現在の翻訳者",
+  "translationCurrentTranslators": "翻訳者",
   "filtersTimeFilters": "時間フィルター",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "이 앱을 전 세계 더 많은 사람들이 사용할 수 있도록 도와주는 모든 멋진 번역자 여러분께 진심으로 감사드립니다!",
   "translationHelpTranslateContent": "Crowdin에서 앱 번역을 도울 수 있습니다. 여러분의 언어가 Crowdin에 없다면 Discord 서버에서 요청해 주세요. 도움에 정말 감사드립니다!",
   "translationHelpTranslateButton": "Crowdin에서 번역 돕기",
-  "translationCurrentTranslators": "현재 번역자",
+  "translationCurrentTranslators": "번역자",
   "filtersTimeFilters": "시간 필터",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Een enorme dank aan al onze geweldige vertalers die ons helpen deze app toegankelijk te maken voor meer mensen over de hele wereld!",
   "translationHelpTranslateContent": "Je kunt ons helpen de app op Crowdin te vertalen. Als je taal niet beschikbaar is op Crowdin, kan je deze aanvragen in onze Discord Server. Heel erg bedankt voor je hulp!",
   "translationHelpTranslateButton": "Help met vertalen op Crowdin",
-  "translationCurrentTranslators": "Huidige vertalers",
+  "translationCurrentTranslators": "Vertalers",
   "filtersTimeFilters": "Tijd filters",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_no.arb
+++ b/lib/l10n/app_no.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "En stor takk til alle de fantastiske oversetterne våre som hjelper oss med å gjøre appen tilgjengelig for flere mennesker over hele verden!",
   "translationHelpTranslateContent": "Du kan hjelpe oss med å oversette appen på Crowdin. Hvis språket ditt ikke er tilgjengelig på Crowdin, kan du gjerne be om det på Discord-serveren vår. Tusen takk for hjelpen!",
   "translationHelpTranslateButton": "Hjelp til med oversetting på Crowdin",
-  "translationCurrentTranslators": "Nåværende oversettere",
+  "translationCurrentTranslators": "Oversettere",
   "filtersTimeFilters": "Tidsfiltre",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Wielkie dzięki dla wszystkich naszych niesamowitych tłumaczy, którzy pomagają nam uczynić tę aplikację dostępną dla większej liczby ludzi na całym świecie!",
   "translationHelpTranslateContent": "Możesz nam pomóc przetłumaczyć aplikację na Crowdin. Jeśli Twojego języka nie ma na Crowdin, śmiało poproś o niego na naszym serwerze Discord. Bardzo dziękujemy za pomoc!",
   "translationHelpTranslateButton": "Pomóż przetłumaczyć na Crowdin",
-  "translationCurrentTranslators": "Aktualni tłumacze",
+  "translationCurrentTranslators": "Tłumacze",
   "filtersTimeFilters": "Filtry czasu",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Um enorme obrigado a todos os nossos incríveis tradutores que nos ajudam a tornar este aplicativo acessível a mais pessoas ao redor do mundo!",
   "translationHelpTranslateContent": "Pode ajudar-nos a traduzir a aplicação no Crowdin. Se a sua linguagem não está disponível no Crowdin, sinta-se à vontade para pedi-la no nosso servidor de Discord. Muito obrigado pela sua ajuda!",
   "translationHelpTranslateButton": "Ajude-nos a traduzir no Crowdin",
-  "translationCurrentTranslators": "Atuais tradutores",
+  "translationCurrentTranslators": "Tradutores",
   "filtersTimeFilters": "Filtros de tempo",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Un mare mulțumesc tuturor traducătorilor noștri minunați care ne ajută să facem aplicația accesibilă pentru mai mulți oameni din întreaga lume!",
   "translationHelpTranslateContent": "Ne poți ajuta să traducem aplicația pe Crowdin. Dacă limba ta nu este disponibilă pe Crowdin, o poți solicita pe serverul nostru Discord. Îți mulțumim mult pentru ajutor!",
   "translationHelpTranslateButton": "Ajută la traducere pe Crowdin",
-  "translationCurrentTranslators": "Traducători actuali",
+  "translationCurrentTranslators": "Traducători",
   "filtersTimeFilters": "Filtre de timp",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Огромное спасибо всем нашим замечательным переводчикам, которые помогают нам сделать это приложение доступным для большего количества людей по всему миру!",
   "translationHelpTranslateContent": "Вы можете помочь нам перевести приложение на Crowdin. Если ваш язык недоступен на Crowdin, смело запрашивайте его на нашем сервере Discord. Большое спасибо за вашу помощь!",
   "translationHelpTranslateButton": "Помогите с переводом на Crowdin",
-  "translationCurrentTranslators": "Текущие Переводчики",
+  "translationCurrentTranslators": "Переводчики",
   "filtersTimeFilters": "Фильтры времени",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Ogromno hvala svim našim sjajnim prevodiocima koji nam pomažu da ova aplikacija bude dostupna većem broju ljudi širom sveta!",
   "translationHelpTranslateContent": "Možeš pomoći u prevodu aplikacije na Crowdin-u. Ako tvoj jezik nije dostupan na Crowdin-u, slobodno ga zatraži na našem Discord serveru. Hvala ti puno na pomoći!",
   "translationHelpTranslateButton": "Pomozi u prevodu na Crowdin-u",
-  "translationCurrentTranslators": "Trenutni prevodioci",
+  "translationCurrentTranslators": "Prevodioci",
   "filtersTimeFilters": "Vremenski filteri",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Ett stort tack till alla våra fantastiska översättare som hjälper oss att göra appen tillgänglig för fler människor världen över!",
   "translationHelpTranslateContent": "Du kan hjälpa oss att översätta appen på Crowdin. Om ditt språk inte finns på Crowdin får du gärna be om det på vår Discord-server. Tack så mycket för hjälpen!",
   "translationHelpTranslateButton": "Hjälp till att översätta på Crowdin",
-  "translationCurrentTranslators": "Nuvarande översättare",
+  "translationCurrentTranslators": "Översättare",
   "filtersTimeFilters": "Tidsfilter",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Bu uygulamayı dünya çapında daha fazla insana ulaştırmamıza yardımcı olan tüm harika çevirmenlerimize çok teşekkür ederiz!",
   "translationHelpTranslateContent": "Uygulamayı Crowdin'de çevirmemize yardımcı olabilirsiniz. Diliniz Crowdin'de mevcut değilse, Discord Sunucumuzda talep etmekten çekinmeyin. Yardımınız için çok teşekkür ederim!",
   "translationHelpTranslateButton": "Crowdin'de Çeviriye Yardım Edin",
-  "translationCurrentTranslators": "Güncel Tercümanlar",
+  "translationCurrentTranslators": "Tercümanlar",
   "filtersTimeFilters": "Zaman Filtreleri",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Величезна подяка всім нашим неймовірним перекладачам, які допомагають нам зробити цей додаток доступним для більшої кількості людей по всьому світу!",
   "translationHelpTranslateContent": "Ви можете допомогти нам перекласти додаток на Crowdin. Якщо вашої мови немає на Crowdin, не соромтеся запитати її на нашому сервері Discord. Дуже вдячні за вашу допомогу!",
   "translationHelpTranslateButton": "Допоможіть перекласти на Crowdin",
-  "translationCurrentTranslators": "Поточні перекладачі",
+  "translationCurrentTranslators": "Перекладачі",
   "filtersTimeFilters": "Фільтри часу",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "ہمارے تمام حیرت انگیز مترجمین کا بہت بہت شکریہ جنہوں نے اس ایپ کو دنیا بھر کے مزید لوگوں تک قابل رسائی بنانے میں ہماری مدد کی!",
   "translationHelpTranslateContent": "آپ Crowdin پر ایپ کا ترجمہ کرنے میں ہماری مدد کر سکتے ہیں۔ اگر آپ کی زبان Crowdin پر دستیاب نہیں ہے تو بلا جھجھک ہمارے Discord Server میں اس کی درخواست کریں۔ آپ کی مدد کے لیے آپ کا بہت بہت شکریہ!",
   "translationHelpTranslateButton": "Crowdin پر ترجمہ میں مدد کریں۔",
-  "translationCurrentTranslators": "موجودہ مترجم",
+  "translationCurrentTranslators": "مترجم",
   "filtersTimeFilters": "وقت کے فلٹرز",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "Xin gửi lời cảm ơn lớn tới tất cả những dịch giả tuyệt vời đã giúp chúng tôi đưa ứng dụng này đến với nhiều người hơn trên khắp thế giới!",
   "translationHelpTranslateContent": "Bạn có thể giúp chúng tôi dịch ứng dụng trên Crowdin. Nếu ngôn ngữ của bạn chưa có trên Crowdin, hãy thoải mái yêu cầu trong Máy chủ Discord của chúng tôi. Cảm ơn bạn rất nhiều vì đã giúp đỡ!",
   "translationHelpTranslateButton": "Giúp dịch trên Crowdin",
-  "translationCurrentTranslators": "Dịch giả hiện tại",
+  "translationCurrentTranslators": "Dịch giả",
   "filtersTimeFilters": "Bộ lọc thời gian",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1491,7 +1491,7 @@
   "translationThankYouContent": "非常感谢我们所有出色的翻译人员，他们帮助我们让世界各地的更多人可以访问这个应用程序！",
   "translationHelpTranslateContent": "您可以在Crowdin上帮助我们翻译应用程序。如果您的语言在Crowdin上不可用，请随时在我们的Discord服务器上请求。非常感谢你的帮助！",
   "translationHelpTranslateButton": "在Crowdin上帮助翻译",
-  "translationCurrentTranslators": "当前翻译员",
+  "translationCurrentTranslators": "翻译员",
   "filtersTimeFilters": "时间筛选",
   "@filtersTimeFilters": {
     "description": "Time-based filters section title"

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,3 +1,4 @@
+- Settings language and theme pickers now match the app's current settings styling in light and dark mode
 - Refined notification audience settings with clearer account scope controls.
 - Updated the FAQ with clearer feature coverage for accounts, notifications, widgets, to-do, and upgrade tracking
 - Fixed the home to-do card so it also hides accounts you've turned "Show on to-do page" off for, not just the full to-do list


### PR DESCRIPTION
## Summary
- Align the language and theme selection sheets with the rest of Settings using a shared native list pattern.
- Refresh the "Help translate" page with a lighter native layout, the original GIF, shorter Crowdin copy, and translator chips.
- Update localization strings and release notes for the visible settings changes.

## Validation
- flutter gen-l10n
- flutter analyze --no-pub lib\features\settings\presentation\settings_page.dart lib\features\settings\presentation\translation_page.dart
- JSON validation for lib/l10n/app_*.arb
- git diff --check

## Test notes
- Check Settings > Language and Settings > Change theme in dark/light mode.
- Check Settings > Help translate in French/dark mode, including the GIF, Crowdin/Discord rows, and translator label.