### PR TITLE
feat: polish calculators, CWL, and war UX

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -86,9 +86,9 @@ export async function hasFlutterSemantics(page: Page): Promise<boolean> {
  */
 export function authSegment(page: Page, name: RegExp): Locator {
   const exactName = /email/i.test(name.source)
-    ? /^email$/i
+    ? /^email(?:\s+email)?$/i
     : /discord/i.test(name.source)
-      ? /^discord$/i
+      ? /^discord(?:\s+discord)?$/i
       : name;
 
   return page

--- a/lib/common/widgets/compact_filter_chip.dart
+++ b/lib/common/widgets/compact_filter_chip.dart
@@ -1,0 +1,77 @@
+import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:flutter/material.dart';
+
+/// Compact filter toggle used by dense, horizontally-scannable page controls.
+class CompactFilterChip extends StatelessWidget {
+  const CompactFilterChip({
+    super.key,
+    required this.label,
+    this.icon,
+    this.imageUrl,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData? icon;
+  final String? imageUrl;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final accent = colorScheme.primary;
+    final hasImage = imageUrl?.trim().isNotEmpty == true;
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(AppRadius.pill),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        splashFactory: NoSplash.splashFactory,
+        onTap: onTap,
+        child: Container(
+          height: 36,
+          padding: const EdgeInsets.symmetric(horizontal: 11),
+          decoration: BoxDecoration(
+            color: selected
+                ? accent.withValues(alpha: 0.16)
+                : colorScheme.surfaceContainerHighest.withValues(alpha: 0.38),
+            borderRadius: BorderRadius.circular(AppRadius.pill),
+            border: Border.all(
+              color: selected
+                  ? accent.withValues(alpha: 0.42)
+                  : colorScheme.outlineVariant.withValues(alpha: 0.28),
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (hasImage) ...[
+                MobileWebImage(imageUrl: imageUrl!, height: 15, width: 15),
+                const SizedBox(width: 5),
+              ] else if (icon != null) ...[
+                Icon(
+                  icon,
+                  size: 15,
+                  color: selected ? accent : colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 5),
+              ],
+              Text(
+                label,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: selected ? FontWeight.w900 : FontWeight.w700,
+                  height: 1,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -44,12 +44,7 @@ class ApiConfig {
       return _withoutTrailingSlash(_apiV2BaseOverride);
     }
 
-    return switch (environment) {
-      ApiEnvironment.local => '$apiBaseUrl/v2',
-      // The notification endpoints are currently deployed on local-api.
-      // Move this to api.clashk.ing after the v2 rollout is complete.
-      ApiEnvironment.production => 'https://local-api.clashk.ing/v2',
-    };
+    return _resolvedApiV2UrlFor(environment);
   }
 
   static String get proxyUrl {
@@ -68,9 +63,21 @@ class ApiConfig {
     ApiEnvironment.production => 'https://api.clashk.ing',
   };
 
-  static String defaultApiV2UrlFor(ApiEnvironment target) => switch (target) {
+  static String defaultApiV2UrlFor(ApiEnvironment target) =>
+      _defaultApiV2UrlFor(target);
+
+  static String _resolvedApiV2UrlFor(ApiEnvironment target) {
+    // Keep CK_API_BASE_URL useful for local development while production has
+    // one canonical v2 host shared by the runtime getter and default helper.
+    if (target == ApiEnvironment.local && _apiBaseOverride.isNotEmpty) {
+      return '$apiBaseUrl/v2';
+    }
+    return _defaultApiV2UrlFor(target);
+  }
+
+  static String _defaultApiV2UrlFor(ApiEnvironment target) => switch (target) {
     ApiEnvironment.local => '${defaultApiBaseUrlFor(target)}/v2',
-    ApiEnvironment.production => 'https://local-api.clashk.ing/v2',
+    ApiEnvironment.production => 'https://v2-api.clashk.ing/v2',
   };
 
   static String defaultProxyUrlFor(ApiEnvironment target) => switch (target) {

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -32,6 +32,8 @@ const _fireballQuakeSetupId = 'fireball-quake';
 const _giantArrowSetupId = 'giant-arrow';
 const _flameFlingerSetupId = 'flame-flinger';
 const _townHallBuildingName = 'Town Hall';
+const _lightningSpellName = 'Lightning Spell';
+const _darkElixirResourceName = 'dark elixir';
 const _defaultFarmPerfectLoot = 1000000;
 
 class CalculatorsPage extends StatefulWidget {
@@ -777,7 +779,7 @@ class _CalculatorScaffold extends StatelessWidget {
         tabs: [
           InfoProfileTabData(
             label: loc.calculatorsModeDamage,
-            imageUrl: ImageAssets.getSpellImage('Lightning Spell'),
+            imageUrl: ImageAssets.getSpellImage(_lightningSpellName),
           ),
           InfoProfileTabData(
             label: loc.calculatorsModeFarmGoal,
@@ -804,7 +806,7 @@ class _CalculatorHeader extends StatelessWidget {
     final isDesktopWeb = isSidePageDesktop(context);
     final imageHeight = media.padding.top + (isDesktopWeb ? 292 : 246);
     final imageUrl = selectedMode == _CalculatorMode.damage
-        ? ImageAssets.getSpellImage('Lightning Spell')
+        ? ImageAssets.getSpellImage(_lightningSpellName)
         : ImageAssets.getHomeVillageBuildingImage(_townHallBuildingName, 1);
     final fallbackIcon = selectedMode == _CalculatorMode.damage
         ? Icons.bolt_rounded
@@ -1736,9 +1738,27 @@ class _CalculatorAccountPickerSheetState
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
+    final accounts = _filteredAccounts();
+
+    return FractionallySizedBox(
+      heightFactor: 0.82,
+      child: Column(
+        children: [
+          _buildHeader(context),
+          _buildSearchField(context),
+          Expanded(
+            child: accounts.isEmpty && !widget.allowCustom
+                ? _buildEmptyState(context)
+                : _buildAccountsList(context, accounts),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<DamageAccountPreset> _filteredAccounts() {
     final query = _query.trim().toLowerCase();
-    final accounts = widget.accountPresets
+    return widget.accountPresets
         .where(
           (account) =>
               query.isEmpty ||
@@ -1746,134 +1766,139 @@ class _CalculatorAccountPickerSheetState
               account.tag.toLowerCase().contains(query),
         )
         .toList(growable: false);
+  }
 
-    return FractionallySizedBox(
-      heightFactor: 0.82,
-      child: Column(
+  Widget _buildHeader(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 12, 8),
+      child: Row(
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 16, 12, 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    loc.damageAccountPresetShort,
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                ),
-                IconButton(
-                  tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
-                  onPressed: () => Navigator.pop(context),
-                  icon: const Icon(Icons.close_rounded),
-                ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
-            child: TextField(
-              controller: _searchController,
-              decoration: InputDecoration(
-                labelText: loc.damageChooseAccount,
-                prefixIcon: const Icon(Icons.search_rounded),
-                suffixIcon: _query.isEmpty
-                    ? null
-                    : IconButton(
-                        tooltip: loc.generalClearSearch,
-                        onPressed: () {
-                          _searchController.clear();
-                          setState(() => _query = '');
-                        },
-                        icon: const Icon(Icons.close_rounded),
-                      ),
-              ),
-              onChanged: (value) => setState(() => _query = value),
-            ),
-          ),
           Expanded(
-            child: accounts.isEmpty && !widget.allowCustom
-                ? AppEmptyState(
-                    icon: Icons.person_search_rounded,
-                    title: loc.damageNoAccountsAvailable,
-                    body: loc.generalTryAgain,
-                  )
-                : ListView.builder(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    itemCount: accounts.length + (widget.allowCustom ? 1 : 0),
-                    itemBuilder: (context, index) {
-                      if (widget.allowCustom && index == 0) {
-                        final selected = widget.selectedTag == null;
-                        return ListTile(
-                          selected: selected,
-                          selectedTileColor: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(AppRadius.chip),
-                          ),
-                          leading: const SizedBox.square(
-                            dimension: 44,
-                            child: Icon(Icons.tune_rounded),
-                          ),
-                          title: Text(loc.damageQuickSetupCustom),
-                          subtitle: Text(loc.damageAccountSelectorHint),
-                          trailing: selected
-                              ? const Icon(Icons.check_rounded)
-                              : null,
-                          onTap: () =>
-                              Navigator.pop(context, _accountlessPresetTag),
-                        );
-                      }
-                      final account =
-                          accounts[widget.allowCustom ? index - 1 : index];
-                      final selected = account.tag == widget.selectedTag;
-                      return ListTile(
-                        selected: selected,
-                        selectedTileColor: Theme.of(
-                          context,
-                        ).colorScheme.surfaceContainerHighest,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(AppRadius.chip),
-                        ),
-                        leading: SizedBox.square(
-                          dimension: 44,
-                          child: MobileWebImage(
-                            imageUrl: ImageAssets.townHall(account.townHall),
-                            fit: BoxFit.contain,
-                            errorWidget: (_, _, _) => MobileWebImage(
-                              imageUrl: ImageAssets.defaultProfile,
-                              fit: BoxFit.contain,
-                              errorWidget: (_, _, _) =>
-                                  const Icon(Icons.person_rounded),
-                            ),
-                          ),
-                        ),
-                        title: Text(
-                          '${account.name} · ${loc.gameTownHallShortLevel(account.townHall)}',
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        subtitle: Text(
-                          [
-                            account.tag,
-                            if (account.league?.trim().isNotEmpty == true)
-                              account.league!,
-                          ].join(' · '),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        trailing: selected
-                            ? const Icon(Icons.check_rounded)
-                            : null,
-                        onTap: () => Navigator.pop(context, account.tag),
-                      );
-                    },
-                  ),
+            child: Text(
+              loc.damageAccountPresetShort,
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+            ),
+          ),
+          IconButton(
+            tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.close_rounded),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildSearchField(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+      child: TextField(
+        controller: _searchController,
+        decoration: InputDecoration(
+          labelText: loc.damageChooseAccount,
+          prefixIcon: const Icon(Icons.search_rounded),
+          suffixIcon: _query.isEmpty
+              ? null
+              : IconButton(
+                  tooltip: loc.generalClearSearch,
+                  onPressed: () {
+                    _searchController.clear();
+                    setState(() => _query = '');
+                  },
+                  icon: const Icon(Icons.close_rounded),
+                ),
+        ),
+        onChanged: (value) => setState(() => _query = value),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return AppEmptyState(
+      icon: Icons.person_search_rounded,
+      title: loc.damageNoAccountsAvailable,
+      body: loc.generalTryAgain,
+    );
+  }
+
+  Widget _buildAccountsList(
+    BuildContext context,
+    List<DamageAccountPreset> accounts,
+  ) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      itemCount: accounts.length + (widget.allowCustom ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (widget.allowCustom && index == 0) {
+          return _buildCustomTile(context);
+        }
+        final account = accounts[widget.allowCustom ? index - 1 : index];
+        return _buildAccountTile(context, account);
+      },
+    );
+  }
+
+  Widget _buildCustomTile(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final selected = widget.selectedTag == null;
+    return ListTile(
+      selected: selected,
+      selectedTileColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+      ),
+      leading: const SizedBox.square(
+        dimension: 44,
+        child: Icon(Icons.tune_rounded),
+      ),
+      title: Text(loc.damageQuickSetupCustom),
+      subtitle: Text(loc.damageAccountSelectorHint),
+      trailing: selected ? const Icon(Icons.check_rounded) : null,
+      onTap: () => Navigator.pop(context, _accountlessPresetTag),
+    );
+  }
+
+  Widget _buildAccountTile(BuildContext context, DamageAccountPreset account) {
+    final loc = AppLocalizations.of(context)!;
+    final selected = account.tag == widget.selectedTag;
+    return ListTile(
+      selected: selected,
+      selectedTileColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+      ),
+      leading: SizedBox.square(
+        dimension: 44,
+        child: MobileWebImage(
+          imageUrl: ImageAssets.townHall(account.townHall),
+          fit: BoxFit.contain,
+          errorWidget: (_, _, _) => MobileWebImage(
+            imageUrl: ImageAssets.defaultProfile,
+            fit: BoxFit.contain,
+            errorWidget: (_, _, _) => const Icon(Icons.person_rounded),
+          ),
+        ),
+      ),
+      title: Text(
+        '${account.name} · ${loc.gameTownHallShortLevel(account.townHall)}',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        [
+          account.tag,
+          if (account.league?.trim().isNotEmpty == true) account.league!,
+        ].join(' · '),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: selected ? const Icon(Icons.check_rounded) : null,
+      onTap: () => Navigator.pop(context, account.tag),
     );
   }
 }
@@ -2402,7 +2427,7 @@ class _ZapQuakePanel extends StatelessWidget {
           .map(
             (combo) => Chip(
               avatar: MobileWebImage(
-                imageUrl: ImageAssets.getSpellImage('Lightning Spell'),
+                imageUrl: ImageAssets.getSpellImage(_lightningSpellName),
                 width: 18,
                 height: 18,
                 fit: BoxFit.contain,
@@ -2721,7 +2746,7 @@ Map<DamageSourceKind, int> _ownedDamageLevels(Player player) {
     }
   }
 
-  add(DamageSourceKind.lightning, player.spells, 'Lightning Spell');
+  add(DamageSourceKind.lightning, player.spells, _lightningSpellName);
   add(DamageSourceKind.earthquake, player.spells, 'Earthquake Spell');
   add(DamageSourceKind.giantArrow, player.equipments, 'Giant Arrow');
   add(DamageSourceKind.fireball, player.equipments, 'Fireball');
@@ -2748,7 +2773,7 @@ String? _upgradeResourceLabel(AppLocalizations loc, String? resource) {
   return switch (normalized) {
     'gold' => loc.resourceGold,
     'elixir' => loc.resourceElixir,
-    'dark elixir' => loc.resourceDarkElixir,
+    _darkElixirResourceName => loc.resourceDarkElixir,
     final value when value != null && value.isNotEmpty => resource,
     _ => null,
   };
@@ -2837,12 +2862,14 @@ String? _farmResourceImage(String? resource) =>
     switch (resource?.trim().toLowerCase().replaceAll('_', ' ')) {
       'gold' => '${ImageAssets.baseUrl}/resources/gold.webp',
       'elixir' => '${ImageAssets.baseUrl}/resources/elixir.webp',
-      'dark elixir' => '${ImageAssets.baseUrl}/resources/dark_elixir.webp',
+      _darkElixirResourceName =>
+        '${ImageAssets.baseUrl}/resources/dark_elixir.webp',
       _ => null,
     };
 
 int _farmDefaultPerfectLoot(String? resource) =>
-    resource?.trim().toLowerCase().replaceAll('_', ' ') == 'dark elixir'
+    resource?.trim().toLowerCase().replaceAll('_', ' ') ==
+        _darkElixirResourceName
     ? 10000
     : _defaultFarmPerfectLoot;
 

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -435,8 +435,15 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
   }
 
   void _startFarmTrackerLoad(String? tag) {
-    if (tag == null || tag.isEmpty || tag == _farmTrackerLoadTag) return;
+    if (tag == null || tag.isEmpty) {
+      _farmTrackerLoadTag = tag;
+      _farmTrackerSnapshot = null;
+      _farmTrackerLoading = false;
+      return;
+    }
+    if (tag == _farmTrackerLoadTag) return;
     _farmTrackerLoadTag = tag;
+    _farmTrackerSnapshot = null;
     final cached = UpgradeTrackerRepository.shared.peekCached(tag);
     if (cached != null) {
       _farmTrackerSnapshot = cached;
@@ -447,7 +454,10 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     // the authenticated tracker configuration. Avoid starting an auxiliary
     // SharedPreferences/network load in that mode; a warmed shared snapshot
     // is still used above when one exists.
-    if (widget.accountPresets != null) return;
+    if (widget.accountPresets != null) {
+      _farmTrackerLoading = false;
+      return;
+    }
     _farmTrackerLoading = true;
     unawaited(_loadFarmTrackerSnapshot(tag));
   }
@@ -564,13 +574,14 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       builder: (context) => _CalculatorAccountPickerSheet(
         accountPresets: _accountPresets,
         selectedTag: selectedTag,
+        allowCustom: !forFarmGoal,
       ),
     );
     if (!mounted || result == null) return;
     if (forFarmGoal) {
       _selectFarmAccount(result);
     } else {
-      _applyAccountPresetTag(result);
+      _applyAccountPresetTag(result == _accountlessPresetTag ? null : result);
     }
   }
 
@@ -1683,15 +1694,18 @@ class _AccountSelectorPanel extends StatelessWidget {
 }
 
 const _noFarmBuilding = '__none__';
+const _accountlessPresetTag = '__accountless__';
 
 class _CalculatorAccountPickerSheet extends StatefulWidget {
   const _CalculatorAccountPickerSheet({
     required this.accountPresets,
     required this.selectedTag,
+    required this.allowCustom,
   });
 
   final List<DamageAccountPreset> accountPresets;
   final String? selectedTag;
+  final bool allowCustom;
 
   @override
   State<_CalculatorAccountPickerSheet> createState() =>
@@ -1768,7 +1782,7 @@ class _CalculatorAccountPickerSheetState
             ),
           ),
           Expanded(
-            child: accounts.isEmpty
+            child: accounts.isEmpty && !widget.allowCustom
                 ? AppEmptyState(
                     icon: Icons.person_search_rounded,
                     title: loc.damageNoAccountsAvailable,
@@ -1776,9 +1790,33 @@ class _CalculatorAccountPickerSheetState
                   )
                 : ListView.builder(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
-                    itemCount: accounts.length,
+                    itemCount: accounts.length + (widget.allowCustom ? 1 : 0),
                     itemBuilder: (context, index) {
-                      final account = accounts[index];
+                      if (widget.allowCustom && index == 0) {
+                        final selected = widget.selectedTag == null;
+                        return ListTile(
+                          selected: selected,
+                          selectedTileColor: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(AppRadius.chip),
+                          ),
+                          leading: const SizedBox.square(
+                            dimension: 44,
+                            child: Icon(Icons.tune_rounded),
+                          ),
+                          title: Text(loc.damageQuickSetupCustom),
+                          subtitle: Text(loc.damageAccountSelectorHint),
+                          trailing: selected
+                              ? const Icon(Icons.check_rounded)
+                              : null,
+                          onTap: () =>
+                              Navigator.pop(context, _accountlessPresetTag),
+                        );
+                      }
+                      final account =
+                          accounts[widget.allowCustom ? index - 1 : index];
                       final selected = account.tag == widget.selectedTag;
                       return ListTile(
                         selected: selected,

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -490,9 +490,9 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     }
   }
 
-  UpgradeTrackerItem? _farmTrackerSuggestion(
+  _FarmTrackerTarget? _farmTrackerSuggestion(
     List<BuildingDefinition> buildings,
-  ) => _farmTrackerBuildingItems(buildings).firstOrNull;
+  ) => _farmTrackerTargets(buildings).firstOrNull;
 
   List<BuildingDefinition> _farmTrackerBuildings(
     List<BuildingDefinition> buildings,
@@ -501,13 +501,13 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       for (final building in buildings)
         building.name.trim().toLowerCase(): building,
     };
-    return _farmTrackerBuildingItems(buildings)
-        .map((item) => byName[item.name.trim().toLowerCase()])
+    return _farmTrackerTargets(buildings)
+        .map((target) => byName[target.item.name.trim().toLowerCase()])
         .whereType<BuildingDefinition>()
         .toList(growable: false);
   }
 
-  List<UpgradeTrackerItem> _farmTrackerBuildingItems(
+  List<_FarmTrackerTarget> _farmTrackerTargets(
     List<BuildingDefinition> buildings,
   ) {
     final snapshot = _farmTrackerSnapshot;
@@ -517,15 +517,15 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     final names = buildings
         .map((building) => building.name.trim().toLowerCase())
         .toSet();
-    final ordered = <UpgradeTrackerItem>[];
+    final ordered = <_FarmTrackerTarget>[];
     final seen = <String>{};
 
-    void addItem(UpgradeTrackerItem item) {
+    void addItem(UpgradeTrackerItem item, {UpgradeStep? step}) {
       final name = item.name.trim().toLowerCase();
       if (item.steps.isEmpty || !names.contains(name) || !seen.add(name)) {
         return;
       }
-      ordered.add(item);
+      ordered.add(_FarmTrackerTarget(item: item, plannedStep: step));
     }
 
     final planned =
@@ -540,7 +540,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
             .toList()
           ..sort((a, b) => a.startsAt.compareTo(b.startsAt));
     for (final upgrade in planned) {
-      addItem(upgrade.item);
+      addItem(upgrade.item, step: upgrade.step);
     }
     for (final item in snapshot.itemsFor(
       village: UpgradeVillage.home,
@@ -552,7 +552,8 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     return ordered;
   }
 
-  void _useFarmTrackerSuggestion(UpgradeTrackerItem item) {
+  void _useFarmTrackerSuggestion(_FarmTrackerTarget target) {
+    final item = target.item;
     final building = _catalog.buildings
         .where(
           (candidate) =>
@@ -563,7 +564,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     if (building == null) return;
     final farmTownHall = _farmSelectedPreset?.townHall ?? _catalog.maxTownHall;
     final levels = _farmTargetLevels(building, farmTownHall);
-    final targetLevel = item.steps.first.targetLevel;
+    final targetLevel = target.targetLevel ?? item.steps.first.targetLevel;
     final matchingLevel = levels
         .where((level) => level.level == targetLevel)
         .firstOrNull;
@@ -934,6 +935,15 @@ class _QuickSetupPanel extends StatelessWidget {
   }
 }
 
+class _FarmTrackerTarget {
+  const _FarmTrackerTarget({required this.item, this.plannedStep});
+
+  final UpgradeTrackerItem item;
+  final UpgradeStep? plannedStep;
+
+  int? get targetLevel => plannedStep?.targetLevel;
+}
+
 class _FarmGoalView extends StatelessWidget {
   const _FarmGoalView({
     required this.accountPresets,
@@ -963,9 +973,9 @@ class _FarmGoalView extends StatelessWidget {
   final BuildingDefinition? selectedBuilding;
   final List<BuildingLevelDefinition> levels;
   final BuildingLevelDefinition? selectedLevel;
-  final UpgradeTrackerItem? trackerSuggestion;
+  final _FarmTrackerTarget? trackerSuggestion;
   final bool trackerLoading;
-  final ValueChanged<UpgradeTrackerItem> onUseTrackerSuggestion;
+  final ValueChanged<_FarmTrackerTarget> onUseTrackerSuggestion;
   final ValueChanged<String> onBuildingChanged;
   final ValueChanged<int> onLevelChanged;
   final TextEditingController averageLootController;
@@ -1102,7 +1112,7 @@ class _FarmGoalView extends StatelessWidget {
     AppLocalizations loc, {
     required String resourceLabel,
     required int? upgradeCost,
-    required UpgradeTrackerItem? trackerSuggestion,
+    required _FarmTrackerTarget? trackerSuggestion,
     required bool trackerLoading,
   }) {
     return SidePagePanel(
@@ -1135,8 +1145,14 @@ class _FarmGoalView extends StatelessWidget {
                 children: [
                   MobileWebImage(
                     imageUrl: ImageAssets.getHomeVillageBuildingImage(
-                      trackerSuggestion.name,
-                      trackerSuggestion.steps.firstOrNull?.targetLevel ?? 1,
+                      trackerSuggestion.item.name,
+                      trackerSuggestion.targetLevel ??
+                          trackerSuggestion
+                              .item
+                              .steps
+                              .firstOrNull
+                              ?.targetLevel ??
+                          1,
                     ),
                     width: 28,
                     height: 28,
@@ -1150,7 +1166,9 @@ class _FarmGoalView extends StatelessWidget {
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      loc.farmGoalTrackerSuggestion(trackerSuggestion.name),
+                      loc.farmGoalTrackerSuggestion(
+                        trackerSuggestion.item.name,
+                      ),
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
@@ -2780,17 +2798,20 @@ String? _upgradeResourceLabel(AppLocalizations loc, String? resource) {
 }
 
 UpgradeCost? _trackerCostForSelection(
-  UpgradeTrackerItem? item,
+  _FarmTrackerTarget? target,
   BuildingDefinition? building,
   BuildingLevelDefinition? level,
 ) {
+  final item = target?.item;
   if (item == null || building == null || level == null) return null;
   if (item.name.trim().toLowerCase() != building.name.trim().toLowerCase()) {
     return null;
   }
-  final step = item.steps
-      .where((candidate) => candidate.targetLevel == level.level)
-      .firstOrNull;
+  final step = target?.plannedStep?.targetLevel == level.level
+      ? target?.plannedStep
+      : item.steps
+            .where((candidate) => candidate.targetLevel == level.level)
+            .firstOrNull;
   if (step == null || step.costs.isEmpty) return null;
   final selectedResource = level.upgradeResource?.trim().toLowerCase();
   return step.costs

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -450,7 +450,10 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       _farmTrackerLoading = false;
       return;
     }
-    if (tag == _farmTrackerLoadTag) return;
+    if (tag == _farmTrackerLoadTag &&
+        (_farmTrackerLoading || _farmTrackerSnapshotTag == tag)) {
+      return;
+    }
     _farmTrackerLoadTag = tag;
     _farmTrackerSnapshot = null;
     _farmTrackerSnapshotTag = null;
@@ -466,6 +469,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     // SharedPreferences/network load in that mode; a warmed shared snapshot
     // is still used above when one exists.
     if (widget.accountPresets != null) {
+      _farmTrackerLoadTag = null;
       _farmTrackerLoading = false;
       return;
     }
@@ -479,7 +483,8 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       if (!mounted || tag != _farmAccountTag) return;
       setState(() {
         _farmTrackerSnapshot = snapshot;
-        _farmTrackerSnapshotTag = tag;
+        _farmTrackerSnapshotTag = snapshot == null ? null : tag;
+        _farmTrackerLoadTag = snapshot == null ? null : tag;
         _farmTrackerLoading = false;
       });
     } catch (_) {
@@ -487,6 +492,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       setState(() {
         _farmTrackerSnapshot = null;
         _farmTrackerSnapshotTag = null;
+        _farmTrackerLoadTag = null;
         _farmTrackerLoading = false;
       });
     }

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -423,6 +423,8 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
   }
 
   void _selectFarmAccount(String? tag) {
+    if (tag == _farmAccountTag) return;
+
     setState(() {
       _farmAccountTag = tag;
       _farmBuildingId = null;

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -530,13 +530,14 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       ordered.add(_FarmTrackerTarget(item: item, plannedStep: step));
     }
 
+    final now = DateTime.now();
     final planned =
         snapshot
             .buildPlan(
               queue: UpgradeQueue.builders,
               strategy: UpgradePlanStrategy.balanced,
               village: UpgradeVillage.home,
-              startsAt: DateTime.now(),
+              startsAt: now,
             )
             .expand((lane) => lane.upgrades)
             .toList()
@@ -549,6 +550,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       queue: UpgradeQueue.builders,
       remainingOnly: true,
     )) {
+      if (snapshot.remainingActiveSeconds(item, now: now) > 0) continue;
       addItem(item);
     }
     return ordered;
@@ -590,14 +592,15 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       builder: (context) => _CalculatorAccountPickerSheet(
         accountPresets: _accountPresets,
         selectedTag: selectedTag,
-        allowCustom: !forFarmGoal,
+        allowCustom: true,
       ),
     );
     if (!mounted || result == null) return;
+    final accountTag = result == _accountlessPresetTag ? null : result;
     if (forFarmGoal) {
-      _selectFarmAccount(result);
+      _selectFarmAccount(accountTag);
     } else {
-      _applyAccountPresetTag(result == _accountlessPresetTag ? null : result);
+      _applyAccountPresetTag(accountTag);
     }
   }
 

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/empty_state.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:clashkingapp/common/widgets/compact_filter_chip.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/services/game_data_service.dart';
 import 'package:clashkingapp/features/coc_accounts/data/coc_account_service.dart';
@@ -11,6 +15,8 @@ import 'package:clashkingapp/features/damage_calculator/domain/damage_calculator
 import 'package:clashkingapp/features/damage_calculator/domain/damage_calculator_session.dart';
 import 'package:clashkingapp/features/player/data/player_service.dart';
 import 'package:clashkingapp/features/player/models/player.dart';
+import 'package:clashkingapp/features/upgrade_tracker/data/upgrade_tracker_repository.dart';
+import 'package:clashkingapp/features/upgrade_tracker/models/upgrade_tracker_models.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -26,6 +32,7 @@ const _fireballQuakeSetupId = 'fireball-quake';
 const _giantArrowSetupId = 'giant-arrow';
 const _flameFlingerSetupId = 'flame-flinger';
 const _townHallBuildingName = 'Town Hall';
+const _defaultFarmPerfectLoot = 1000000;
 
 class CalculatorsPage extends StatefulWidget {
   const CalculatorsPage({super.key, this.catalog, this.accountPresets});
@@ -68,6 +75,9 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
   String? _farmAccountTag;
   String? _farmBuildingId;
   int? _farmBuildingLevel;
+  UpgradeTrackerSnapshot? _farmTrackerSnapshot;
+  bool _farmTrackerLoading = false;
+  String? _farmTrackerLoadTag;
   late final TextEditingController _farmAverageLootController;
 
   @override
@@ -93,22 +103,26 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (_readProviders || widget.accountPresets != null) return;
-    _readProviders = true;
-    try {
-      final accounts = context.read<CocAccountService>();
-      _accountPresets = _verifiedAccountPresets(
-        accounts,
-        context.read<PlayerService>(),
-      );
-      final selectedTag = accounts.selectedTag;
-      _farmAccountTag =
-          _accountPresets.any((preset) => preset.tag == selectedTag)
-          ? selectedTag
-          : _accountPresets.firstOrNull?.tag;
-    } on ProviderNotFoundException {
-      _accountPresets = const [];
+    if (!_readProviders) {
+      _readProviders = true;
+      if (widget.accountPresets == null) {
+        try {
+          final accounts = context.read<CocAccountService>();
+          _accountPresets = _verifiedAccountPresets(
+            accounts,
+            context.read<PlayerService>(),
+          );
+          final selectedTag = accounts.selectedTag;
+          _farmAccountTag =
+              _accountPresets.any((preset) => preset.tag == selectedTag)
+              ? selectedTag
+              : _accountPresets.firstOrNull?.tag;
+        } on ProviderNotFoundException {
+          _accountPresets = const [];
+        }
+      }
     }
+    _startFarmTrackerLoad(_farmAccountTag);
   }
 
   @override
@@ -127,6 +141,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     final farmPreset = _farmSelectedPreset;
     final farmTownHall = farmPreset?.townHall ?? _catalog.maxTownHall;
     final farmBuildings = _catalog.buildingsForTownHall(farmTownHall);
+    final trackerBuildings = _farmTrackerBuildings(farmBuildings);
     final farmBuilding = _farmSelectedBuilding(farmBuildings);
     final farmLevels = _farmTargetLevels(farmBuilding, farmTownHall);
 
@@ -139,14 +154,17 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
         children: [
           _FarmGoalView(
             accountPresets: _accountPresets,
-            selectedAccountTag: _farmAccountTag,
             selectedAccount: farmPreset,
-            onAccountChanged: _selectFarmAccount,
+            onOpenAccountPicker: () => _showAccountPicker(forFarmGoal: true),
             buildings: farmBuildings,
+            trackerBuildings: trackerBuildings,
             selectedBuildingId: _farmBuildingId,
             selectedBuilding: farmBuilding,
             levels: farmLevels,
             selectedLevel: _farmSelectedLevel(farmLevels),
+            trackerSuggestion: _farmTrackerSuggestion(farmBuildings),
+            trackerLoading: _farmTrackerLoading,
+            onUseTrackerSuggestion: _useFarmTrackerSuggestion,
             onBuildingChanged: _selectFarmBuilding,
             onLevelChanged: _selectFarmBuildingLevel,
             averageLootController: _farmAverageLootController,
@@ -270,8 +288,8 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       const SizedBox(height: 14),
       _AccountSelectorPanel(
         accountPresets: _accountPresets,
-        selectedAccountTag: _session.selectedAccountTag,
-        onAccountChanged: _applyAccountPresetTag,
+        selectedAccount: _accountPreset(_session.selectedAccountTag),
+        onOpenAccountPicker: () => _showAccountPicker(forFarmGoal: false),
       ),
       const SizedBox(height: 14),
       ..._sourceSectionWidgets(loc, selectedSetup, sourceVisibility),
@@ -408,6 +426,152 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       _farmBuildingLevel = null;
       _farmAverageLootController.clear();
     });
+    _startFarmTrackerLoad(tag);
+  }
+
+  DamageAccountPreset? _accountPreset(String? tag) {
+    if (tag == null) return null;
+    return _accountPresets.where((preset) => preset.tag == tag).firstOrNull;
+  }
+
+  void _startFarmTrackerLoad(String? tag) {
+    if (tag == null || tag.isEmpty || tag == _farmTrackerLoadTag) return;
+    _farmTrackerLoadTag = tag;
+    final cached = UpgradeTrackerRepository.shared.peekCached(tag);
+    if (cached != null) {
+      _farmTrackerSnapshot = cached;
+      _farmTrackerLoading = false;
+      return;
+    }
+    // Injected presets are used by isolated screens/tests and do not carry
+    // the authenticated tracker configuration. Avoid starting an auxiliary
+    // SharedPreferences/network load in that mode; a warmed shared snapshot
+    // is still used above when one exists.
+    if (widget.accountPresets != null) return;
+    _farmTrackerLoading = true;
+    unawaited(_loadFarmTrackerSnapshot(tag));
+  }
+
+  Future<void> _loadFarmTrackerSnapshot(String tag) async {
+    try {
+      final snapshot = await UpgradeTrackerRepository.shared.load(tag);
+      if (!mounted || tag != _farmAccountTag) return;
+      setState(() {
+        _farmTrackerSnapshot = snapshot;
+        _farmTrackerLoading = false;
+      });
+    } catch (_) {
+      if (!mounted || tag != _farmAccountTag) return;
+      setState(() {
+        _farmTrackerSnapshot = null;
+        _farmTrackerLoading = false;
+      });
+    }
+  }
+
+  UpgradeTrackerItem? _farmTrackerSuggestion(
+    List<BuildingDefinition> buildings,
+  ) => _farmTrackerBuildingItems(buildings).firstOrNull;
+
+  List<BuildingDefinition> _farmTrackerBuildings(
+    List<BuildingDefinition> buildings,
+  ) {
+    final byName = {
+      for (final building in buildings)
+        building.name.trim().toLowerCase(): building,
+    };
+    return _farmTrackerBuildingItems(buildings)
+        .map((item) => byName[item.name.trim().toLowerCase()])
+        .whereType<BuildingDefinition>()
+        .toList(growable: false);
+  }
+
+  List<UpgradeTrackerItem> _farmTrackerBuildingItems(
+    List<BuildingDefinition> buildings,
+  ) {
+    final snapshot = _farmTrackerSnapshot;
+    if (snapshot == null) return const [];
+    final names = buildings
+        .map((building) => building.name.trim().toLowerCase())
+        .toSet();
+    final ordered = <UpgradeTrackerItem>[];
+    final seen = <String>{};
+
+    void addItem(UpgradeTrackerItem item) {
+      final name = item.name.trim().toLowerCase();
+      if (item.steps.isEmpty || !names.contains(name) || !seen.add(name)) {
+        return;
+      }
+      ordered.add(item);
+    }
+
+    final planned =
+        snapshot
+            .buildPlan(
+              queue: UpgradeQueue.builders,
+              strategy: UpgradePlanStrategy.balanced,
+              village: UpgradeVillage.home,
+              startsAt: DateTime.now(),
+            )
+            .expand((lane) => lane.upgrades)
+            .toList()
+          ..sort((a, b) => a.startsAt.compareTo(b.startsAt));
+    for (final upgrade in planned) {
+      addItem(upgrade.item);
+    }
+    for (final item in snapshot.itemsFor(
+      village: UpgradeVillage.home,
+      queue: UpgradeQueue.builders,
+      remainingOnly: true,
+    )) {
+      addItem(item);
+    }
+    return ordered;
+  }
+
+  void _useFarmTrackerSuggestion(UpgradeTrackerItem item) {
+    final building = _catalog.buildings
+        .where(
+          (candidate) =>
+              candidate.name.trim().toLowerCase() ==
+              item.name.trim().toLowerCase(),
+        )
+        .firstOrNull;
+    if (building == null) return;
+    final farmTownHall = _farmSelectedPreset?.townHall ?? _catalog.maxTownHall;
+    final levels = _farmTargetLevels(building, farmTownHall);
+    final targetLevel = item.steps.first.targetLevel;
+    final matchingLevel = levels
+        .where((level) => level.level == targetLevel)
+        .firstOrNull;
+    if (matchingLevel == null) return;
+    setState(() {
+      _farmBuildingId = building.id;
+      _farmBuildingLevel = matchingLevel.level;
+      _setFarmLootSuggestion();
+    });
+  }
+
+  Future<void> _showAccountPicker({required bool forFarmGoal}) async {
+    if (_accountPresets.isEmpty) return;
+    final selectedTag = forFarmGoal
+        ? _farmAccountTag
+        : _session.selectedAccountTag;
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => _CalculatorAccountPickerSheet(
+        accountPresets: _accountPresets,
+        selectedTag: selectedTag,
+      ),
+    );
+    if (!mounted || result == null) return;
+    if (forFarmGoal) {
+      _selectFarmAccount(result);
+    } else {
+      _applyAccountPresetTag(result);
+    }
   }
 
   void _selectFarmBuilding(String buildingId) {
@@ -439,12 +603,9 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     );
     final levels = _farmTargetLevels(building, farmTownHall);
     final level = _farmSelectedLevel(levels);
-    final suggestion = _farmLeagueLoot(
-      league: farmPreset?.league,
-      townHall: farmTownHall,
-      resource: level?.upgradeResource,
-    );
-    _farmAverageLootController.text = suggestion?.toString() ?? '';
+    _farmAverageLootController.text = level == null
+        ? ''
+        : _farmDefaultPerfectLoot(level.upgradeResource).toString();
   }
 
   List<BuildingLevelDefinition> _farmTargetLevels(
@@ -458,6 +619,14 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
         ? townHall + 1
         : townHall;
     return building.levelsForTownHall(targetTownHall);
+  }
+
+  String? _quickSetupImageUrl(Map<DamageSourceKind, int> counts) {
+    for (final kind in counts.keys) {
+      final imageUrl = _session.catalog.source(kind)?.imageUrl.trim();
+      if (imageUrl?.isNotEmpty == true) return imageUrl;
+    }
+    return null;
   }
 
   List<_QuickSetup> _quickSetups(AppLocalizations loc) => [
@@ -474,6 +643,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
             id: id,
             label: _quickSetupLabel(loc, id),
             counts: counts,
+            imageUrl: _quickSetupImageUrl(counts),
           );
         })
         .where(
@@ -574,7 +744,7 @@ class _CalculatorScaffold extends StatelessWidget {
     return Scaffold(
       body: InfoProfileTabScaffold(
         key: const ValueKey('calculator-tabs'),
-        header: const _CalculatorHeader(),
+        header: _CalculatorHeader(selectedMode: selectedMode),
         selectedIndex: selectedMode.index,
         onTabSelected: (index) => onModeChanged(
           _CalculatorMode.values[index.clamp(
@@ -585,11 +755,14 @@ class _CalculatorScaffold extends StatelessWidget {
         tabs: [
           InfoProfileTabData(
             label: loc.calculatorsModeDamage,
-            icon: Icons.bolt_rounded,
+            imageUrl: ImageAssets.getSpellImage('Lightning Spell'),
           ),
           InfoProfileTabData(
             label: loc.calculatorsModeFarmGoal,
-            icon: Icons.savings_outlined,
+            imageUrl: ImageAssets.getHomeVillageBuildingImage(
+              _townHallBuildingName,
+              1,
+            ),
           ),
         ],
         body: child,
@@ -599,13 +772,21 @@ class _CalculatorScaffold extends StatelessWidget {
 }
 
 class _CalculatorHeader extends StatelessWidget {
-  const _CalculatorHeader();
+  const _CalculatorHeader({required this.selectedMode});
+
+  final _CalculatorMode selectedMode;
 
   @override
   Widget build(BuildContext context) {
     final media = MediaQuery.of(context);
     final isDesktopWeb = isSidePageDesktop(context);
     final imageHeight = media.padding.top + (isDesktopWeb ? 292 : 246);
+    final imageUrl = selectedMode == _CalculatorMode.damage
+        ? ImageAssets.getSpellImage('Lightning Spell')
+        : ImageAssets.getHomeVillageBuildingImage(_townHallBuildingName, 1);
+    final fallbackIcon = selectedMode == _CalculatorMode.damage
+        ? Icons.bolt_rounded
+        : Icons.home_work_rounded;
 
     return Stack(
       children: [
@@ -650,10 +831,13 @@ class _CalculatorHeader extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        const Icon(
-                          Icons.calculate_rounded,
-                          size: 58,
-                          color: Colors.white,
+                        MobileWebImage(
+                          imageUrl: imageUrl,
+                          width: 58,
+                          height: 58,
+                          fit: BoxFit.contain,
+                          errorWidget: (_, _, _) =>
+                              Icon(fallbackIcon, size: 58, color: Colors.white),
                         ),
                         const SizedBox(height: 8),
                         Text(
@@ -682,11 +866,13 @@ class _QuickSetup {
     required this.id,
     required this.label,
     required this.counts,
+    this.imageUrl,
   });
 
   final String id;
   final String label;
   final Map<DamageSourceKind, int> counts;
+  final String? imageUrl;
 }
 
 class _QuickSetupPanel extends StatelessWidget {
@@ -706,11 +892,20 @@ class _QuickSetupPanel extends StatelessWidget {
       (setup) => setup.id == selectedId,
       orElse: () => setups.first,
     );
-    return SidePageHorizontalSelector<_QuickSetup>(
-      values: setups,
-      selected: selectedSetup,
-      labelBuilder: (setup) => setup.label,
-      onSelected: onSelected,
+    return Wrap(
+      key: const ValueKey('calculator-quick-setups'),
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final setup in setups)
+          CompactFilterChip(
+            label: setup.label,
+            icon: _quickSetupIcon(setup.id),
+            imageUrl: setup.imageUrl,
+            selected: setup.id == selectedSetup.id,
+            onTap: () => onSelected(setup),
+          ),
+      ],
     );
   }
 }
@@ -718,14 +913,17 @@ class _QuickSetupPanel extends StatelessWidget {
 class _FarmGoalView extends StatelessWidget {
   const _FarmGoalView({
     required this.accountPresets,
-    required this.selectedAccountTag,
     required this.selectedAccount,
-    required this.onAccountChanged,
+    required this.onOpenAccountPicker,
     required this.buildings,
+    required this.trackerBuildings,
     required this.selectedBuildingId,
     required this.selectedBuilding,
     required this.levels,
     required this.selectedLevel,
+    required this.trackerSuggestion,
+    required this.trackerLoading,
+    required this.onUseTrackerSuggestion,
     required this.onBuildingChanged,
     required this.onLevelChanged,
     required this.averageLootController,
@@ -733,14 +931,17 @@ class _FarmGoalView extends StatelessWidget {
   });
 
   final List<DamageAccountPreset> accountPresets;
-  final String? selectedAccountTag;
   final DamageAccountPreset? selectedAccount;
-  final ValueChanged<String?> onAccountChanged;
+  final VoidCallback onOpenAccountPicker;
   final List<BuildingDefinition> buildings;
+  final List<BuildingDefinition> trackerBuildings;
   final String? selectedBuildingId;
   final BuildingDefinition? selectedBuilding;
   final List<BuildingLevelDefinition> levels;
   final BuildingLevelDefinition? selectedLevel;
+  final UpgradeTrackerItem? trackerSuggestion;
+  final bool trackerLoading;
+  final ValueChanged<UpgradeTrackerItem> onUseTrackerSuggestion;
   final ValueChanged<String> onBuildingChanged;
   final ValueChanged<int> onLevelChanged;
   final TextEditingController averageLootController;
@@ -750,13 +951,27 @@ class _FarmGoalView extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final averageLoot = _parseFarmAmount(averageLootController.text);
+    final trackerCost = _trackerCostForSelection(
+      trackerSuggestion,
+      selectedBuilding,
+      selectedLevel,
+    );
     final resourceLabel =
-        _upgradeResourceLabel(loc, selectedLevel?.upgradeResource) ?? '';
-    final upgradeCost = selectedLevel?.upgradeCost;
-    final raids = _farmRaids(
+        _upgradeResourceLabel(
+          loc,
+          trackerCost?.resource ?? selectedLevel?.upgradeResource,
+        ) ??
+        '';
+    final upgradeCost =
+        trackerCost?.amount.round() ?? selectedLevel?.upgradeCost;
+    final leagueEstimate = _farmLeagueLootEstimate(
+      league: selectedAccount?.league,
+      townHall: selectedAccount?.townHall ?? 0,
+      resource: selectedLevel?.upgradeResource,
+    );
+    final scenarios = _farmAttackScenarios(
       upgradeCost: upgradeCost,
-      resourceLabel: resourceLabel,
-      averageLoot: averageLoot,
+      perfectLoot: averageLoot,
     );
 
     return Column(
@@ -765,8 +980,8 @@ class _FarmGoalView extends StatelessWidget {
         SidePageSectionHeader(title: loc.farmGoalAccountTitle),
         _AccountSelectorPanel(
           accountPresets: accountPresets,
-          selectedAccountTag: selectedAccountTag,
-          onAccountChanged: onAccountChanged,
+          selectedAccount: selectedAccount,
+          onOpenAccountPicker: onOpenAccountPicker,
           hint: loc.farmGoalAccountHint,
         ),
         const SizedBox(height: 22),
@@ -776,12 +991,20 @@ class _FarmGoalView extends StatelessWidget {
           loc,
           resourceLabel: resourceLabel,
           upgradeCost: upgradeCost,
+          trackerSuggestion: trackerSuggestion,
+          trackerLoading: trackerLoading,
         ),
         const SizedBox(height: 22),
         SidePageSectionHeader(title: loc.farmGoalLootTitle),
-        _buildLootPanel(context, loc, resourceLabel: resourceLabel),
+        _buildLootPanel(
+          context,
+          loc,
+          resource: selectedLevel?.upgradeResource,
+          resourceLabel: resourceLabel,
+          leagueEstimate: leagueEstimate,
+        ),
         const SizedBox(height: 16),
-        if (raids == null)
+        if (scenarios.isEmpty)
           _InlineEmpty(
             message: _farmMissingMessage(
               loc,
@@ -791,30 +1014,52 @@ class _FarmGoalView extends StatelessWidget {
           )
         else
           _FarmGoalResultPanel(
-            raids: raids,
+            scenarios: scenarios,
             upgradeCost: upgradeCost!,
             resourceLabel: resourceLabel,
-            averageLoot: averageLoot,
+            perfectLoot: averageLoot,
           ),
       ],
     );
   }
 
-  int? _farmRaids({
+  List<_FarmAttackScenario> _farmAttackScenarios({
     required int? upgradeCost,
-    required String resourceLabel,
-    required int averageLoot,
+    required int perfectLoot,
   }) {
-    if (upgradeCost == null || upgradeCost <= 0) return null;
-    if (resourceLabel.isEmpty || averageLoot <= 0) return null;
-    return (upgradeCost / averageLoot).ceil();
+    if (upgradeCost == null || upgradeCost <= 0 || perfectLoot <= 0) {
+      return const [];
+    }
+    return [100, 80, 60]
+        .map((percent) {
+          final lootPerAttack = (perfectLoot * percent / 100).round();
+          return _FarmAttackScenario(
+            destructionPercent: percent,
+            lootPerAttack: lootPerAttack,
+            attacks: (upgradeCost / lootPerAttack).ceil(),
+          );
+        })
+        .toList(growable: false);
   }
 
-  Map<String, String> _buildingOptions(AppLocalizations loc) => {
-    _noFarmBuilding: loc.farmGoalChooseBuilding,
-    for (final building in buildings)
-      building.id: _buildingDisplayName(loc, building.name),
-  };
+  Map<String, String> _buildingOptions(AppLocalizations loc) {
+    final trackerOptions = trackerBuildings.isEmpty
+        ? buildings
+        : trackerBuildings;
+    final options = <String, String>{
+      _noFarmBuilding: loc.farmGoalChooseBuilding,
+      for (final building in trackerOptions)
+        building.id: _buildingDisplayName(loc, building.name),
+    };
+    if (selectedBuilding != null &&
+        !options.containsKey(selectedBuilding!.id)) {
+      options[selectedBuilding!.id] = _buildingDisplayName(
+        loc,
+        selectedBuilding!.name,
+      );
+    }
+    return options;
+  }
 
   String _farmMissingMessage(
     AppLocalizations loc, {
@@ -833,6 +1078,8 @@ class _FarmGoalView extends StatelessWidget {
     AppLocalizations loc, {
     required String resourceLabel,
     required int? upgradeCost,
+    required UpgradeTrackerItem? trackerSuggestion,
+    required bool trackerLoading,
   }) {
     return SidePagePanel(
       key: const ValueKey('farm-goal-target'),
@@ -847,6 +1094,51 @@ class _FarmGoalView extends StatelessWidget {
               context,
             ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800),
           ),
+          if (trackerLoading)
+            const Padding(
+              padding: EdgeInsets.only(top: 12),
+              child: SkeletonLoader(
+                height: 44,
+                width: double.infinity,
+                borderRadius: BorderRadius.all(Radius.circular(AppRadius.chip)),
+              ),
+            )
+          else if (trackerSuggestion != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 10, bottom: 2),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MobileWebImage(
+                    imageUrl: ImageAssets.getHomeVillageBuildingImage(
+                      trackerSuggestion.name,
+                      trackerSuggestion.steps.firstOrNull?.targetLevel ?? 1,
+                    ),
+                    width: 28,
+                    height: 28,
+                    fit: BoxFit.contain,
+                    errorWidget: (_, _, _) => Icon(
+                      Icons.construction_rounded,
+                      size: 24,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      loc.farmGoalTrackerSuggestion(trackerSuggestion.name),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => onUseTrackerSuggestion(trackerSuggestion),
+                    child: Text(loc.farmGoalUseTrackerTarget),
+                  ),
+                ],
+              ),
+            ),
           const SizedBox(height: 8),
           SidePageInlineSelector<String>(
             key: const ValueKey('farm-goal-building'),
@@ -882,12 +1174,20 @@ class _FarmGoalView extends StatelessWidget {
   Widget _buildLootPanel(
     BuildContext context,
     AppLocalizations loc, {
+    required String? resource,
     required String resourceLabel,
+    required _FarmLeagueLootEstimate? leagueEstimate,
   }) {
     final league = selectedAccount?.league;
-    final hint = league == null || resourceLabel.isEmpty
+    final resourceImageUrl = _farmResourceImage(resource);
+    final hint =
+        league == null || leagueEstimate?.loot == null || resourceLabel.isEmpty
         ? loc.farmGoalNoLeagueLoot
-        : loc.farmGoalLeagueEstimate(league);
+        : loc.farmGoalLeagueEstimate(
+            league,
+            formatSidePageInt(leagueEstimate!.loot!),
+            resourceLabel,
+          );
 
     return SidePagePanel(
       key: const ValueKey('farm-goal-loot'),
@@ -905,9 +1205,26 @@ class _FarmGoalView extends StatelessWidget {
             decoration: InputDecoration(
               labelText: loc.farmGoalAverageLootLabel,
               suffixText: resourceLabel,
-              prefixIcon: const Icon(Icons.savings_outlined),
+              prefixIcon: resourceImageUrl == null
+                  ? const Icon(Icons.savings_outlined)
+                  : Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: MobileWebImage(
+                        imageUrl: resourceImageUrl,
+                        width: 24,
+                        height: 24,
+                        fit: BoxFit.contain,
+                      ),
+                    ),
             ),
             onChanged: (_) => onLootChanged(),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            loc.farmGoalPerfectLootHint,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 8),
           Text(
@@ -916,6 +1233,19 @@ class _FarmGoalView extends StatelessWidget {
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
           ),
+          if (leagueEstimate?.starBonus != null &&
+              resourceLabel.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              loc.farmGoalStarBonusEstimate(
+                formatSidePageInt(leagueEstimate!.starBonus!),
+                resourceLabel,
+              ),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -1023,18 +1353,30 @@ class _FarmGoalTargetSummary extends StatelessWidget {
   }
 }
 
-class _FarmGoalResultPanel extends StatelessWidget {
-  const _FarmGoalResultPanel({
-    required this.raids,
-    required this.upgradeCost,
-    required this.resourceLabel,
-    required this.averageLoot,
+class _FarmAttackScenario {
+  const _FarmAttackScenario({
+    required this.destructionPercent,
+    required this.lootPerAttack,
+    required this.attacks,
   });
 
-  final int raids;
+  final int destructionPercent;
+  final int lootPerAttack;
+  final int attacks;
+}
+
+class _FarmGoalResultPanel extends StatelessWidget {
+  const _FarmGoalResultPanel({
+    required this.scenarios,
+    required this.upgradeCost,
+    required this.resourceLabel,
+    required this.perfectLoot,
+  });
+
+  final List<_FarmAttackScenario> scenarios;
   final int upgradeCost;
   final String resourceLabel;
-  final int averageLoot;
+  final int perfectLoot;
 
   @override
   Widget build(BuildContext context) {
@@ -1043,56 +1385,65 @@ class _FarmGoalResultPanel extends StatelessWidget {
       key: const ValueKey('farm-goal-result'),
       radius: AppRadius.card,
       padding: const EdgeInsets.all(16),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(
-            Icons.track_changes_rounded,
-            size: 28,
-            color: Theme.of(context).colorScheme.secondary,
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  loc.farmGoalResultTitle,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w800),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  loc.farmGoalResultSummary(
-                    formatSidePageInt(upgradeCost),
-                    resourceLabel,
-                    formatSidePageInt(averageLoot),
-                  ),
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 12),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                '$raids',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w900),
+              MobileWebImage(
+                imageUrl: ImageAssets.raidAttacks,
+                width: 32,
+                height: 32,
+                fit: BoxFit.contain,
+                errorWidget: (_, _, _) => Icon(
+                  Icons.track_changes_rounded,
+                  size: 28,
+                  color: Theme.of(context).colorScheme.secondary,
+                ),
               ),
-              Text(
-                loc.farmGoalRaids,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      loc.farmGoalResultTitle,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      loc.farmGoalResultSummary(
+                        formatSidePageInt(upgradeCost),
+                        resourceLabel,
+                        formatSidePageInt(perfectLoot),
+                      ),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
+          ),
+          const SizedBox(height: 8),
+          const Divider(height: 20),
+          for (var index = 0; index < scenarios.length; index++) ...[
+            _FarmAttackScenarioRow(
+              scenario: scenarios[index],
+              resourceLabel: resourceLabel,
+            ),
+            if (index < scenarios.length - 1) const Divider(height: 20),
+          ],
+          const SizedBox(height: 12),
+          Text(
+            loc.farmGoalScenarioHint,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
         ],
       ),
@@ -1100,17 +1451,77 @@ class _FarmGoalResultPanel extends StatelessWidget {
   }
 }
 
+class _FarmAttackScenarioRow extends StatelessWidget {
+  const _FarmAttackScenarioRow({
+    required this.scenario,
+    required this.resourceLabel,
+  });
+
+  final _FarmAttackScenario scenario;
+  final String resourceLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final title = scenario.destructionPercent == 100
+        ? loc.farmGoalScenarioPerfect
+        : loc.farmGoalScenarioAtPercent(scenario.destructionPercent.toString());
+    final textTheme = Theme.of(context).textTheme;
+    final mutedColor = Theme.of(context).colorScheme.onSurfaceVariant;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                '${formatSidePageInt(scenario.lootPerAttack)} $resourceLabel / ${loc.farmGoalAttackShort}',
+                style: textTheme.bodySmall?.copyWith(color: mutedColor),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              '${scenario.attacks}',
+              style: textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            Text(
+              loc.farmGoalAttacks,
+              style: textTheme.bodySmall?.copyWith(color: mutedColor),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
 class _AccountSelectorPanel extends StatelessWidget {
   const _AccountSelectorPanel({
     required this.accountPresets,
-    required this.selectedAccountTag,
-    required this.onAccountChanged,
+    required this.selectedAccount,
+    required this.onOpenAccountPicker,
     this.hint,
   });
 
   final List<DamageAccountPreset> accountPresets;
-  final String? selectedAccountTag;
-  final ValueChanged<String?> onAccountChanged;
+  final DamageAccountPreset? selectedAccount;
+  final VoidCallback onOpenAccountPicker;
   final String? hint;
 
   @override
@@ -1123,9 +1534,15 @@ class _AccountSelectorPanel extends StatelessWidget {
       child: accountPresets.isEmpty
           ? Row(
               children: [
-                Icon(
-                  Icons.person_search_rounded,
-                  color: colorScheme.onSurfaceVariant,
+                MobileWebImage(
+                  imageUrl: ImageAssets.defaultProfile,
+                  width: 34,
+                  height: 34,
+                  fit: BoxFit.contain,
+                  errorWidget: (_, _, _) => Icon(
+                    Icons.person_search_rounded,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -1144,9 +1561,15 @@ class _AccountSelectorPanel extends StatelessWidget {
               children: [
                 Row(
                   children: [
-                    Icon(
-                      Icons.person_outline_rounded,
-                      color: colorScheme.onSurfaceVariant,
+                    MobileWebImage(
+                      imageUrl: ImageAssets.defaultProfile,
+                      width: 24,
+                      height: 24,
+                      fit: BoxFit.contain,
+                      errorWidget: (_, _, _) => Icon(
+                        Icons.person_outline_rounded,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
                     ),
                     const SizedBox(width: 10),
                     Text(
@@ -1158,20 +1581,93 @@ class _AccountSelectorPanel extends StatelessWidget {
                   ],
                 ),
                 const SizedBox(height: 10),
-                SidePageInlineSelector<String>(
-                  selected: selectedAccountTag ?? _noAccountPreset,
-                  options: {
-                    _noAccountPreset: loc.damageChooseAccount,
-                    for (final preset in accountPresets)
-                      preset.tag:
-                          '${preset.name} · ${loc.gameTownHallShortLevel(preset.townHall)}',
-                  },
-                  onSelected: (tag) {
-                    onAccountChanged(tag == _noAccountPreset ? null : tag);
-                  },
-                  minWidth: double.infinity,
-                  maxWidth: double.infinity,
-                  height: 46,
+                Material(
+                  color: Colors.transparent,
+                  borderRadius: BorderRadius.circular(AppRadius.chip),
+                  child: InkWell(
+                    key: const ValueKey('calculator-account-selector'),
+                    borderRadius: BorderRadius.circular(AppRadius.chip),
+                    onTap: onOpenAccountPicker,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      child: Row(
+                        children: [
+                          SizedBox.square(
+                            dimension: 44,
+                            child: selectedAccount == null
+                                ? MobileWebImage(
+                                    imageUrl: ImageAssets.defaultProfile,
+                                    fit: BoxFit.contain,
+                                    errorWidget: (_, _, _) => Icon(
+                                      Icons.person_search_rounded,
+                                      color: colorScheme.onSurfaceVariant,
+                                    ),
+                                  )
+                                : MobileWebImage(
+                                    imageUrl: ImageAssets.townHall(
+                                      selectedAccount!.townHall,
+                                    ),
+                                    fit: BoxFit.contain,
+                                    errorWidget: (_, _, _) => MobileWebImage(
+                                      imageUrl: ImageAssets.defaultProfile,
+                                      fit: BoxFit.contain,
+                                      errorWidget: (_, _, _) => Icon(
+                                        Icons.person_rounded,
+                                        color: colorScheme.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: selectedAccount == null
+                                ? Text(
+                                    loc.damageChooseAccount,
+                                    style: Theme.of(context).textTheme.bodyLarge
+                                        ?.copyWith(fontWeight: FontWeight.w700),
+                                  )
+                                : Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        selectedAccount!.name,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.copyWith(
+                                              fontWeight: FontWeight.w800,
+                                            ),
+                                      ),
+                                      Text(
+                                        '${selectedAccount!.tag} · ${loc.gameTownHallShortLevel(selectedAccount!.townHall)}',
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color:
+                                                  colorScheme.onSurfaceVariant,
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                          ),
+                          IconButton(
+                            tooltip: loc.damageSwitchAccount,
+                            onPressed: onOpenAccountPicker,
+                            icon: const Icon(Icons.switch_account_rounded),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                 ),
                 const SizedBox(height: 8),
                 Text(
@@ -1186,8 +1682,152 @@ class _AccountSelectorPanel extends StatelessWidget {
   }
 }
 
-const _noAccountPreset = '__none__';
 const _noFarmBuilding = '__none__';
+
+class _CalculatorAccountPickerSheet extends StatefulWidget {
+  const _CalculatorAccountPickerSheet({
+    required this.accountPresets,
+    required this.selectedTag,
+  });
+
+  final List<DamageAccountPreset> accountPresets;
+  final String? selectedTag;
+
+  @override
+  State<_CalculatorAccountPickerSheet> createState() =>
+      _CalculatorAccountPickerSheetState();
+}
+
+class _CalculatorAccountPickerSheetState
+    extends State<_CalculatorAccountPickerSheet> {
+  final _searchController = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final query = _query.trim().toLowerCase();
+    final accounts = widget.accountPresets
+        .where(
+          (account) =>
+              query.isEmpty ||
+              account.name.toLowerCase().contains(query) ||
+              account.tag.toLowerCase().contains(query),
+        )
+        .toList(growable: false);
+
+    return FractionallySizedBox(
+      heightFactor: 0.82,
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 12, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    loc.damageAccountPresetShort,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                  onPressed: () => Navigator.pop(context),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+            child: TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                labelText: loc.damageChooseAccount,
+                prefixIcon: const Icon(Icons.search_rounded),
+                suffixIcon: _query.isEmpty
+                    ? null
+                    : IconButton(
+                        tooltip: loc.generalClearSearch,
+                        onPressed: () {
+                          _searchController.clear();
+                          setState(() => _query = '');
+                        },
+                        icon: const Icon(Icons.close_rounded),
+                      ),
+              ),
+              onChanged: (value) => setState(() => _query = value),
+            ),
+          ),
+          Expanded(
+            child: accounts.isEmpty
+                ? AppEmptyState(
+                    icon: Icons.person_search_rounded,
+                    title: loc.damageNoAccountsAvailable,
+                    body: loc.generalTryAgain,
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    itemCount: accounts.length,
+                    itemBuilder: (context, index) {
+                      final account = accounts[index];
+                      final selected = account.tag == widget.selectedTag;
+                      return ListTile(
+                        selected: selected,
+                        selectedTileColor: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(AppRadius.chip),
+                        ),
+                        leading: SizedBox.square(
+                          dimension: 44,
+                          child: MobileWebImage(
+                            imageUrl: ImageAssets.townHall(account.townHall),
+                            fit: BoxFit.contain,
+                            errorWidget: (_, _, _) => MobileWebImage(
+                              imageUrl: ImageAssets.defaultProfile,
+                              fit: BoxFit.contain,
+                              errorWidget: (_, _, _) =>
+                                  const Icon(Icons.person_rounded),
+                            ),
+                          ),
+                        ),
+                        title: Text(
+                          '${account.name} · ${loc.gameTownHallShortLevel(account.townHall)}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        subtitle: Text(
+                          [
+                            account.tag,
+                            if (account.league?.trim().isNotEmpty == true)
+                              account.league!,
+                          ].join(' · '),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: selected
+                            ? const Icon(Icons.check_rounded)
+                            : null,
+                        onTap: () => Navigator.pop(context, account.tag),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 class _TargetEmptyPanel extends StatelessWidget {
   const _TargetEmptyPanel({required this.onChoose});
@@ -1207,9 +1847,15 @@ class _TargetEmptyPanel extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Icon(
-                Icons.gps_fixed_rounded,
-                color: colorScheme.onSurfaceVariant,
+              MobileWebImage(
+                imageUrl: ImageAssets.townHall(1),
+                width: 42,
+                height: 42,
+                fit: BoxFit.contain,
+                errorWidget: (_, _, _) => Icon(
+                  Icons.gps_fixed_rounded,
+                  color: colorScheme.onSurfaceVariant,
+                ),
               ),
               const SizedBox(width: 12),
               Expanded(
@@ -1237,17 +1883,11 @@ class _TargetEmptyPanel extends StatelessWidget {
           const SizedBox(height: 14),
           SizedBox(
             width: double.infinity,
-            height: 46,
             child: OutlinedButton.icon(
               key: const ValueKey('choose-building'),
               onPressed: onChoose,
               icon: const Icon(Icons.add_rounded),
               label: Text(loc.damageChooseTarget),
-              style: OutlinedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.control),
-                ),
-              ),
             ),
           ),
         ],
@@ -1267,19 +1907,8 @@ class _AddBuildingButton extends StatelessWidget {
     final loc = AppLocalizations.of(context)!;
     return SizedBox(
       width: double.infinity,
-      height: 44,
       child: OutlinedButton.icon(
         key: const ValueKey('add-building'),
-        style: OutlinedButton.styleFrom(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppRadius.control),
-          ),
-          side: BorderSide(
-            color: Theme.of(context).colorScheme.outlineVariant.withValues(
-              alpha: AppOpacity.borderStrong,
-            ),
-          ),
-        ),
         onPressed: enabled ? onPressed : null,
         icon: const Icon(Icons.add_rounded),
         label: Text(loc.damageAddBuilding),
@@ -1448,12 +2077,20 @@ class _TargetResultSummary extends StatelessWidget {
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(
-                      result.destroyed
-                          ? Icons.check_circle_outline_rounded
-                          : Icons.shield_outlined,
-                      size: 16,
-                      color: accent,
+                    MobileWebImage(
+                      imageUrl: result.destroyed
+                          ? ImageAssets.iconTick
+                          : ImageAssets.iconCross,
+                      width: 18,
+                      height: 18,
+                      fit: BoxFit.contain,
+                      errorWidget: (_, _, _) => Icon(
+                        result.destroyed
+                            ? Icons.check_circle_outline_rounded
+                            : Icons.shield_outlined,
+                        size: 16,
+                        color: accent,
+                      ),
                     ),
                     const SizedBox(width: 5),
                     Text(
@@ -1634,6 +2271,14 @@ class _ZapQuakePanel extends StatelessWidget {
         children: [
           Row(
             children: [
+              MobileWebImage(
+                imageUrl: lightningSource.imageUrl,
+                width: 28,
+                height: 28,
+                fit: BoxFit.contain,
+                errorWidget: (_, _, _) => const Icon(Icons.bolt_rounded),
+              ),
+              const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   loc.damageSpellCapacity,
@@ -1707,7 +2352,14 @@ class _ZapQuakePanel extends StatelessWidget {
       children: combinations
           .map(
             (combo) => Chip(
-              avatar: const Icon(Icons.bolt_rounded, size: 18),
+              avatar: MobileWebImage(
+                imageUrl: ImageAssets.getSpellImage('Lightning Spell'),
+                width: 18,
+                height: 18,
+                fit: BoxFit.contain,
+                errorWidget: (_, _, _) =>
+                    const Icon(Icons.bolt_rounded, size: 18),
+              ),
               label: Text(
                 loc.damageZapQuakeCombination(
                   combo.lightningCount,
@@ -2053,7 +2705,38 @@ String? _upgradeResourceLabel(AppLocalizations loc, String? resource) {
   };
 }
 
-int? _farmLeagueLoot({
+UpgradeCost? _trackerCostForSelection(
+  UpgradeTrackerItem? item,
+  BuildingDefinition? building,
+  BuildingLevelDefinition? level,
+) {
+  if (item == null || building == null || level == null) return null;
+  if (item.name.trim().toLowerCase() != building.name.trim().toLowerCase()) {
+    return null;
+  }
+  final step = item.steps
+      .where((candidate) => candidate.targetLevel == level.level)
+      .firstOrNull;
+  if (step == null || step.costs.isEmpty) return null;
+  final selectedResource = level.upgradeResource?.trim().toLowerCase();
+  return step.costs
+          .where(
+            (cost) =>
+                selectedResource == null ||
+                cost.resource.trim().toLowerCase() == selectedResource,
+          )
+          .firstOrNull ??
+      step.costs.first;
+}
+
+class _FarmLeagueLootEstimate {
+  const _FarmLeagueLootEstimate({this.loot, this.starBonus});
+
+  final int? loot;
+  final int? starBonus;
+}
+
+_FarmLeagueLootEstimate? _farmLeagueLootEstimate({
   required String? league,
   required int townHall,
   required String? resource,
@@ -2071,10 +2754,20 @@ int? _farmLeagueLoot({
     if (!_rewardAppliesToTownHall(reward, townHall)) continue;
     selectedReward = reward;
   }
-  final resources = selectedReward?['resources'];
-  if (resources is! Map) return null;
   final resourceKey = _farmResourceKey(resource);
-  final value = resourceKey == null ? null : resources[resourceKey];
+  if (resourceKey == null) return null;
+  final loot = _farmRewardAmount(selectedReward?['resources'], resourceKey);
+  final starBonus = _farmRewardAmount(
+    selectedReward?['star_bonus'],
+    resourceKey,
+  );
+  if (loot == null && starBonus == null) return null;
+  return _FarmLeagueLootEstimate(loot: loot, starBonus: starBonus);
+}
+
+int? _farmRewardAmount(dynamic rewards, String resourceKey) {
+  if (rewards is! Map) return null;
+  final value = rewards[resourceKey];
   return value is num && value > 0 ? value.round() : null;
 }
 
@@ -2091,6 +2784,19 @@ String? _farmResourceKey(String resource) =>
       _ => null,
     };
 
+String? _farmResourceImage(String? resource) =>
+    switch (resource?.trim().toLowerCase().replaceAll('_', ' ')) {
+      'gold' => '${ImageAssets.baseUrl}/resources/gold.webp',
+      'elixir' => '${ImageAssets.baseUrl}/resources/elixir.webp',
+      'dark elixir' => '${ImageAssets.baseUrl}/resources/dark_elixir.webp',
+      _ => null,
+    };
+
+int _farmDefaultPerfectLoot(String? resource) =>
+    resource?.trim().toLowerCase().replaceAll('_', ' ') == 'dark elixir'
+    ? 10000
+    : _defaultFarmPerfectLoot;
+
 int _parseFarmAmount(String value) =>
     int.tryParse(value.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;
 
@@ -2099,7 +2805,15 @@ String _quickSetupLabel(AppLocalizations loc, String id) => switch (id) {
   _fireballQuakeSetupId => loc.damageQuickSetupFireballQuake,
   _giantArrowSetupId => loc.damageQuickSetupGiantArrow,
   _flameFlingerSetupId => loc.damageQuickSetupFlameFlinger,
-  _ => loc.damageSummaryAttack,
+  _ => loc.damageQuickSetupCustom,
+};
+
+IconData _quickSetupIcon(String id) => switch (id) {
+  _zapQuakeSetupId => Icons.bolt_rounded,
+  _fireballQuakeSetupId => Icons.local_fire_department_rounded,
+  _giantArrowSetupId => Icons.north_east_rounded,
+  _flameFlingerSetupId => Icons.rocket_launch_rounded,
+  _ => Icons.tune_rounded,
 };
 
 String _sourceLabel(AppLocalizations loc, DamageSourceDefinition source) =>

--- a/lib/features/pages/presentation/calculators_page.dart
+++ b/lib/features/pages/presentation/calculators_page.dart
@@ -76,6 +76,7 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
   String? _farmBuildingId;
   int? _farmBuildingLevel;
   UpgradeTrackerSnapshot? _farmTrackerSnapshot;
+  String? _farmTrackerSnapshotTag;
   bool _farmTrackerLoading = false;
   String? _farmTrackerLoadTag;
   late final TextEditingController _farmAverageLootController;
@@ -424,6 +425,9 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       _farmAccountTag = tag;
       _farmBuildingId = null;
       _farmBuildingLevel = null;
+      _farmTrackerSnapshot = null;
+      _farmTrackerSnapshotTag = null;
+      _farmTrackerLoading = false;
       _farmAverageLootController.clear();
     });
     _startFarmTrackerLoad(tag);
@@ -438,15 +442,18 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     if (tag == null || tag.isEmpty) {
       _farmTrackerLoadTag = tag;
       _farmTrackerSnapshot = null;
+      _farmTrackerSnapshotTag = null;
       _farmTrackerLoading = false;
       return;
     }
     if (tag == _farmTrackerLoadTag) return;
     _farmTrackerLoadTag = tag;
     _farmTrackerSnapshot = null;
+    _farmTrackerSnapshotTag = null;
     final cached = UpgradeTrackerRepository.shared.peekCached(tag);
     if (cached != null) {
       _farmTrackerSnapshot = cached;
+      _farmTrackerSnapshotTag = tag;
       _farmTrackerLoading = false;
       return;
     }
@@ -468,12 +475,14 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
       if (!mounted || tag != _farmAccountTag) return;
       setState(() {
         _farmTrackerSnapshot = snapshot;
+        _farmTrackerSnapshotTag = tag;
         _farmTrackerLoading = false;
       });
     } catch (_) {
       if (!mounted || tag != _farmAccountTag) return;
       setState(() {
         _farmTrackerSnapshot = null;
+        _farmTrackerSnapshotTag = null;
         _farmTrackerLoading = false;
       });
     }
@@ -500,7 +509,9 @@ class _CalculatorsPageState extends State<CalculatorsPage> {
     List<BuildingDefinition> buildings,
   ) {
     final snapshot = _farmTrackerSnapshot;
-    if (snapshot == null) return const [];
+    if (snapshot == null || _farmTrackerSnapshotTag != _farmAccountTag) {
+      return const [];
+    }
     final names = buildings
         .map((building) => building.name.trim().toLowerCase())
         .toSet();

--- a/lib/features/pages/presentation/stats_page.dart
+++ b/lib/features/pages/presentation/stats_page.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/empty_state.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
@@ -78,12 +79,15 @@ class _StatsPageContentState extends State<_StatsPageContent> {
           children: [
             if (provider.audience == StatsAudience.battle)
               Padding(
-                padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
                 child: _DateRangeControl(provider: provider),
               ),
             Expanded(
               child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 180),
+                duration: _motionDuration(
+                  context,
+                  const Duration(milliseconds: 180),
+                ),
                 child: KeyedSubtree(
                   key: ValueKey(provider.section),
                   child: switch (provider.section) {
@@ -258,47 +262,76 @@ class _DateRangeControl extends StatelessWidget {
     );
     final colorScheme = Theme.of(context).colorScheme;
     return Material(
-      color: colorScheme.primaryContainer.withValues(alpha: 0.58),
-      borderRadius: BorderRadius.circular(16),
+      color: colorScheme.surfaceContainerHighest.withValues(
+        alpha: AppOpacity.fillMuted,
+      ),
+      borderRadius: BorderRadius.circular(AppRadius.chip),
       child: InkWell(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppRadius.chip),
         onTap: () => _pick(context),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-          child: Row(
-            children: [
-              const Icon(Icons.date_range_rounded),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      loc.statsDateRange,
-                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                    Text(
-                      '${formatter.format(provider.dates.start)} – '
-                      '${formatter.format(provider.dates.end)} '
-                      '· ${loc.statsIndexDays(provider.dates.inclusiveDays)}',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                  ],
-                ),
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 56),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppRadius.chip),
+            border: Border.all(
+              color: colorScheme.outlineVariant.withValues(
+                alpha: AppOpacity.borderStrong,
               ),
-              Text(
-                loc.statsDateRangeHint,
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            child: Row(
+              children: [
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colorScheme.surface.withValues(alpha: 0.72),
+                    shape: BoxShape.circle,
+                  ),
+                  child: SizedBox.square(
+                    dimension: 34,
+                    child: Icon(
+                      Icons.date_range_rounded,
+                      size: 19,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        loc.statsDateRange,
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontWeight: FontWeight.w700,
+                            ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '${formatter.format(provider.dates.start)} - '
+                        '${formatter.format(provider.dates.end)} '
+                        '- ${loc.statsIndexDays(provider.dates.inclusiveDays)}',
+                        maxLines: 2,
+                        overflow: TextOverflow.fade,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Icon(
+                  Icons.chevron_right_rounded,
                   color: colorScheme.onSurfaceVariant,
                 ),
-              ),
-              const SizedBox(width: 4),
-              const Icon(Icons.chevron_right_rounded),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -406,16 +439,10 @@ class _SectionFrame extends StatelessWidget {
           ],
           if (data != null) builder(data),
           if (state.updatedAt != null) ...[
-            const SizedBox(height: 14),
+            const SizedBox(height: 4),
             Align(
               alignment: Alignment.centerLeft,
-              child: Chip(
-                avatar: const Icon(
-                  Icons.check_circle_outline_rounded,
-                  size: 18,
-                ),
-                label: Text(loc.statsUpdated),
-              ),
+              child: _FreshDataChip(label: loc.statsUpdated),
             ),
           ],
         ],
@@ -511,7 +538,7 @@ class _PlayersSection extends StatelessWidget {
               subtitle: loc.statsTrackedPlayers,
               values: counts.townHalls,
               labelBuilder: (id) => 'TH${id ?? '?'}',
-              color: const Color(0xFFFF9F43),
+              color: StatColors.capitalProjected,
             ),
             const SizedBox(height: 12),
             _DistributionCard(
@@ -519,7 +546,7 @@ class _PlayersSection extends StatelessWidget {
               subtitle: loc.statsTrackedPlayers,
               values: counts.leagueTiers,
               labelBuilder: _leagueTierLabel,
-              color: const Color(0xFF8B5CF6),
+              color: StatColors.capitalTrophy,
             ),
             const SizedBox(height: 12),
             _DistributionCard(
@@ -527,7 +554,7 @@ class _PlayersSection extends StatelessWidget {
               subtitle: loc.statsTrackedPlayers,
               values: counts.builderHalls,
               labelBuilder: (id) => 'BH${id ?? '?'}',
-              color: const Color(0xFF38BDF8),
+              color: StatColors.capitalAttack,
             ),
             const SizedBox(height: 12),
             _PreviewPanel(
@@ -566,7 +593,7 @@ class _ClansSection extends StatelessWidget {
               subtitle: loc.statsTrackedClans,
               values: counts.cwlLeagues,
               labelBuilder: (id) => _cwlLeagues[id] ?? '${id ?? '?'}',
-              color: const Color(0xFFFF5D8F),
+              color: StatColors.loss,
             ),
             const SizedBox(height: 12),
             _DistributionCard(
@@ -574,7 +601,7 @@ class _ClansSection extends StatelessWidget {
               subtitle: loc.statsTrackedClans,
               values: counts.capitalLeagues,
               labelBuilder: (id) => loc.statsLeagueId(id ?? 0),
-              color: const Color(0xFF2DD4BF),
+              color: StatColors.capitalDistrict,
             ),
             const SizedBox(height: 12),
             _CountsSummaryCard(
@@ -750,7 +777,7 @@ class _CountBarChart extends StatelessWidget {
             ),
         ],
       ),
-      duration: const Duration(milliseconds: 300),
+      duration: _motionDuration(context, const Duration(milliseconds: 300)),
       curve: Curves.easeOutCubic,
     );
   }
@@ -856,13 +883,14 @@ class _PreviewBadge extends StatelessWidget {
     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
     decoration: BoxDecoration(
       color: Theme.of(context).colorScheme.tertiaryContainer,
-      borderRadius: BorderRadius.circular(99),
+      borderRadius: BorderRadius.circular(AppRadius.pill),
     ),
     child: Text(
       label,
-      style: Theme.of(
-        context,
-      ).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.w900),
+      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+        color: Theme.of(context).colorScheme.onTertiaryContainer,
+        fontWeight: FontWeight.w900,
+      ),
     ),
   );
 }
@@ -889,7 +917,7 @@ class _MiniPreviewBars extends StatelessWidget {
                   decoration: BoxDecoration(
                     color: color.withValues(alpha: 0.72),
                     borderRadius: const BorderRadius.vertical(
-                      top: Radius.circular(6),
+                      top: Radius.circular(AppRadius.control),
                     ),
                   ),
                 ),
@@ -1179,7 +1207,10 @@ class _ArmyMetaChart extends StatelessWidget {
                     ),
                 ],
               ),
-              duration: const Duration(milliseconds: 300),
+              duration: _motionDuration(
+                context,
+                const Duration(milliseconds: 300),
+              ),
               curve: Curves.easeOutCubic,
             ),
           ),
@@ -1228,7 +1259,7 @@ class _ArmyCard extends StatelessWidget {
                           padding: const EdgeInsets.symmetric(horizontal: 4),
                           decoration: BoxDecoration(
                             color: Theme.of(context).colorScheme.inverseSurface,
-                            borderRadius: BorderRadius.circular(99),
+                            borderRadius: BorderRadius.circular(AppRadius.pill),
                           ),
                           child: Text(
                             '${entry.value}',
@@ -1389,6 +1420,7 @@ class _ArmyFiltersSheetState extends State<_ArmyFiltersSheet> {
                   '${filter.minQuantity ?? 1}–${filter.maxQuantity ?? '∞'}',
                 ),
                 trailing: IconButton(
+                  tooltip: loc.presetsDelete,
                   onPressed: () => setState(() => include.remove(filter)),
                   icon: const Icon(Icons.close_rounded),
                 ),
@@ -1420,6 +1452,7 @@ class _ArmyFiltersSheetState extends State<_ArmyFiltersSheet> {
                   ),
                 ),
                 IconButton(
+                  tooltip: loc.statsAddItem,
                   onPressed: _addInclude,
                   icon: const Icon(Icons.add_circle_rounded),
                 ),
@@ -1717,6 +1750,7 @@ class _ItemResultCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
+    final scheme = Theme.of(context).colorScheme;
     return _SurfaceCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1731,17 +1765,31 @@ class _ItemResultCard extends StatelessWidget {
                   ),
                 ),
               ),
-              Chip(label: Text(item.type)),
+              _PreviewBadge(label: item.type),
             ],
           ),
-          if (item.hero != null) Text('${loc.statsOwningHero}: ${item.hero}'),
-          Text('${loc.statsUsage}: ${_compact(item.useCount)}'),
-          if (item.compositionShare != null)
-            Text(
-              '${loc.statsCompositionShare}: '
-              '${_percent(item.compositionShare!)}',
-            ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _MetricPill(
+                label: loc.statsUsage,
+                value: _compact(item.useCount),
+              ),
+              if (item.compositionShare != null)
+                _MetricPill(
+                  label: loc.statsCompositionShare,
+                  value: _percent(item.compositionShare!),
+                ),
+              if (item.hero != null)
+                _MetricPill(label: loc.statsOwningHero, value: item.hero!),
+            ],
+          ),
+          Divider(
+            height: 22,
+            color: scheme.outlineVariant.withValues(alpha: AppOpacity.border),
+          ),
           _MetricsContent(metrics: item.metrics),
         ],
       ),
@@ -1796,7 +1844,7 @@ class _WarSectionState extends State<_WarSection> {
               value: equalTownHalls,
               onChanged: (value) => setState(() => equalTownHalls = value),
             ),
-            FilledButton(onPressed: _apply, child: Text(loc.statsApplyFilters)),
+            _FilterApplyButton(onPressed: _apply),
           ],
         ),
       ),
@@ -1870,21 +1918,11 @@ class _CwlSectionState extends State<_CwlSection> {
               value: equalTownHalls,
               onChanged: (value) => setState(() => equalTownHalls = value),
             ),
-            DropdownButtonFormField<int?>(
-              initialValue: leagueId,
-              decoration: InputDecoration(labelText: loc.statsCwlLeague),
-              items: [
-                DropdownMenuItem<int?>(
-                  value: null,
-                  child: Text(loc.statsAllCwlLeagues),
-                ),
-                ..._cwlLeagues.entries.map(
-                  (entry) => DropdownMenuItem<int?>(
-                    value: entry.key,
-                    child: Text(entry.value),
-                  ),
-                ),
-              ],
+            _CompactMenuField<int?>(
+              label: loc.statsCwlLeague,
+              icon: Icons.emoji_events_outlined,
+              value: leagueId,
+              options: {null: loc.statsAllCwlLeagues, ..._cwlLeagues},
               onChanged: (value) => setState(() => leagueId = value),
             ),
             const SizedBox(height: 10),
@@ -1896,7 +1934,7 @@ class _CwlSectionState extends State<_CwlSection> {
               ),
             ),
             const SizedBox(height: 12),
-            FilledButton(onPressed: _apply, child: Text(loc.statsApplyFilters)),
+            _FilterApplyButton(onPressed: _apply),
           ],
         ),
       ),
@@ -1966,7 +2004,7 @@ class _RankedSectionState extends State<_RankedSection> {
               onChanged: (value) => setState(() => leagueTier = value ?? 1),
             ),
             const SizedBox(height: 12),
-            FilledButton(
+            _FilterApplyButton(
               onPressed: () {
                 final provider = context.read<StatsProvider>();
                 provider.updateRankedFilters(
@@ -1975,7 +2013,6 @@ class _RankedSectionState extends State<_RankedSection> {
                 );
                 provider.load(StatsSection.ranked, force: true);
               },
-              child: Text(loc.statsApplyFilters),
             ),
           ],
         ),
@@ -2069,19 +2106,25 @@ class _MetricsContent extends StatelessWidget {
             _MetricPill(
               label: loc.statsSamples,
               value: _compact(metrics.sampleSize),
+              icon: Icons.dataset_outlined,
             ),
             if (metrics.usageRate != null)
               _MetricPill(
                 label: loc.statsUsage,
                 value: _percent(metrics.usageRate!),
+                icon: Icons.pie_chart_outline_rounded,
               ),
             _MetricPill(
               label: loc.statsAverageStars,
               value: metrics.averageStars.toStringAsFixed(2),
+              icon: Icons.star_rounded,
+              accentColor: StatColors.warStarGold,
             ),
             _MetricPill(
               label: loc.statsAverageDestruction,
               value: _percent(metrics.averageDestruction),
+              icon: Icons.percent_rounded,
+              accentColor: Theme.of(context).colorScheme.primary,
             ),
           ],
         ),
@@ -2110,33 +2153,65 @@ class _StarRates extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     final rates = [
       metrics.zeroStarRate,
       metrics.oneStarRate,
       metrics.twoStarRate,
       metrics.threeStarRate,
     ];
-    final colors = [Colors.grey, Colors.orange, Colors.blue, Colors.green];
+    final colors = [
+      scheme.onSurfaceVariant,
+      StatColors.loss,
+      StatColors.tie,
+      StatColors.win,
+    ];
     return Column(
       children: List.generate(
         4,
         (index) => Padding(
-          padding: const EdgeInsets.only(bottom: 4),
+          padding: const EdgeInsets.only(bottom: 8),
           child: Row(
             children: [
-              SizedBox(width: 28, child: Text('$index★')),
+              SizedBox(
+                width: 34,
+                child: Text(
+                  '$index★',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w800),
+                ),
+              ),
               Expanded(
                 child: LinearProgressIndicator(
                   value: _asPercentValue(rates[index]).clamp(0, 100) / 100,
-                  minHeight: 7,
-                  borderRadius: BorderRadius.circular(99),
+                  minHeight: 9,
+                  borderRadius: BorderRadius.circular(AppRadius.pill),
                   color: colors[index],
+                  backgroundColor: scheme.surfaceContainerHighest.withValues(
+                    alpha: 0.42,
+                  ),
                 ),
               ),
               const SizedBox(width: 8),
-              SizedBox(
-                width: 52,
-                child: Text(_percent(rates[index]), textAlign: TextAlign.end),
+              Container(
+                constraints: const BoxConstraints(minWidth: 58, minHeight: 30),
+                alignment: Alignment.center,
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                decoration: BoxDecoration(
+                  color: scheme.surfaceContainerHighest.withValues(alpha: 0.34),
+                  borderRadius: BorderRadius.circular(AppRadius.pill),
+                  border: Border.all(
+                    color: colors[index].withValues(alpha: 0.44),
+                  ),
+                ),
+                child: Text(
+                  _percent(rates[index]),
+                  textAlign: TextAlign.end,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
               ),
             ],
           ),
@@ -2253,7 +2328,7 @@ class _TrendChart extends StatelessWidget {
               ),
             ],
           ),
-          duration: const Duration(milliseconds: 300),
+          duration: _motionDuration(context, const Duration(milliseconds: 300)),
           curve: Curves.easeOutCubic,
         ),
       ),
@@ -2274,6 +2349,7 @@ class _SearchAndFilter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return Row(
       children: [
         Expanded(
@@ -2286,10 +2362,10 @@ class _SearchAndFilter extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 8),
-        FilledButton.tonalIcon(
+        IconButton.filledTonal(
+          tooltip: loc.statsCustomLens,
           onPressed: onFilter,
           icon: const Icon(Icons.tune_rounded),
-          label: Text(AppLocalizations.of(context)!.statsCustomLens),
         ),
       ],
     );
@@ -2358,22 +2434,15 @@ class _TownHallField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    return DropdownButtonFormField<int?>(
-      initialValue: value,
-      decoration: InputDecoration(
-        labelText: opponent ? loc.statsOpponentTownHall : loc.statsTownHall,
-      ),
-      items: [
-        if (allowAll)
-          DropdownMenuItem<int?>(
-            value: null,
-            child: Text(loc.statsAllTownHalls),
-          ),
-        ...List.generate(12, (index) => 18 - index).map(
-          (value) =>
-              DropdownMenuItem<int?>(value: value, child: Text('TH$value')),
-        ),
-      ],
+    return _CompactMenuField<int?>(
+      label: opponent ? loc.statsOpponentTownHall : loc.statsTownHall,
+      icon: opponent ? Icons.gps_fixed_rounded : Icons.other_houses_rounded,
+      value: value,
+      options: {
+        if (allowAll) null: loc.statsAllTownHalls,
+        for (final townHall in List.generate(12, (index) => 18 - index))
+          townHall: 'TH$townHall',
+      },
       onChanged: onChanged,
     );
   }
@@ -2393,24 +2462,169 @@ class _LeagueTierField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    return DropdownButtonFormField<int?>(
+    return _CompactMenuField<int?>(
+      label: loc.statsLeagueTier,
+      icon: Icons.workspace_premium_outlined,
+      value: value,
+      options: {
+        if (optional) null: loc.generalAll,
+        for (final tier in List.generate(10, (index) => index + 1))
+          tier: tier == 1
+              ? loc.statsLegendLeagueOne
+              : '${loc.statsLeagueTier} $tier',
+      },
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _CompactMenuField<T> extends StatelessWidget {
+  const _CompactMenuField({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.options,
+    required this.onChanged,
+  });
+
+  final String label;
+  final IconData icon;
+  final T value;
+  final Map<T, String> options;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final selectedLabel = options[value] ?? value.toString();
+    return PopupMenuButton<T>(
       initialValue: value,
-      decoration: InputDecoration(labelText: loc.statsLeagueTier),
-      items: [
-        if (optional)
-          DropdownMenuItem<int?>(value: null, child: Text(loc.generalAll)),
-        ...List.generate(10, (index) => index + 1).map(
-          (tier) => DropdownMenuItem<int?>(
-            value: tier,
-            child: Text(
-              tier == 1
-                  ? loc.statsLegendLeagueOne
-                  : '${loc.statsLeagueTier} $tier',
+      onSelected: onChanged,
+      color: scheme.surface,
+      elevation: 4,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+        side: BorderSide(
+          color: scheme.outlineVariant.withValues(alpha: AppOpacity.border),
+        ),
+      ),
+      itemBuilder: (context) => options.entries
+          .map(
+            (entry) => PopupMenuItem<T>(
+              value: entry.key,
+              height: 42,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      entry.value,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (entry.key == value)
+                    Icon(Icons.check_rounded, size: 18, color: scheme.primary),
+                ],
+              ),
             ),
+          )
+          .toList(growable: false),
+      child: _CompactFilterTile(label: label, value: selectedLabel, icon: icon),
+    );
+  }
+}
+
+class _CompactFilterTile extends StatelessWidget {
+  const _CompactFilterTile({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      constraints: const BoxConstraints(minHeight: 58),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest.withValues(alpha: 0.34),
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(
+            alpha: AppOpacity.borderStrong,
           ),
         ),
-      ],
-      onChanged: onChanged,
+      ),
+      child: Row(
+        children: [
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: scheme.surface.withValues(alpha: 0.72),
+              shape: BoxShape.circle,
+            ),
+            child: SizedBox.square(
+              dimension: 32,
+              child: Icon(icon, size: 18, color: scheme.primary),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 1),
+                Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w900),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Icon(
+            Icons.keyboard_arrow_down_rounded,
+            size: 20,
+            color: scheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterApplyButton extends StatelessWidget {
+  const _FilterApplyButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: AlignmentDirectional.centerEnd,
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.tune_rounded, size: 18),
+        label: Text(AppLocalizations.of(context)!.statsApplyFilters),
+      ),
     );
   }
 }
@@ -2422,41 +2636,98 @@ class _SurfaceCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    return Container(
-      width: double.infinity,
-      margin: const EdgeInsets.only(bottom: 8),
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardTheme.color ?? scheme.surface,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(
-          color: scheme.outlineVariant.withValues(alpha: 0.36),
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: SizedBox(
+        width: double.infinity,
+        child: SidePagePanel(
+          radius: AppRadius.card,
+          padding: const EdgeInsets.all(16),
+          child: child,
         ),
       ),
-      child: child,
     );
   }
 }
 
 class _MetricPill extends StatelessWidget {
-  const _MetricPill({required this.label, required this.value});
+  const _MetricPill({
+    required this.label,
+    required this.value,
+    this.icon,
+    this.accentColor,
+  });
 
   final String label;
   final String value;
+  final IconData? icon;
+  final Color? accentColor;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-      decoration: BoxDecoration(
-        color: scheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        '$label  $value',
-        style: const TextStyle(fontWeight: FontWeight.w800),
+    final accent = accentColor ?? scheme.onSurfaceVariant;
+    return Semantics(
+      label: '$label: $value',
+      excludeSemantics: true,
+      child: Container(
+        constraints: const BoxConstraints(minHeight: 44),
+        padding: const EdgeInsets.fromLTRB(8, 6, 11, 6),
+        decoration: BoxDecoration(
+          color: scheme.surfaceContainerHighest.withValues(alpha: 0.34),
+          borderRadius: BorderRadius.circular(AppRadius.chip),
+          border: Border.all(
+            color: scheme.outlineVariant.withValues(
+              alpha: AppOpacity.borderStrong,
+            ),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.16),
+                  shape: BoxShape.circle,
+                ),
+                child: SizedBox.square(
+                  dimension: 28,
+                  child: Icon(icon, size: 16, color: accent),
+                ),
+              ),
+              const SizedBox(width: 7),
+            ],
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 154),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w700,
+                      height: 1.1,
+                    ),
+                  ),
+                  Text(
+                    value,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w900,
+                      height: 1.15,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -2476,20 +2747,24 @@ class _InlineNotice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final color = error ? scheme.errorContainer : scheme.secondaryContainer;
-    final foreground = error
-        ? scheme.onErrorContainer
-        : scheme.onSecondaryContainer;
+    final accent = error ? scheme.error : scheme.primary;
+    final foreground = error ? scheme.onErrorContainer : scheme.onSurface;
+    final fill = error
+        ? scheme.errorContainer.withValues(alpha: 0.46)
+        : scheme.surfaceContainerHighest.withValues(alpha: 0.34);
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(10),
       decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.65),
-        borderRadius: BorderRadius.circular(12),
+        color: fill,
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+        border: Border.all(
+          color: accent.withValues(alpha: AppOpacity.borderStrong),
+        ),
       ),
       child: Row(
         children: [
-          Icon(icon, size: 19, color: foreground),
+          Icon(icon, size: 19, color: accent),
           const SizedBox(width: 8),
           Expanded(
             child: Text(text, style: TextStyle(color: foreground)),
@@ -2499,6 +2774,48 @@ class _InlineNotice extends StatelessWidget {
     );
   }
 }
+
+class _FreshDataChip extends StatelessWidget {
+  const _FreshDataChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      constraints: const BoxConstraints(minHeight: 36),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest.withValues(alpha: 0.24),
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        border: Border.all(
+          color: scheme.primary.withValues(alpha: AppOpacity.borderStrong),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.check_circle_outline_rounded,
+            size: 17,
+            color: scheme.primary,
+          ),
+          const SizedBox(width: 7),
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w800),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Duration _motionDuration(BuildContext context, Duration duration) =>
+    MediaQuery.disableAnimationsOf(context) ? Duration.zero : duration;
 
 String _percent(double value) {
   final normalized = _asPercentValue(value);

--- a/lib/features/pages/presentation/stats_page.dart
+++ b/lib/features/pages/presentation/stats_page.dart
@@ -2496,10 +2496,14 @@ class _CompactMenuField<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final selectedLabel = options[value] ?? value.toString();
-    return PopupMenuButton<T>(
-      initialValue: value,
-      onSelected: onChanged,
+    final entries = options.entries.toList(growable: false);
+    final selectedIndex = entries.indexWhere((entry) => entry.key == value);
+    final selectedLabel = selectedIndex >= 0
+        ? entries[selectedIndex].value
+        : value.toString();
+    return PopupMenuButton<int>(
+      initialValue: selectedIndex >= 0 ? selectedIndex : null,
+      onSelected: (index) => onChanged(entries[index].key),
       color: scheme.surface,
       elevation: 4,
       shape: RoundedRectangleBorder(
@@ -2508,27 +2512,26 @@ class _CompactMenuField<T> extends StatelessWidget {
           color: scheme.outlineVariant.withValues(alpha: AppOpacity.border),
         ),
       ),
-      itemBuilder: (context) => options.entries
-          .map(
-            (entry) => PopupMenuItem<T>(
-              value: entry.key,
-              height: 42,
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      entry.value,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+      itemBuilder: (context) => [
+        for (var index = 0; index < entries.length; index++)
+          PopupMenuItem<int>(
+            value: index,
+            height: 42,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    entries[index].value,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  if (entry.key == value)
-                    Icon(Icons.check_rounded, size: 18, color: scheme.primary),
-                ],
-              ),
+                ),
+                if (entries[index].key == value)
+                  Icon(Icons.check_rounded, size: 18, color: scheme.primary),
+              ],
             ),
-          )
-          .toList(growable: false),
+          ),
+      ],
       child: _CompactFilterTile(label: label, value: selectedLabel, icon: icon),
     );
   }

--- a/lib/features/player/presentation/war_stats/player_war_stats_profile_tab.dart
+++ b/lib/features/player/presentation/war_stats/player_war_stats_profile_tab.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
-import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:clashkingapp/common/widgets/compact_filter_chip.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/utils/file_opener.dart';
@@ -177,19 +177,19 @@ class _PlayerWarStatsProfileTabState extends State<PlayerWarStatsProfileTab> {
 
     return _WarStatsFilterBar(
       chips: [
-        _WarTypeChip(
+        CompactFilterChip(
           label: loc.cwlTitle,
           imageUrl: ImageAssets.cwlSwordsNoBorder,
           selected: isCWLChecked,
           onTap: () => setState(() => isCWLChecked = !isCWLChecked),
         ),
-        _WarTypeChip(
+        CompactFilterChip(
           label: loc.warFiltersRandom,
           icon: Icons.shuffle_rounded,
           selected: isRandomChecked,
           onTap: () => setState(() => isRandomChecked = !isRandomChecked),
         ),
-        _WarTypeChip(
+        CompactFilterChip(
           label: loc.warFiltersFriendly,
           icon: Icons.handshake_rounded,
           selected: isFriendlyChecked,
@@ -1142,78 +1142,6 @@ class _IconPillButton extends StatelessWidget {
               ),
             ),
             child: Icon(icon, size: 18, color: colorScheme.onSurface),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Same compact war-type chip visual recipe as the clan War Log filters.
-class _WarTypeChip extends StatelessWidget {
-  const _WarTypeChip({
-    required this.label,
-    this.icon,
-    this.imageUrl,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final String label;
-  final IconData? icon;
-  final String? imageUrl;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final accent = colorScheme.primary;
-
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(999),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(999),
-        splashFactory: NoSplash.splashFactory,
-        onTap: onTap,
-        child: Container(
-          height: 36,
-          padding: const EdgeInsets.symmetric(horizontal: 11),
-          decoration: BoxDecoration(
-            color: selected
-                ? accent.withValues(alpha: 0.16)
-                : colorScheme.surfaceContainerHighest.withValues(alpha: 0.38),
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(
-              color: selected
-                  ? accent.withValues(alpha: 0.42)
-                  : colorScheme.outlineVariant.withValues(alpha: 0.28),
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (imageUrl != null) ...[
-                MobileWebImage(imageUrl: imageUrl!, height: 15, width: 15),
-                const SizedBox(width: 5),
-              ] else if (icon != null) ...[
-                Icon(
-                  icon,
-                  size: 15,
-                  color: selected ? accent : colorScheme.onSurfaceVariant,
-                ),
-                const SizedBox(width: 5),
-              ],
-              Text(
-                label,
-                style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                  color: colorScheme.onSurface,
-                  fontWeight: selected ? FontWeight.w900 : FontWeight.w700,
-                  height: 1,
-                ),
-              ),
-            ],
           ),
         ),
       ),

--- a/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_members_tab.dart
@@ -90,7 +90,11 @@ class _CwlMembersTabState extends State<CwlMembersTab> {
     final warsPlayed = clanDetails?.warsPlayed ?? 0;
     final attacksPerWar = 1; // Standard CWL attacks per war
 
-    return Column(
+    return ListView(
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      padding: EdgeInsets.only(
+        bottom: 16 + MediaQuery.paddingOf(context).bottom,
+      ),
       children: [
         const SizedBox(height: 12),
         Padding(

--- a/lib/features/war_cwl/presentation/cwl/cwl_rounds_tab.dart
+++ b/lib/features/war_cwl/presentation/cwl/cwl_rounds_tab.dart
@@ -6,6 +6,7 @@ import 'package:clashkingapp/features/war_cwl/models/war_info.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_cwl.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/cwl/widgets/cwl_round_card.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:flutter/material.dart';
 
 class CwlRoundsTab extends StatefulWidget {
@@ -145,19 +146,6 @@ class _RoundSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final roundSurface = isDark
-        ? Colors.black.withValues(alpha: 0.28)
-        : Colors.black.withValues(alpha: 0.06);
-    final roundBorder = Colors.black.withValues(
-      alpha: isCurrentRound
-          ? isDark
-                ? 0.44
-                : 0.18
-          : isDark
-          ? 0.28
-          : 0.10,
-    );
     final selectedWar = _selectedClanWar;
     final fallbackWar = wars.isNotEmpty ? wars.first : null;
     final status = _RoundStatus.fromWar(selectedWar ?? fallbackWar);
@@ -172,51 +160,35 @@ class _RoundSection extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: Column(
         children: [
-          Material(
-            color: Colors.transparent,
-            borderRadius: BorderRadius.circular(AppRadius.chip),
-            child: Ink(
-              decoration: BoxDecoration(
-                color: roundSurface,
-                borderRadius: BorderRadius.circular(AppRadius.chip),
-                border: Border.all(color: roundBorder),
-              ),
-              child: InkWell(
-                onTap: onToggle,
-                borderRadius: BorderRadius.circular(AppRadius.chip),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 14,
-                    vertical: 10,
-                  ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        isExpanded
-                            ? Icons.keyboard_arrow_up_rounded
-                            : Icons.keyboard_arrow_down_rounded,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          loc.cwlRoundNumber(round.roundNumber),
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.w700),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      _RoundBadge(
-                        label: badgeLabel,
-                        color: badgeColor,
-                        imageUrl: badgeImageUrl,
-                      ),
-                    ],
+          CKSectionPanel(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            onTap: onToggle,
+            child: Row(
+              children: [
+                Icon(
+                  isExpanded
+                      ? Icons.keyboard_arrow_up_rounded
+                      : Icons.keyboard_arrow_down_rounded,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    loc.cwlRoundNumber(round.roundNumber),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
-              ),
+                const SizedBox(width: 8),
+                _RoundBadge(
+                  label: badgeLabel,
+                  color: badgeColor,
+                  imageUrl: badgeImageUrl,
+                ),
+              ],
             ),
           ),
           AnimatedCrossFade(
@@ -237,10 +209,10 @@ class _RoundSection extends StatelessWidget {
             crossFadeState: isExpanded
                 ? CrossFadeState.showSecond
                 : CrossFadeState.showFirst,
-            duration: const Duration(milliseconds: 220),
-            firstCurve: Curves.easeOutCubic,
-            secondCurve: Curves.easeOutCubic,
-            sizeCurve: Curves.easeOutCubic,
+            duration: CKMotion.durationOf(context, CKMotion.standard),
+            firstCurve: CKMotion.standardCurve,
+            secondCurve: CKMotion.standardCurve,
+            sizeCurve: CKMotion.standardCurve,
           ),
         ],
       ),

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
@@ -1,5 +1,4 @@
 import 'package:clashking_design_system/clashking_design_system.dart';
-import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/icons/build_stars.dart';
 import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/player/data/player_service.dart';
@@ -332,21 +331,10 @@ class MembersCard extends StatelessWidget {
     final attack = member.attackStats;
     final defense = member.defenseStats;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-      decoration: BoxDecoration(
-        color:
-            Theme.of(context).cardTheme.color ??
-            Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(AppRadius.chip),
-        border: Border.all(
-          color: Theme.of(
-            context,
-          ).colorScheme.outlineVariant.withValues(alpha: AppOpacity.border),
-        ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: CKSectionPanel(
+        padding: const EdgeInsets.all(12),
         child: Column(
           children: [
             Row(
@@ -771,9 +759,8 @@ class MembersCard extends StatelessWidget {
   }
 }
 
-/// Label/value pair for the member full-stats grid — a card-less sibling of
-/// `CKStatTile`: same layout (icon, label, value) but no background/border, so
-/// a dense 13-item wrap doesn't turn into a wall of boxes.
+/// Adapter for the member full-stats grid so its stats use the shared devkit
+/// tile while keeping the CWL-specific call sites compact.
 class _FlatStat extends StatelessWidget {
   final String label;
   final String value;
@@ -786,40 +773,8 @@ class _FlatStat extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return SizedBox(
-      width: 56,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Center(child: icon),
-          const SizedBox(height: 4),
-          Text(
-            label,
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 2),
-          Text(
-            value,
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(
-              context,
-            ).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
-          ),
-        ],
-      ),
-    );
-  }
+  Widget build(BuildContext context) =>
+      CKStatTile(label: label, value: value, icon: icon);
 }
 
 class _MemberFullStatsToggle extends StatelessWidget {

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_round_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_round_card.dart
@@ -5,6 +5,7 @@ import 'package:clashkingapp/features/war_cwl/models/war_info.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/war/war.dart';
 import 'package:flutter/material.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
+import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:intl/intl.dart';
 
 class RoundClanCard extends StatelessWidget {
@@ -15,236 +16,213 @@ class RoundClanCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) =>
-                WarScreen(war: warInfo, cwlRoundNumber: roundNumber),
-          ),
-        );
-      },
-      child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-        decoration: BoxDecoration(
-          color:
-              Theme.of(context).cardTheme.color ??
-              Theme.of(context).colorScheme.surface,
-          borderRadius: BorderRadius.circular(AppRadius.chip),
-          border: Border.all(
-            color: Theme.of(
-              context,
-            ).colorScheme.outlineVariant.withValues(alpha: AppOpacity.border),
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.only(right: 8.0, top: 8.0, bottom: 8.0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                flex: 4,
-                child: Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          height: 50,
-                          width: 50,
-                          child: MobileWebImage(
-                            errorWidget: (context, url, error) =>
-                                Icon(Icons.error),
-                            imageUrl: warInfo.clan!.badgeUrls.small,
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: CKSectionPanel(
+        padding: const EdgeInsets.only(right: 8, top: 8, bottom: 8),
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) =>
+                  WarScreen(war: warInfo, cwlRoundNumber: roundNumber),
+            ),
+          );
+        },
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 4,
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        height: 50,
+                        width: 50,
+                        child: MobileWebImage(
+                          errorWidget: (context, url, error) =>
+                              Icon(Icons.error),
+                          imageUrl: warInfo.clan!.badgeUrls.small,
+                        ),
+                      ),
+                      Column(
+                        children: [
+                          Row(
+                            children: [
+                              SizedBox(
+                                child: MobileWebImage(
+                                  errorWidget: (context, url, error) =>
+                                      Icon(Icons.error),
+                                  imageUrl: ImageAssets.sword,
+                                  width: 12,
+                                  height: 12,
+                                ),
+                              ),
+                              Text(
+                                "${warInfo.clan!.attacks}/${warInfo.teamSize.toString()}",
+                                style: Theme.of(context).textTheme.labelMedium,
+                              ),
+                            ],
                           ),
-                        ),
-                        Column(
-                          children: [
-                            Row(
-                              children: [
-                                SizedBox(
-                                  child: MobileWebImage(
-                                    errorWidget: (context, url, error) =>
-                                        Icon(Icons.error),
-                                    imageUrl: ImageAssets.sword,
-                                    width: 12,
-                                    height: 12,
-                                  ),
+                          Row(
+                            children: [
+                              SizedBox(
+                                child: MobileWebImage(
+                                  errorWidget: (context, url, error) =>
+                                      Icon(Icons.error),
+                                  imageUrl: ImageAssets.hitrate,
+                                  width: 12,
+                                  height: 12,
                                 ),
-                                Text(
-                                  "${warInfo.clan!.attacks}/${warInfo.teamSize.toString()}",
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.labelMedium,
-                                ),
-                              ],
-                            ),
-                            Row(
-                              children: [
-                                SizedBox(
-                                  child: MobileWebImage(
-                                    errorWidget: (context, url, error) =>
-                                        Icon(Icons.error),
-                                    imageUrl: ImageAssets.hitrate,
-                                    width: 12,
-                                    height: 12,
-                                  ),
-                                ),
-                                Text(
-                                  " ${warInfo.clan!.destructionPercentage.toStringAsFixed(2)}",
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.labelMedium,
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    Text(
-                      warInfo.clan!.name,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
+                              ),
+                              Text(
+                                " ${warInfo.clan!.destructionPercentage.toStringAsFixed(2)}",
+                                style: Theme.of(context).textTheme.labelMedium,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  Text(
+                    warInfo.clan!.name,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
               ),
-              Expanded(
-                flex: 2,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      warInfo.state == "preparation"
-                          ? "Starts at ${DateFormat('HH:mm').format(warInfo.startTime!.toLocal())}"
-                          : warInfo.state == "inWar"
-                          ? "Ends at ${DateFormat('HH:mm').format(warInfo.endTime!.toLocal())}"
-                          : getEndedAgoText(warInfo.endTime, context),
-                      style: Theme.of(context).textTheme.bodyMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    Builder(
-                      builder: (context) {
-                        final clanWon =
-                            warInfo.clan!.stars > warInfo.opponent!.stars ||
-                            (warInfo.clan!.stars == warInfo.opponent!.stars &&
-                                warInfo.clan!.destructionPercentage >
-                                    warInfo.opponent!.destructionPercentage);
-                        final opponentWon =
-                            warInfo.opponent!.stars > warInfo.clan!.stars ||
-                            (warInfo.opponent!.stars == warInfo.clan!.stars &&
-                                warInfo.opponent!.destructionPercentage >
-                                    warInfo.clan!.destructionPercentage);
+            ),
+            Expanded(
+              flex: 2,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    warInfo.state == "preparation"
+                        ? "Starts at ${DateFormat('HH:mm').format(warInfo.startTime!.toLocal())}"
+                        : warInfo.state == "inWar"
+                        ? "Ends at ${DateFormat('HH:mm').format(warInfo.endTime!.toLocal())}"
+                        : getEndedAgoText(warInfo.endTime, context),
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  Builder(
+                    builder: (context) {
+                      final clanWon =
+                          warInfo.clan!.stars > warInfo.opponent!.stars ||
+                          (warInfo.clan!.stars == warInfo.opponent!.stars &&
+                              warInfo.clan!.destructionPercentage >
+                                  warInfo.opponent!.destructionPercentage);
+                      final opponentWon =
+                          warInfo.opponent!.stars > warInfo.clan!.stars ||
+                          (warInfo.opponent!.stars == warInfo.clan!.stars &&
+                              warInfo.opponent!.destructionPercentage >
+                                  warInfo.clan!.destructionPercentage);
 
-                        // Bold, not just tinted green - a colorblind user
-                        // shouldn't need to tell winner from loser by hue.
-                        return Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              "${warInfo.clan!.stars}",
-                              style: Theme.of(context).textTheme.bodyLarge
-                                  ?.copyWith(
-                                    color: clanWon ? StatColors.win : null,
-                                    fontWeight: clanWon
-                                        ? FontWeight.bold
-                                        : null,
-                                  ),
-                            ),
-                            const Text(" - "),
-                            Text(
-                              "${warInfo.opponent!.stars}",
-                              style: Theme.of(context).textTheme.bodyLarge
-                                  ?.copyWith(
-                                    color: opponentWon ? StatColors.win : null,
-                                    fontWeight: opponentWon
-                                        ? FontWeight.bold
-                                        : null,
-                                  ),
-                            ),
-                          ],
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ),
-              Expanded(
-                flex: 4,
-                child: Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Column(
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text(
-                                  "${warInfo.opponent!.attacks}/${warInfo.teamSize.toString()}",
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.labelMedium,
+                      // Bold, not just tinted green - a colorblind user
+                      // shouldn't need to tell winner from loser by hue.
+                      return Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            "${warInfo.clan!.stars}",
+                            style: Theme.of(context).textTheme.bodyLarge
+                                ?.copyWith(
+                                  color: clanWon ? StatColors.win : null,
+                                  fontWeight: clanWon ? FontWeight.bold : null,
                                 ),
-                                SizedBox(
-                                  child: MobileWebImage(
-                                    errorWidget: (context, url, error) =>
-                                        Icon(Icons.error),
-                                    imageUrl:
-                                        "https://assets.clashk.ing/icons/Icon_HV_Sword.png",
-                                    width: 12,
-                                    height: 12,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text(
-                                  "${warInfo.opponent!.destructionPercentage.toStringAsFixed(2)} ",
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.labelMedium,
-                                ),
-                                SizedBox(
-                                  child: MobileWebImage(
-                                    errorWidget: (context, url, error) =>
-                                        Icon(Icons.error),
-                                    imageUrl:
-                                        "https://assets.clashk.ing/icons/Icon_DC_Hitrate.png",
-                                    width: 12,
-                                    height: 12,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                        SizedBox(
-                          height: 50,
-                          width: 50,
-                          child: MobileWebImage(
-                            errorWidget: (context, url, error) =>
-                                Icon(Icons.error),
-                            imageUrl: warInfo.opponent!.badgeUrls.small,
                           ),
-                        ),
-                      ],
-                    ),
-                    Text(
-                      warInfo.opponent!.name,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
+                          const Text(" - "),
+                          Text(
+                            "${warInfo.opponent!.stars}",
+                            style: Theme.of(context).textTheme.bodyLarge
+                                ?.copyWith(
+                                  color: opponentWon ? StatColors.win : null,
+                                  fontWeight: opponentWon
+                                      ? FontWeight.bold
+                                      : null,
+                                ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+            Expanded(
+              flex: 4,
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Column(
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                "${warInfo.opponent!.attacks}/${warInfo.teamSize.toString()}",
+                                style: Theme.of(context).textTheme.labelMedium,
+                              ),
+                              SizedBox(
+                                child: MobileWebImage(
+                                  errorWidget: (context, url, error) =>
+                                      Icon(Icons.error),
+                                  imageUrl:
+                                      "https://assets.clashk.ing/icons/Icon_HV_Sword.png",
+                                  width: 12,
+                                  height: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                "${warInfo.opponent!.destructionPercentage.toStringAsFixed(2)} ",
+                                style: Theme.of(context).textTheme.labelMedium,
+                              ),
+                              SizedBox(
+                                child: MobileWebImage(
+                                  errorWidget: (context, url, error) =>
+                                      Icon(Icons.error),
+                                  imageUrl:
+                                      "https://assets.clashk.ing/icons/Icon_DC_Hitrate.png",
+                                  width: 12,
+                                  height: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                      SizedBox(
+                        height: 50,
+                        width: 50,
+                        child: MobileWebImage(
+                          errorWidget: (context, url, error) =>
+                              Icon(Icons.error),
+                          imageUrl: warInfo.opponent!.badgeUrls.small,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    warInfo.opponent!.name,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
@@ -1,4 +1,3 @@
-import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/icons/build_stars.dart';
 import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
@@ -9,6 +8,7 @@ import 'package:clashkingapp/features/clan/presentation/clan_info/clan_page.dart
 import 'package:clashkingapp/features/war_cwl/models/cwl_clan.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_cwl.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -33,21 +33,10 @@ class CwlTeamCard extends StatelessWidget {
       (a, b) => int.parse(b.key).compareTo(int.parse(a.key)),
     );
 
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-      decoration: BoxDecoration(
-        color:
-            Theme.of(context).cardTheme.color ??
-            Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(AppRadius.chip),
-        border: Border.all(
-          color: Theme.of(
-            context,
-          ).colorScheme.outlineVariant.withValues(alpha: AppOpacity.border),
-        ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: CKSectionPanel(
+        padding: const EdgeInsets.all(8),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [

--- a/lib/features/war_cwl/presentation/war/war.dart
+++ b/lib/features/war_cwl/presentation/war/war.dart
@@ -347,10 +347,12 @@ class _WarScreenState extends State<WarScreen> {
                 children: [
                   AppGlassSegmentedControl<int>(
                     values: const [1, 2],
-                    labels: [loc.warMyTeam, loc.warEnemiesTeam],
+                    labels: [
+                      widget.war.clan?.name ?? loc.clanTitle,
+                      widget.war.opponent?.name ?? loc.capitalOpponentsSection,
+                    ],
                     selected: _currentSegment,
                     height: 44,
-                    foregroundColor: Theme.of(context).colorScheme.primary,
                     onChanged: (v) {
                       setState(() {
                         _currentSegment = v;

--- a/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
+++ b/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
@@ -8,15 +8,11 @@ import 'package:clashkingapp/features/war_cwl/data/war_functions.dart'
     show countStars;
 import 'package:clashkingapp/features/war_cwl/models/war_clan.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_info.dart';
-import 'package:clashkingapp/features/war_cwl/models/war_member.dart';
 import 'package:clashkingapp/features/war_cwl/presentation/war/widgets/war_calculator_card.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/common/widgets/empty_state.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-const _frenchStarSingular = 'étoile';
-const _frenchStarPlural = 'étoiles';
 
 class WarStatisticsTab extends StatefulWidget {
   const WarStatisticsTab({super.key, required this.warInfo});
@@ -230,88 +226,96 @@ class _WarStatisticsTabState extends State<WarStatisticsTab> {
     );
     if (earlyResult != null) return earlyResult;
 
-    final tiedNow =
-        clanState.currentScore.compareTo(opponentState.currentScore) == 0;
-    if (tiedNow) {
+    return _secureWinAnalysis(
+      copy: copy,
+      clan: clan,
+      opponent: opponent,
+      clanState: clanState,
+      opponentState: opponentState,
+    );
+  }
+
+  _WarAnalysisResult _secureWinAnalysis({
+    required _WarAnalysisCopy copy,
+    required WarClan clan,
+    required WarClan opponent,
+    required _WarSideState clanState,
+    required _WarSideState opponentState,
+  }) {
+    final alreadySecured =
+        clanState.currentScore.compareTo(opponentState.potentialScore) > 0;
+    final canSecure = clanState.canBeat(opponentState.potentialScore);
+
+    if (alreadySecured) {
       return _WarAnalysisResult(
-        status: _WarAnalysisStatus.live,
-        headline: copy.warStillOpen(),
-        lines: [
-          copy.currentDraw(),
-          copy.remainingAttempts(clanState.remainingAttacks),
-          copy.remainingAttempts(opponentState.remainingAttacks),
-        ],
-      );
-    }
-
-    final clanIsAhead = _isAhead(clan, opponent);
-    final leader = clanIsAhead ? clan : opponent;
-    final chaser = clanIsAhead ? opponent : clan;
-    final leaderState = clanIsAhead ? clanState : opponentState;
-    final chaserState = clanIsAhead ? opponentState : clanState;
-    final targetMembers = clanIsAhead ? clan.members : opponent.members;
-    final chaserCanWin = chaserState.canBeat(leaderState.currentScore);
-    final chaserCanTie = chaserState.canTie(leaderState.currentScore);
-
-    if (leaderState.isPerfect && !chaserState.isPerfect) {
-      if (chaserCanTie) {
-        return _drawOnlyAnalysis(
-          copy: copy,
-          leader: leader,
-          chaser: chaser,
-          chaserState: chaserState,
-          targetMembers: targetMembers,
-        );
-      }
-
-      return _advantageAnalysis(
-        copy: copy,
-        leader: leader,
-        chaser: chaser,
-        chaserState: chaserState,
-        targetScore: leaderState.currentScore,
-        targetMembers: targetMembers,
-        chaserCanTie: false,
-      );
-    }
-
-    if (chaserCanWin) {
-      return _WarAnalysisResult(
-        status: _WarAnalysisStatus.live,
-        headline: copy.warStillOpen(),
-        lines: [
-          copy.currentLeader(leader.name),
-          ..._objectiveLines(
-            copy: copy,
-            actor: chaser,
-            actorState: chaserState,
-            targetScore: leaderState.currentScore,
-            targetMembers: targetMembers,
-            allowWin: true,
+        status: _WarAnalysisStatus.advantage,
+        headline: copy.cannotLose(clan.name),
+        badge: copy.secured(),
+        sections: [
+          _WarAnalysisSection(
+            title: copy.toLead(),
+            lines: [copy.alreadySecured()],
           ),
         ],
+        lines: [copy.alreadySecured()],
       );
     }
 
-    if (chaserCanTie) {
-      return _drawOnlyAnalysis(
-        copy: copy,
-        leader: leader,
-        chaser: chaser,
-        chaserState: chaserState,
-        targetMembers: targetMembers,
-      );
-    }
-
-    return _advantageAnalysis(
+    final objective = _secureWinObjective(
       copy: copy,
-      leader: leader,
-      chaser: chaser,
-      chaserState: chaserState,
-      targetScore: leaderState.currentScore,
-      targetMembers: targetMembers,
-      chaserCanTie: false,
+      actorState: clanState,
+      targetScore: opponentState.potentialScore,
     );
+
+    return _WarAnalysisResult(
+      status: canSecure ? _WarAnalysisStatus.live : _WarAnalysisStatus.locked,
+      headline: copy.warStillOpen(),
+      summary: canSecure
+          ? copy.secureAgainst(opponent.name)
+          : copy.cannotSecureAgainst(opponent.name),
+      sections: [
+        _WarAnalysisSection(title: copy.toLead(), lines: [objective]),
+      ],
+      lines: [objective],
+    );
+  }
+
+  String _secureWinObjective({
+    required _WarAnalysisCopy copy,
+    required _WarSideState actorState,
+    required _WarScore targetScore,
+  }) {
+    final starsForWin = (targetScore.stars + 1 - actorState.currentScore.stars)
+        .clamp(0, actorState.maxStars)
+        .toInt();
+    final canWinByStars = actorState.potentialScore.stars > targetScore.stars;
+    if (canWinByStars && starsForWin > 0) {
+      return copy.starGoal(starsForWin);
+    }
+
+    final starsForTie = (targetScore.stars - actorState.currentScore.stars)
+        .clamp(0, actorState.maxStars)
+        .toInt();
+    final destructionForLead = math.max(
+      0.0,
+      targetScore.destruction - actorState.currentScore.destruction + 0.01,
+    );
+    final canWinByDestruction =
+        actorState.potentialScore.stars >= targetScore.stars &&
+        actorState.potentialScore.destruction > targetScore.destruction;
+
+    if (canWinByDestruction && destructionForLead > 0.004) {
+      if (starsForTie > 0) {
+        return '${copy.starGoal(starsForTie)} · ${copy.destructionGoal(copy.percentPoints(destructionForLead))}';
+      }
+      return copy.destructionGoal(copy.percentPoints(destructionForLead));
+    }
+
+    if (starsForTie > 0) {
+      return copy.starGoal(starsForTie);
+    }
+
+    return copy.noSecureObjective();
   }
 
   _WarAnalysisResult? _earlyWarAnalysis({
@@ -349,167 +353,6 @@ class _WarStatisticsTabState extends State<WarStatisticsTab> {
         opponent.stars == 0 &&
         clan.destructionPercentage == 0.0 &&
         opponent.destructionPercentage == 0.0;
-  }
-
-  _WarAnalysisResult _advantageAnalysis({
-    required _WarAnalysisCopy copy,
-    required WarClan leader,
-    required WarClan chaser,
-    required _WarSideState chaserState,
-    required _WarScore targetScore,
-    required List<WarMember> targetMembers,
-    required bool chaserCanTie,
-  }) {
-    return _WarAnalysisResult(
-      status: _WarAnalysisStatus.advantage,
-      headline: copy.cannotLose(leader.name),
-      lines: [
-        if (chaserCanTie) copy.canStillTie(chaser.name),
-        if (!chaserCanTie) copy.cannotCatchUp(chaser.name),
-        ..._objectiveLines(
-          copy: copy,
-          actor: chaser,
-          actorState: chaserState,
-          targetScore: targetScore,
-          targetMembers: targetMembers,
-          allowWin: false,
-        ),
-      ],
-    );
-  }
-
-  _WarAnalysisResult _drawOnlyAnalysis({
-    required _WarAnalysisCopy copy,
-    required WarClan leader,
-    required WarClan chaser,
-    required _WarSideState chaserState,
-    required List<WarMember> targetMembers,
-  }) {
-    return _WarAnalysisResult(
-      status: _WarAnalysisStatus.drawOnly,
-      headline: copy.cannotLose(leader.name),
-      lines: [
-        copy.canStillTie(chaser.name),
-        copy.objectivePerfectWar(),
-        ..._perfectObjectiveLines(
-          copy: copy,
-          chaserState: chaserState,
-          targetMembers: targetMembers,
-        ),
-      ],
-    );
-  }
-
-  List<String> _perfectObjectiveLines({
-    required _WarAnalysisCopy copy,
-    required _WarSideState chaserState,
-    required List<WarMember> targetMembers,
-  }) {
-    final lines = <String>[];
-    final starsNeeded = (chaserState.maxStars - chaserState.currentScore.stars)
-        .clamp(0, chaserState.maxStars)
-        .toInt();
-    final destructionNeeded = math.max(
-      0.0,
-      100.0 - chaserState.currentScore.destruction,
-    );
-
-    if (starsNeeded > 0) {
-      lines.add(copy.starsOnUntripledBases(starsNeeded));
-    }
-    if (destructionNeeded > 0.004) {
-      lines.add(copy.destructionPoints(copy.percentPoints(destructionNeeded)));
-    }
-    lines.add(copy.remainingAttempts(chaserState.remainingAttacks));
-    lines.addAll(_opportunityLines(copy, targetMembers));
-    return lines;
-  }
-
-  List<String> _objectiveLines({
-    required _WarAnalysisCopy copy,
-    required WarClan actor,
-    required _WarSideState actorState,
-    required _WarScore targetScore,
-    required List<WarMember> targetMembers,
-    required bool allowWin,
-  }) {
-    final lines = <String>[];
-    final starsForWin = (targetScore.stars + 1 - actorState.currentScore.stars)
-        .clamp(0, actorState.maxStars)
-        .toInt();
-    final starsForTie = (targetScore.stars - actorState.currentScore.stars)
-        .clamp(0, actorState.maxStars)
-        .toInt();
-    final destructionForLead = math.max(
-      0.0,
-      targetScore.destruction - actorState.currentScore.destruction + 0.01,
-    );
-    final canLeadByDestruction =
-        allowWin &&
-        actorState.potentialScore.stars >= targetScore.stars &&
-        actorState.potentialScore.destruction > targetScore.destruction;
-
-    if (canLeadByDestruction) {
-      if (starsForTie > 0) {
-        lines.add(copy.starsToTie(actor.name, starsForTie));
-      }
-      if (destructionForLead > 0.004) {
-        lines.add(
-          copy.destructionToLead(copy.percentPoints(destructionForLead)),
-        );
-      }
-    } else if (allowWin && starsForWin > 0) {
-      lines.add(copy.starsToWin(actor.name, starsForWin));
-    } else if (starsForTie > 0) {
-      lines.add(copy.starsToTie(actor.name, starsForTie));
-    } else if (destructionForLead > 0.004) {
-      lines.add(copy.destructionToLead(copy.percentPoints(destructionForLead)));
-    }
-
-    lines.add(copy.remainingAttempts(actorState.remainingAttacks));
-    lines.addAll(_opportunityLines(copy, targetMembers));
-    return lines;
-  }
-
-  List<String> _opportunityLines(
-    _WarAnalysisCopy copy,
-    List<WarMember> targetMembers,
-  ) {
-    final opportunities =
-        targetMembers
-            .where(
-              (member) =>
-                  member.bestOpponentAttack == null ||
-                  member.bestOpponentAttack!.stars < 3 ||
-                  member.bestOpponentAttack!.destructionPercentage < 100,
-            )
-            .toList()
-          ..sort((a, b) {
-            final aAttack = a.bestOpponentAttack;
-            final bAttack = b.bestOpponentAttack;
-            final starCompare = (bAttack?.stars ?? 0).compareTo(
-              aAttack?.stars ?? 0,
-            );
-            if (starCompare != 0) return starCompare;
-            final destructionCompare = (bAttack?.destructionPercentage ?? 0)
-                .compareTo(aAttack?.destructionPercentage ?? 0);
-            if (destructionCompare != 0) return destructionCompare;
-            return a.mapPosition.compareTo(b.mapPosition);
-          });
-
-    return opportunities.take(2).map((member) {
-      final attack = member.bestOpponentAttack;
-      return copy.opportunity(
-        member.mapPosition,
-        attack?.stars ?? 0,
-        attack?.destructionPercentage ?? 0,
-      );
-    }).toList();
-  }
-
-  bool _isAhead(WarClan clan, WarClan opponent) {
-    if (clan.stars != opponent.stars) return clan.stars > opponent.stars;
-    return clan.destructionPercentage > opponent.destructionPercentage;
   }
 }
 
@@ -578,6 +421,7 @@ class _WarAnalysis extends StatelessWidget {
       _WarAnalysisStatus.waiting => colorScheme.primary,
     };
     final visibleLines = analysis.lines.take(5).toList(growable: false);
+    final visibleSections = analysis.sections ?? const <_WarAnalysisSection>[];
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -587,54 +431,118 @@ class _WarAnalysis extends StatelessWidget {
             MobileWebImage(imageUrl: ImageAssets.war, width: 22, height: 22),
             const SizedBox(width: 8),
             Expanded(child: _SectionTitle(label: title)),
+            if (analysis.badge != null) ...[
+              const SizedBox(width: 8),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.16),
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: accent.withValues(alpha: 0.32)),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 5,
+                  ),
+                  child: Text(
+                    analysis.badge!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: accent,
+                      fontWeight: FontWeight.w900,
+                      height: 1,
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
         const SizedBox(height: 10),
-        Row(
-          children: [
-            Container(
-              width: 4,
-              height: 44,
-              decoration: BoxDecoration(
-                color: accent,
-                borderRadius: BorderRadius.circular(999),
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    analysis.headline,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                      color: colorScheme.onSurface,
-                      fontWeight: FontWeight.w900,
-                      height: 1.1,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  for (var index = 0; index < visibleLines.length; index++) ...[
-                    Text(
-                      visibleLines[index],
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w700,
-                        height: 1.2,
-                      ),
-                    ),
-                    if (index < visibleLines.length - 1)
-                      const SizedBox(height: 3),
-                  ],
-                ],
-              ),
-            ),
-          ],
+        Text(
+          analysis.headline,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.w900,
+            height: 1.1,
+          ),
         ),
+        if (analysis.summary != null) ...[
+          const SizedBox(height: 5),
+          Text(
+            analysis.summary!,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+              height: 1.25,
+            ),
+          ),
+        ],
+        if (visibleSections.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          for (var index = 0; index < visibleSections.length; index++) ...[
+            _WarAnalysisSectionView(section: visibleSections[index]),
+            if (index < visibleSections.length - 1) const SizedBox(height: 8),
+          ],
+        ] else ...[
+          const SizedBox(height: 4),
+          for (var index = 0; index < visibleLines.length; index++) ...[
+            Text(
+              visibleLines[index],
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w700,
+                height: 1.2,
+              ),
+            ),
+            if (index < visibleLines.length - 1) const SizedBox(height: 3),
+          ],
+        ],
+      ],
+    );
+  }
+}
+
+class _WarAnalysisSectionView extends StatelessWidget {
+  final _WarAnalysisSection section;
+
+  const _WarAnalysisSectionView({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          section.title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.w900,
+            height: 1.1,
+          ),
+        ),
+        const SizedBox(height: 3),
+        for (final line in section.lines)
+          Text(
+            line,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w700,
+              height: 1.25,
+            ),
+          ),
       ],
     );
   }
@@ -645,13 +553,26 @@ enum _WarAnalysisStatus { live, advantage, drawOnly, locked, waiting }
 class _WarAnalysisResult {
   final _WarAnalysisStatus status;
   final String headline;
+  final String? badge;
+  final String? summary;
+  final List<_WarAnalysisSection>? sections;
   final List<String> lines;
 
   const _WarAnalysisResult({
     required this.status,
     required this.headline,
+    this.badge,
+    this.summary,
+    this.sections,
     required this.lines,
   });
+}
+
+class _WarAnalysisSection {
+  final String title;
+  final List<String> lines;
+
+  const _WarAnalysisSection({required this.title, required this.lines});
 }
 
 class _WarScore {
@@ -778,57 +699,31 @@ class _WarAnalysisCopy {
 
   bool get _fr => loc.localeName.startsWith('fr');
 
-  String warStillOpen() => _fr ? 'Guerre encore ouverte' : 'War still open';
+  String warStillOpen() => loc.warOngoing;
 
-  String currentLeader(String clan) =>
-      _fr ? '$clan mène actuellement' : '$clan is currently ahead';
+  String cannotLose(String clan) => loc.warAnalysisCannotLose(clan);
 
-  String currentDraw() =>
-      _fr ? 'Les deux clans sont à égalité' : 'Both clans are tied';
+  String secured() => loc.warAnalysisSecuredBadge;
 
-  String cannotLose(String clan) =>
-      _fr ? '$clan ne peut plus perdre' : '$clan can no longer lose';
+  String alreadySecured() => loc.warAnalysisAlreadySecured;
 
-  String canStillTie(String clan) =>
-      _fr ? '$clan peut encore égaliser' : '$clan can still tie';
+  String secureAgainst(String clan) => loc.warAnalysisSecureAgainst(clan);
 
-  String cannotCatchUp(String clan) => loc.warCannotCatchUp(clan);
+  String cannotSecureAgainst(String clan) =>
+      loc.warAnalysisCannotSecureAgainst(clan);
 
-  String objectivePerfectWar() =>
-      _fr ? 'Objectif: guerre parfaite' : 'Objective: perfect war';
+  String noSecureObjective() => loc.warAnalysisNoSecureObjective;
 
-  String starsOnUntripledBases(int stars) => _fr
-      ? '+$stars ${_plural(stars, _frenchStarSingular, _frenchStarPlural)} sur ${_plural(stars, 'une base non triplée', 'des bases non triplées')}'
-      : '+$stars ${_plural(stars, 'star', 'stars')} on untripled bases';
+  String toLead() => loc.warAnalysisToWin;
 
-  String starsToWin(String clan, int stars) => _fr
-      ? '$clan doit gagner +$stars ${_plural(stars, _frenchStarSingular, _frenchStarPlural)}'
-      : '$clan needs +$stars ${_plural(stars, 'star', 'stars')} to take the lead';
+  String starGoal(int stars) => loc.warAnalysisStarGoal(stars);
 
-  String starsToTie(String clan, int stars) => _fr
-      ? '$clan doit gagner +$stars ${_plural(stars, _frenchStarSingular, _frenchStarPlural)} pour égaliser'
-      : '$clan needs +$stars ${_plural(stars, 'star', 'stars')} to tie';
+  String destructionGoal(String percent) => '+$percent%';
 
-  String destructionToLead(String points) {
-    final pointWord = points == '1' ? 'point' : 'points';
-    return _fr
-        ? '+$points pt de destruction pour passer devant'
-        : '+$points destruction $pointWord to lead';
-  }
+  String remainingAttempts(int attacks) =>
+      loc.warAnalysisRemainingAttempts(attacks);
 
-  String destructionPoints(String points) =>
-      _fr ? '+$points pt de destruction' : '+$points destruction points';
-
-  String remainingAttempts(int attacks) => _fr
-      ? '$attacks ${_plural(attacks, 'tentative restante', 'tentatives restantes')}'
-      : '$attacks ${_plural(attacks, 'attempt', 'attempts')} left';
-
-  String opportunity(int mapPosition, int stars, int destruction) => _fr
-      ? '#$mapPosition: déjà $stars ${_plural(stars, _frenchStarSingular, _frenchStarPlural)}, $destruction%'
-      : '#$mapPosition: currently $stars ${_plural(stars, 'star', 'stars')}, $destruction%';
-
-  String noBetterResult() =>
-      _fr ? 'Aucun meilleur résultat possible' : 'No better result is possible';
+  String noBetterResult() => loc.warAnalysisNoBetterResult;
 
   String percentPoints(double value) {
     final text = value >= 10
@@ -836,8 +731,6 @@ class _WarAnalysisCopy {
         : value.toStringAsFixed(2);
     return _fr ? text.replaceFirst('.', ',') : text;
   }
-
-  String _plural(int count, String one, String many) => count == 1 ? one : many;
 }
 
 class _CalculatorActionButton extends StatelessWidget {

--- a/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
+++ b/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
@@ -243,7 +243,7 @@ class _WarStatisticsTabState extends State<WarStatisticsTab> {
     required _WarSideState opponentState,
   }) {
     final alreadySecured =
-        clanState.currentScore.compareTo(opponentState.potentialScore) > 0;
+        clanState.currentScore.compareTo(opponentState.potentialScore) >= 0;
     final canSecure = clanState.canBeat(opponentState.potentialScore);
 
     if (alreadySecured) {
@@ -253,7 +253,7 @@ class _WarStatisticsTabState extends State<WarStatisticsTab> {
         badge: copy.secured(),
         sections: [
           _WarAnalysisSection(
-            title: copy.toLead(),
+            title: copy.situation(),
             lines: [copy.alreadySecured()],
           ),
         ],
@@ -713,6 +713,8 @@ class _WarAnalysisCopy {
       loc.warAnalysisCannotSecureAgainst(clan);
 
   String noSecureObjective() => loc.warAnalysisNoSecureObjective;
+
+  String situation() => loc.warDataState;
 
   String toLead() => loc.warAnalysisToWin;
 

--- a/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
+++ b/lib/features/war_cwl/presentation/war/war_statistics_tab.dart
@@ -285,6 +285,10 @@ class _WarStatisticsTabState extends State<WarStatisticsTab> {
     required _WarSideState actorState,
     required _WarScore targetScore,
   }) {
+    if (!actorState.canBeat(targetScore)) {
+      return copy.noSecureObjective();
+    }
+
     final starsForWin = (targetScore.stars + 1 - actorState.currentScore.stars)
         .clamp(0, actorState.maxStars)
         .toInt();

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50,00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1017,6 +1017,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3985,21 +3985,59 @@
   "farmGoalLootTitle": "Estimated loot",
   "farmGoalResourceLabel": "Resource",
   "farmGoalAmountLabel": "Amount to farm",
-  "farmGoalAverageLootLabel": "Average loot per raid",
-  "farmGoalLeagueEstimate": "Suggested from the {league} league bonus. You can adjust it.",
+  "farmGoalAverageLootLabel": "Loot from a perfect attack",
+  "farmGoalPerfectLootHint": "Starting point for a perfect attack. Adjust it to match your actual loot.",
+  "farmGoalLeagueEstimate": "{league} base league bonus: {amount} {resource}. It is not the total loot from an attack.",
   "@farmGoalLeagueEstimate": {
     "placeholders": {
       "league": {
         "type": "String"
+      },
+      "amount": {
+        "type": "String"
+      },
+      "resource": {
+        "type": "String"
       }
     }
   },
+  "farmGoalStarBonusEstimate": "Star bonus: {amount} {resource} after 5 stars. It is not included in attacks needed.",
+  "@farmGoalStarBonusEstimate": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      },
+      "resource": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalScenarioPerfect": "Perfect attack · 100%",
+  "farmGoalScenarioAtPercent": "{percent}% destruction",
+  "@farmGoalScenarioAtPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalAttackShort": "attack",
+  "farmGoalScenarioHint": "Approximation: loot varies by building destroyed. Percentages apply to your perfect-attack estimate.",
   "farmGoalNoLeagueLoot": "Choose an account with a league to get a loot suggestion.",
-  "farmGoalMissingTarget": "Choose a building and target level to calculate the required raids.",
-  "farmGoalMissingValues": "Enter an amount and an average loot value to see the number of raids.",
-  "farmGoalResultTitle": "Raids needed",
-  "farmGoalRaids": "raids",
-  "farmGoalResultSummary": "{target} {resource} at about {average} per raid.",
+  "farmGoalTrackerSuggestion": "Upgrade Tracker suggests {name}.",
+  "@farmGoalTrackerSuggestion": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalUseTrackerTarget": "Use target",
+  "farmGoalMissingTarget": "Choose a building and target level to calculate the required attacks.",
+  "farmGoalMissingValues": "Enter a target and a perfect-attack loot estimate to see the attack scenarios.",
+  "farmGoalResultTitle": "Attacks needed",
+  "farmGoalAttacks": "attacks",
+  "farmGoalResultSummary": "{target} {resource} with about {average} per perfect attack.",
   "@farmGoalResultSummary": {
     "placeholders": {
       "target": {
@@ -4081,6 +4119,7 @@
   "damageCalculatorTitle": "Damage Calculator",
   "damageAccountPresetShort": "Account",
   "damageChooseAccount": "Choose an account",
+  "damageSwitchAccount": "Switch account",
   "damageAccountSelectorHint": "The levels used follow the selected account.",
   "damageNoAccountsAvailable": "No verified account available",
   "damageTargetSectionTitle": "Building to destroy",
@@ -4097,26 +4136,11 @@
   "damageQuickSetupFlameFlinger": "Flame Flinger",
   "damageQuickSetupCustom": "Custom",
   "damageClearStack": "Clear",
-  "damageSummaryTarget": "Target",
-  "damageSummaryAttack": "Damage",
-  "damageSummaryResult": "Result",
-  "damageSummaryPending": "Pending",
   "damageNoDamageSelected": "No damage",
   "damageSelectedSourcesCount": "{count} source(s)",
   "@damageSelectedSourcesCount": {
     "placeholders": {
       "count": {
-        "type": "int"
-      }
-    }
-  },
-  "damageDestroyedCount": "{destroyed}/{total} destroyed",
-  "@damageDestroyedCount": {
-    "placeholders": {
-      "destroyed": {
-        "type": "int"
-      },
-      "total": {
         "type": "int"
       }
     }

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1005,6 +1005,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_es_ES.arb
+++ b/lib/l10n/app_es_ES.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3975,21 +3975,59 @@
   "farmGoalLootTitle": "Butin estimé",
   "farmGoalResourceLabel": "Ressource",
   "farmGoalAmountLabel": "Montant à obtenir",
-  "farmGoalAverageLootLabel": "Butin moyen par raid",
-  "farmGoalLeagueEstimate": "Suggestion basée sur le bonus de la ligue {league}. Tu peux l'ajuster.",
+  "farmGoalAverageLootLabel": "Butin d'une attaque parfaite",
+  "farmGoalPerfectLootHint": "Point de départ pour une attaque parfaite. Ajuste-le selon ton butin réel.",
+  "farmGoalLeagueEstimate": "Bonus de base de la ligue {league} : {amount} {resource}. Il ne représente pas le butin total d'une attaque.",
   "@farmGoalLeagueEstimate": {
     "placeholders": {
       "league": {
         "type": "String"
+      },
+      "amount": {
+        "type": "String"
+      },
+      "resource": {
+        "type": "String"
       }
     }
   },
+  "farmGoalStarBonusEstimate": "Bonus d'étoiles : {amount} {resource} après 5 étoiles. Il n'est pas inclus dans le nombre d'attaques.",
+  "@farmGoalStarBonusEstimate": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      },
+      "resource": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalScenarioPerfect": "Attaque parfaite · 100 %",
+  "farmGoalScenarioAtPercent": "{percent} % de destruction",
+  "@farmGoalScenarioAtPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalAttackShort": "attaque",
+  "farmGoalScenarioHint": "Approximation : le butin varie selon les bâtiments détruits. Les pourcentages s'appliquent à ton estimation d'une attaque parfaite.",
   "farmGoalNoLeagueLoot": "Choisis un compte avec une ligue pour obtenir une suggestion de butin.",
-  "farmGoalMissingTarget": "Choisis un bâtiment et un niveau cible pour calculer le nombre de raids nécessaires.",
-  "farmGoalMissingValues": "Renseigne un montant et un butin moyen pour voir le nombre de raids.",
-  "farmGoalResultTitle": "Raids nécessaires",
-  "farmGoalRaids": "raids",
-  "farmGoalResultSummary": "{target} {resource} à environ {average} par raid.",
+  "farmGoalTrackerSuggestion": "Le suivi des améliorations suggère {name}.",
+  "@farmGoalTrackerSuggestion": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "farmGoalUseTrackerTarget": "Utiliser la cible",
+  "farmGoalMissingTarget": "Choisis un bâtiment et un niveau cible pour calculer le nombre d'attaques nécessaires.",
+  "farmGoalMissingValues": "Renseigne une cible et une estimation du butin d'une attaque parfaite pour voir les scénarios.",
+  "farmGoalResultTitle": "Attaques nécessaires",
+  "farmGoalAttacks": "attaques",
+  "farmGoalResultSummary": "{target} {resource} avec environ {average} par attaque parfaite.",
   "@farmGoalResultSummary": {
     "placeholders": {
       "target": {
@@ -4072,6 +4110,7 @@
   "damageCalculatorTitle": "Calculateur de dégâts",
   "damageAccountPresetShort": "Compte",
   "damageChooseAccount": "Choisir un compte",
+  "damageSwitchAccount": "Changer de compte",
   "damageAccountSelectorHint": "Les niveaux utilisés suivent le compte choisi.",
   "damageNoAccountsAvailable": "Aucun compte vérifié disponible",
   "damageTargetSectionTitle": "Bâtiment à détruire",
@@ -4088,26 +4127,11 @@
   "damageQuickSetupFlameFlinger": "Lance-flammes",
   "damageQuickSetupCustom": "Personnalisée",
   "damageClearStack": "Effacer",
-  "damageSummaryTarget": "Cible",
-  "damageSummaryAttack": "Dégâts",
-  "damageSummaryResult": "Résultat",
-  "damageSummaryPending": "À compléter",
   "damageNoDamageSelected": "Aucun dégât",
   "damageSelectedSourcesCount": "{count} source(s)",
   "@damageSelectedSourcesCount": {
     "placeholders": {
       "count": {
-        "type": "int"
-      }
-    }
-  },
-  "damageDestroyedCount": "{destroyed}/{total} détruit(s)",
-  "@damageDestroyedCount": {
-    "placeholders": {
-      "destroyed": {
-        "type": "int"
-      },
-      "total": {
         "type": "int"
       }
     }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -997,6 +997,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} ne peut plus perdre",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Sécurisé",
+  "warAnalysisAlreadySecured": "Déjà sécurisé",
+  "warAnalysisSecureAgainst": "Objectif calculé en supposant que {clanName} utilise toutes ses attaques restantes.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Impossible à sécuriser mathématiquement si {clanName} optimise ses attaques restantes.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Impossible à sécuriser avec les attaques restantes",
+  "warAnalysisStarGoal": "+{stars} étoile(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} tentative(s) restante(s)",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "Aucun meilleur résultat possible",
   "warCalculatorHintPercent": "50,00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_no.arb
+++ b/lib/l10n/app_no.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -958,6 +958,20 @@
       }
     }
   },
+  "warAnalysisCannotLose": "{clanName} can no longer lose",
+  "@warAnalysisCannotLose": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisSecuredBadge": "Secured",
+  "warAnalysisAlreadySecured": "Already secured",
+  "warAnalysisSecureAgainst": "Objective calculated assuming {clanName} uses all remaining attacks.",
+  "@warAnalysisSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisCannotSecureAgainst": "Cannot be mathematically secured if {clanName} optimizes all remaining attacks.",
+  "@warAnalysisCannotSecureAgainst": {"placeholders": {"clanName": {"type": "String"}}},
+  "warAnalysisNoSecureObjective": "Cannot be secured with the remaining attacks",
+  "warAnalysisStarGoal": "+{stars} star(s)",
+  "@warAnalysisStarGoal": {"placeholders": {"stars": {"type": "int"}}},
+  "warAnalysisRemainingAttempts": "{attacks} attack(s) left",
+  "@warAnalysisRemainingAttempts": {"placeholders": {"attacks": {"type": "int"}}},
+  "warAnalysisNoBetterResult": "No better result is possible",
   "warCalculatorHintPercent": "50.00",
   "@warCalculatorHintPercent": {
     "description": "Hint text for percentage input in war calculator"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -180,9 +180,11 @@ packages:
   clashking_design_system:
     dependency: "direct main"
     description:
-      path: "../clashking-devkit/design/packages/flutter"
-      relative: true
-    source: path
+      path: "design/packages/flutter"
+      ref: "codex/shared-devkit-controls"
+      resolved-ref: "27d984dd1c5c7894b93f26b3062c4ded66680be2"
+      url: "https://github.com/ClashKingInc/DevKit.git"
+    source: git
     version: "0.2.0"
   cli_util:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -180,11 +180,9 @@ packages:
   clashking_design_system:
     dependency: "direct main"
     description:
-      path: "design/packages/flutter"
-      ref: "codex/shared-devkit-controls"
-      resolved-ref: ef875eb840e276bd177520dc6b6df9511d1d7927
-      url: "https://github.com/ClashKingInc/DevKit.git"
-    source: git
+      path: "../clashking-devkit/design/packages/flutter"
+      relative: true
+    source: path
     version: "0.2.0"
   cli_util:
     dependency: transitive

--- a/test/core/config/api_config_local_test.dart
+++ b/test/core/config/api_config_local_test.dart
@@ -16,4 +16,11 @@ void main() {
       'http://localhost:8000/proxy/v1',
     );
   });
+
+  test('production API environment targets the public v2 API', () {
+    expect(
+      ApiConfig.defaultApiV2UrlFor(ApiEnvironment.production),
+      'https://v2-api.clashk.ing/v2',
+    );
+  });
 }

--- a/test/features/pages/presentation/calculators_page_test.dart
+++ b/test/features/pages/presentation/calculators_page_test.dart
@@ -14,11 +14,23 @@ void main() {
     await _pump(tester);
 
     expect(find.text('Calculators'), findsOneWidget);
-    expect(find.text('Damage'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('calculator-tabs')),
+        matching: find.text('Damage'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Building to destroy'), findsOneWidget);
     expect(find.text('No building selected'), findsOneWidget);
     expect(find.text('Choose a building'), findsOneWidget);
-    expect(find.text('Custom'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('calculator-quick-setups')),
+        matching: find.text('Custom'),
+      ),
+      findsOneWidget,
+    );
     expect(find.byType(TabBarView), findsNothing);
 
     await tester.tap(find.text('Choose a building'));
@@ -55,19 +67,35 @@ void main() {
       findsNothing,
     );
 
-    await tester.tap(find.text('Air Defense'));
+    await tester.tap(find.text('Air Defense').first);
     await tester.pumpAndSettle();
 
-    expect(find.text('Air Defense'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('target-air-defense')),
+        matching: find.text('Air Defense'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('600 HP'), findsOneWidget);
   });
 
   testWidgets('allows a custom attack method', (tester) async {
     await _pump(tester);
 
-    await tester.ensureVisible(find.text('Custom'));
+    await tester.ensureVisible(
+      find.descendant(
+        of: find.byKey(const ValueKey('calculator-quick-setups')),
+        matching: find.text('Custom'),
+      ),
+    );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Custom'));
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const ValueKey('calculator-quick-setups')),
+        matching: find.text('Custom'),
+      ),
+    );
     await tester.pumpAndSettle();
 
     final lightningRow = find.byKey(const ValueKey('source-lightning'));
@@ -93,7 +121,7 @@ void main() {
     );
   });
 
-  testWidgets('calculates raids for a farm goal', (tester) async {
+  testWidgets('calculates attacks for a farm goal', (tester) async {
     addTearDown(() => GameDataService.loadFromBundleForTesting({}));
     GameDataService.loadFromBundleForTesting({
       'league_tiers': [
@@ -103,11 +131,21 @@ void main() {
             {
               'townhall_level': 10,
               'resources': {'gold': 350000},
+              'star_bonus': {'gold': 900000},
             },
           ],
         },
       ],
     });
+    expect(
+      (GameDataService.playerLeagueData['leagues'] as Map)['Titan League 25'],
+      isNotNull,
+    );
+    expect(
+      ((GameDataService.playerLeagueData['leagues'] as Map)['Titan League 25']
+          as Map)['rewards'][0]['star_bonus'],
+      isNotNull,
+    );
     await _pump(
       tester,
       catalog: _farmGoalCatalog,
@@ -127,13 +165,22 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.text('Choose a building'), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('farm-goal-building')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Town Hall').last);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('farm-goal-level')), findsOneWidget);
-    expect(find.text('350000'), findsOneWidget);
+    expect(find.text('1000000'), findsOneWidget);
+    expect(
+      find.textContaining('Titan League 25 base league bonus: 350,000 Gold'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Star bonus: 900,000 Gold after 5 stars'),
+      findsOneWidget,
+    );
     await tester.enterText(
       find.byKey(const ValueKey('farm-goal-average-loot')),
       '100',
@@ -147,7 +194,11 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.descendant(of: result, matching: find.text('Raids needed')),
+      find.descendant(of: result, matching: find.text('17')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: result, matching: find.text('Attacks needed')),
       findsOneWidget,
     );
   });

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,4 +1,5 @@
 - Replaced loading spinners across the app with skeleton placeholders that match the loaded layouts.
+- War state analysis now separates locked outcomes from still-playable tie or win scenarios.
 - Stats now follows the shared ClashKing side-page design system with tokenized panels, filters, stat pills, and chart accents.
 - Calculator screens now use ClashKing assets throughout targets, accounts, sources, resources, results, and method filters, with shared outlined actions and no redundant target/damage/result summary.
 - Calculator header imagery now follows the active mode instead of displaying the generic ClashKing logo.

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,4 +1,10 @@
 - Replaced loading spinners across the app with skeleton placeholders that match the loaded layouts.
+- Stats now follows the shared ClashKing side-page design system with tokenized panels, filters, stat pills, and chart accents.
+- Calculator screens now use ClashKing assets throughout targets, accounts, sources, resources, results, and method filters, with shared outlined actions and no redundant target/damage/result summary.
+- Calculator header imagery now follows the active mode instead of displaying the generic ClashKing logo.
+- Fixed production authentication by routing v2 requests to the public API instead of the unavailable local-api host.
+- Calculator account selection now matches Upgrade Tracker with Town Hall icons, account search, and a dedicated picker.
+- Farm goals now use cached Upgrade Tracker data to suggest the next building target and its known upgrade cost when available.
 - Empty/no-result screens now share the same visual treatment across side pages and rankings.
 - Settings language and theme pickers now match the app's current settings styling in light and dark mode
 - Refined notification audience settings with clearer account scope controls.
@@ -19,7 +25,7 @@
 - Ranked League account switching now uses a labelled account selector directly in the player identity.
 - Damage Calculator now starts from a clear attack method, shows only relevant damage sources first, and hides the Zap Quake optimizer outside Zap Quake mode.
 - Calculators now use the same hero header and tabs as player and clan detail pages.
-- Added a farm goal mode next to the damage calculator to estimate required raids from a resource target and average loot.
+- Added a farm goal mode next to the damage calculator to estimate required attacks from a resource target, perfect-attack loot, and 100%/80%/60% destruction scenarios, with upcoming buildings from Upgrade Tracker and separate league bonus context.
 - Farm goals now use a selected building level and suggest league-based loot for the selected account.
 - Calculator UX now has cleaner setup controls, compact source rows, localized building labels, and no redundant empty stack card
 - Posts now show announcement-shaped skeleton cards while loading instead of a spinner


### PR DESCRIPTION
## Summary
- Polish the Stats and Calculator pages to better match the ClashKing design system, including compact filter rows, tokenized panels, refreshed controls, and improved reduced-motion handling.
- Align CWL rounds, members, and team cards with the shared app/devkit visual language.
- Improve the war tabs by using actual clan names instead of ambiguous “my team/enemy team” labels.
- Rework the War State card around the user’s real goal: the stars/destruction percentage needed to mathematically secure the war against the opponent’s maximum remaining score.
- Add the new war-analysis localization keys to all available ARB files, with French translations and English fallbacks where native translations are not available.
- Route production v2 API requests through the public API host and update API config test coverage.
- Refresh Play Store release notes for the changed UI.

## Validation
- `flutter gen-l10n`
- Verified the 9 new war-analysis localization keys are present in all 33 ARB files.
- `flutter analyze`

## Notes
- Temporary Codex files and local patch artifacts were intentionally left out of the commit.