### PR TITLE
feat: replace loading spinners with skeletons

### DIFF
--- a/lib/common/widgets/app_bar/coc_accounts_app_bar.dart
+++ b/lib/common/widgets/app_bar/coc_accounts_app_bar.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -67,8 +68,11 @@ class CocAccountsAppBar extends StatelessWidget implements PreferredSizeWidget {
                     ? MobileWebImage(
                         imageUrl: user.avatarUrl,
                         fit: BoxFit.cover,
-                        placeholder: (context, url) =>
-                            CircularProgressIndicator(),
+                        placeholder: (context, url) => SkeletonLoader(
+                          width: 40,
+                          height: 40,
+                          borderRadius: BorderRadius.circular(20),
+                        ),
                         errorWidget: (context, url, error) => Icon(Icons.error),
                       )
                     : null,

--- a/lib/common/widgets/error/error_page.dart
+++ b/lib/common/widgets/error/error_page.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/widgets/app_bar/coc_accounts_app_bar.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/utils/debug_utils.dart';
@@ -180,16 +181,7 @@ class _ErrorPageState extends State<ErrorPage> {
                         elevation: _isRetrying ? 1 : 3,
                       ),
                       icon: _isRetrying
-                          ? SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                valueColor: AlwaysStoppedAnimation<Color>(
-                                  Colors.white,
-                                ),
-                              ),
-                            )
+                          ? const SkeletonActionIndicator(width: 20, height: 6)
                           : const Icon(Icons.refresh, size: 20),
                       label: Text(
                         _isRetrying

--- a/lib/common/widgets/icons/excel_download_icon.dart
+++ b/lib/common/widgets/icons/excel_download_icon.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/utils/file_opener.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/core/utils/debug_utils.dart';
@@ -90,11 +91,7 @@ class _DownloadCwlExcelButtonState extends State<DownloadCwlExcelButton> {
     return _isDownloading
         ? const Padding(
             padding: EdgeInsets.all(8.0),
-            child: SizedBox(
-              height: 24,
-              width: 24,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
+            child: SkeletonActionIndicator(width: 24, height: 8),
           )
         : IconButton(
             icon: const Icon(Icons.download),

--- a/lib/common/widgets/info_profile_tabs.dart
+++ b/lib/common/widgets/info_profile_tabs.dart
@@ -232,7 +232,9 @@ class _InfoProfileTabScaffoldState extends State<InfoProfileTabScaffold>
     if (!_tabController.indexIsChanging &&
         _tabController.offset.abs() < 0.001 &&
         _tabController.index != selected) {
-      if (!_usesPages) _resetNestedInnerScroll();
+      if (!_usesPages) {
+        _prepareBodySelection();
+      }
       _tabController.index = selected;
     }
   }
@@ -357,7 +359,9 @@ class _InfoProfileTabScaffoldState extends State<InfoProfileTabScaffold>
 
   void _prepareBodySelection() {
     _resetNestedInnerScroll();
-    if (_chromeProgress.value >= 0.98) _snapOuterToPinThreshold();
+    if (_chromeProgress.value >= 0.98) {
+      _snapOuterToPinThreshold();
+    }
   }
 
   void _preparePageSwipe() {
@@ -374,9 +378,8 @@ class _InfoProfileTabScaffoldState extends State<InfoProfileTabScaffold>
       if (_usesPages) {
         _resetPageToTop(index);
       } else {
-        _resetNestedInnerScroll();
+        _prepareBodySelection();
       }
-      if (_chromeProgress.value >= 0.98) _snapOuterToPinThreshold();
       widget.onTabSelected(index);
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -384,15 +387,22 @@ class _InfoProfileTabScaffoldState extends State<InfoProfileTabScaffold>
     });
   }
 
-  void _resetNestedInnerScroll() {
-    final controller = _nestedScrollKey.currentState?.innerController;
-    if (controller != null && controller.hasClients) controller.jumpTo(0);
-  }
-
   void _resetPageToTop(int index) {
     final position = _scrollableStateBelow(_pageScrollKeys[index])?.position;
     if (position != null && position.hasPixels && position.pixels != 0) {
       position.jumpTo(0);
+    }
+  }
+
+  void _resetNestedInnerScroll() {
+    final controller = _nestedScrollKey.currentState?.innerController;
+    if (controller == null || !controller.hasClients) return;
+    for (final position in List<ScrollPosition>.of(controller.positions)) {
+      if (!position.hasPixels) continue;
+      final target = position.minScrollExtent;
+      if ((position.pixels - target).abs() > 0.5) {
+        position.jumpTo(target);
+      }
     }
   }
 

--- a/lib/common/widgets/liquid_glass.dart
+++ b/lib/common/widgets/liquid_glass.dart
@@ -610,33 +610,39 @@ class _AppGlassSegmentedControlState<T>
                                 )
                                   Expanded(
                                     child: Semantics(
+                                      container: true,
                                       button: true,
+                                      enabled: true,
                                       selected: selectedIndex == index,
                                       label: widget.labels[index],
+                                      onTap: () => _selectIndex(index),
                                       child: GestureDetector(
                                         behavior: HitTestBehavior.opaque,
                                         onTap: () => _selectIndex(index),
                                         child: Center(
-                                          child: AnimatedDefaultTextStyle(
-                                            duration: const Duration(
-                                              milliseconds: 180,
-                                            ),
-                                            curve: Curves.easeOutCubic,
-                                            style: labelStyle.copyWith(
-                                              color: selectedIndex == index
-                                                  ? labelColor
-                                                  : labelColor.withValues(
-                                                      alpha: 0.67,
-                                                    ),
-                                              fontWeight: selectedIndex == index
-                                                  ? FontWeight.w600
-                                                  : FontWeight.w500,
-                                            ),
-                                            child: Text(
-                                              widget.labels[index],
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
-                                              textAlign: TextAlign.center,
+                                          child: ExcludeSemantics(
+                                            child: AnimatedDefaultTextStyle(
+                                              duration: const Duration(
+                                                milliseconds: 180,
+                                              ),
+                                              curve: Curves.easeOutCubic,
+                                              style: labelStyle.copyWith(
+                                                color: selectedIndex == index
+                                                    ? labelColor
+                                                    : labelColor.withValues(
+                                                        alpha: 0.67,
+                                                      ),
+                                                fontWeight:
+                                                    selectedIndex == index
+                                                    ? FontWeight.w600
+                                                    : FontWeight.w500,
+                                              ),
+                                              child: Text(
+                                                widget.labels[index],
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                                textAlign: TextAlign.center,
+                                              ),
                                             ),
                                           ),
                                         ),

--- a/lib/common/widgets/loading/skeleton_loading.dart
+++ b/lib/common/widgets/loading/skeleton_loading.dart
@@ -92,6 +92,251 @@ class _SkeletonLoaderState extends State<SkeletonLoader>
   }
 }
 
+class SkeletonActionIndicator extends StatelessWidget {
+  final double width;
+  final double height;
+
+  const SkeletonActionIndicator({super.key, this.width = 20, this.height = 8});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+      height: width,
+      child: Center(
+        child: SkeletonLoader(
+          width: width,
+          height: height,
+          borderRadius: BorderRadius.circular(height),
+        ),
+      ),
+    );
+  }
+}
+
+class SkeletonListItem extends StatelessWidget {
+  final bool leading;
+  final bool trailing;
+  final int lines;
+  final EdgeInsetsGeometry padding;
+
+  const SkeletonListItem({
+    super.key,
+    this.leading = true,
+    this.trailing = true,
+    this.lines = 2,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final radius = BorderRadius.circular(CKRadius.card);
+
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.28),
+        borderRadius: radius,
+        border: Border.all(
+          color: colorScheme.outlineVariant.withValues(alpha: 0.36),
+        ),
+      ),
+      child: Row(
+        children: [
+          if (leading) ...[
+            SkeletonLoader(
+              width: 48,
+              height: 48,
+              borderRadius: BorderRadius.circular(CKRadius.control),
+            ),
+            const SizedBox(width: 12),
+          ],
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SkeletonLoader(
+                  width: double.infinity,
+                  height: 16,
+                  borderRadius: BorderRadius.circular(CKSpacing.xs),
+                ),
+                if (lines > 1) ...[
+                  const SizedBox(height: 10),
+                  SkeletonLoader(
+                    width: 160,
+                    height: 12,
+                    borderRadius: BorderRadius.circular(CKSpacing.xs),
+                  ),
+                ],
+                if (lines > 2) ...[
+                  const SizedBox(height: 10),
+                  SkeletonLoader(
+                    width: 96,
+                    height: 12,
+                    borderRadius: BorderRadius.circular(CKSpacing.xs),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (trailing) ...[
+            const SizedBox(width: 12),
+            SkeletonLoader(
+              width: 36,
+              height: 24,
+              borderRadius: BorderRadius.circular(CKRadius.chip),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class SkeletonList extends StatelessWidget {
+  final int itemCount;
+  final EdgeInsetsGeometry padding;
+  final bool leading;
+  final bool trailing;
+  final int lines;
+
+  const SkeletonList({
+    super.key,
+    this.itemCount = 5,
+    this.padding = EdgeInsets.zero,
+    this.leading = true,
+    this.trailing = true,
+    this.lines = 2,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: padding,
+      child: Column(
+        children: List.generate(
+          itemCount,
+          (index) => Padding(
+            padding: EdgeInsets.only(bottom: index == itemCount - 1 ? 0 : 12),
+            child: SkeletonListItem(
+              leading: leading,
+              trailing: trailing,
+              lines: lines,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SkeletonPage extends StatelessWidget {
+  final int itemCount;
+  final EdgeInsetsGeometry padding;
+  final bool includeHeader;
+
+  const SkeletonPage({
+    super.key,
+    this.itemCount = 5,
+    this.padding = const EdgeInsets.all(16),
+    this.includeHeader = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: padding,
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (includeHeader) ...[
+            SkeletonLoader(
+              width: 180,
+              height: 24,
+              borderRadius: BorderRadius.circular(CKSpacing.sm),
+            ),
+            const SizedBox(height: 10),
+            SkeletonLoader(
+              width: 260,
+              height: 14,
+              borderRadius: BorderRadius.circular(CKSpacing.xs),
+            ),
+            const SizedBox(height: 20),
+          ],
+          SkeletonList(itemCount: itemCount),
+        ],
+      ),
+    );
+  }
+}
+
+class SkeletonLoadingDialog extends StatelessWidget {
+  const SkeletonLoadingDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 320),
+        child: Material(
+          color: Colors.transparent,
+          child: Container(
+            margin: const EdgeInsets.symmetric(horizontal: 28),
+            padding: const EdgeInsets.all(18),
+            decoration: BoxDecoration(
+              color: colorScheme.surface,
+              borderRadius: BorderRadius.circular(CKRadius.card),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.36),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.18),
+                  blurRadius: 24,
+                  offset: const Offset(0, 12),
+                ),
+              ],
+            ),
+            child: Row(
+              children: [
+                SkeletonLoader(
+                  width: 48,
+                  height: 48,
+                  borderRadius: BorderRadius.circular(CKRadius.control),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SkeletonLoader(
+                        width: double.infinity,
+                        height: 16,
+                        borderRadius: BorderRadius.circular(CKSpacing.xs),
+                      ),
+                      const SizedBox(height: 10),
+                      SkeletonLoader(
+                        width: 140,
+                        height: 12,
+                        borderRadius: BorderRadius.circular(CKSpacing.xs),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// A pre-built skeleton for war stats cards
 class WarStatsSkeletonCard extends StatelessWidget {
   const WarStatsSkeletonCard({super.key});

--- a/lib/core/app/my_home_page.dart
+++ b/lib/core/app/my_home_page.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/widgets/empty_state.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/icons/custom_icons_icons.dart';
 import 'package:clashkingapp/common/widgets/native_liquid_glass.dart';
@@ -201,9 +202,7 @@ class MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     if (!context.watch<CocAccountService>().hasVerifiedAccounts) {
       _redirectToAccountVerification();
-      return const Scaffold(
-        body: SafeArea(child: Center(child: CircularProgressIndicator())),
-      );
+      return const Scaffold(body: SafeArea(child: SkeletonPage(itemCount: 3)));
     }
     _schedulePageControllerSync();
     if (_usesDesktopWebLayout(context)) {

--- a/lib/core/utils/deep_link_handler.dart
+++ b/lib/core/utils/deep_link_handler.dart
@@ -1,5 +1,6 @@
 import 'package:clashkingapp/core/constants/global_keys.dart';
 import 'package:clashkingapp/core/utils/debug_utils.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
 import 'package:clashkingapp/features/clan/presentation/clan_info/clan_page.dart';
@@ -130,7 +131,7 @@ class DeepLinkHandler {
       context: context,
       barrierDismissible: false,
       useRootNavigator: true,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
+      builder: (_) => const SkeletonLoadingDialog(),
     );
 
     try {
@@ -175,7 +176,7 @@ class DeepLinkHandler {
       context: context,
       barrierDismissible: false,
       useRootNavigator: true,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
+      builder: (_) => const SkeletonLoadingDialog(),
     );
 
     try {

--- a/lib/features/auth/presentation/account_management_page.dart
+++ b/lib/features/auth/presentation/account_management_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:clashkingapp/core/models/user.dart';
 import 'package:flutter/material.dart';
@@ -40,7 +41,8 @@ class AccountManagementPageState extends State<AccountManagementPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-                AppLocalizations.of(context)!.authAccountDiscordLinkedSuccess),
+              AppLocalizations.of(context)!.authAccountDiscordLinkedSuccess,
+            ),
             backgroundColor: Colors.green,
           ),
         );
@@ -302,16 +304,16 @@ class AccountManagementPageState extends State<AccountManagementPage> {
       children: [
         Text(
           AppLocalizations.of(context)!.authAccountLinkDiscord,
-          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 8),
         Text(
           AppLocalizations.of(context)!.authAccountAddDiscordAuth,
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Colors.grey[600],
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
         ),
         const SizedBox(height: 16),
         SizedBox(
@@ -321,8 +323,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
             icon: const Icon(Icons.discord),
             label: Text(
               AppLocalizations.of(context)!.authAccountLinkDiscord,
-              style: const TextStyle(
-                  fontSize: 16, fontWeight: FontWeight.bold),
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             style: ElevatedButton.styleFrom(
               backgroundColor: const Color(0xFF5865F2),
@@ -486,7 +487,7 @@ class AccountManagementPageState extends State<AccountManagementPage> {
                         ),
                       ),
                       child: _isLoading
-                          ? CircularProgressIndicator(color: Colors.white)
+                          ? const SkeletonActionIndicator(width: 24, height: 8)
                           : Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [

--- a/lib/features/auth/presentation/email_verification_page.dart
+++ b/lib/features/auth/presentation/email_verification_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:clashkingapp/core/services/token_service.dart';
@@ -308,7 +309,7 @@ class EmailVerificationPageState extends State<EmailVerificationPage> {
                     if (_isLoading) ...[
                       Column(
                         children: [
-                          CircularProgressIndicator(),
+                          const SkeletonActionIndicator(width: 48, height: 10),
                           SizedBox(height: 16),
                           Text(
                             AppLocalizations.of(

--- a/lib/features/auth/presentation/forgot_password_page.dart
+++ b/lib/features/auth/presentation/forgot_password_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:flutter/material.dart';
@@ -179,16 +180,9 @@ class ForgotPasswordPageState extends State<ForgotPasswordPage> {
                                 ),
                               ),
                               child: _isLoading
-                                  ? const SizedBox(
-                                      height: 20,
-                                      width: 20,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                        valueColor:
-                                            AlwaysStoppedAnimation<Color>(
-                                              Colors.white,
-                                            ),
-                                      ),
+                                  ? const SkeletonActionIndicator(
+                                      width: 24,
+                                      height: 8,
                                     )
                                   : Text(
                                       AppLocalizations.of(

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:clashkingapp/common/widgets/loading/app_loading_screen.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
 import 'package:clashkingapp/core/app/my_app_state.dart';
 import 'package:clashkingapp/core/app/my_home_page.dart';
@@ -441,14 +442,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
               elevation: 2,
             ),
             child: _isLoading
-                ? SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(
-                      color: Colors.white,
-                      strokeWidth: 2,
-                    ),
-                  )
+                ? const SkeletonActionIndicator(width: 24, height: 8)
                 : Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
@@ -636,14 +630,7 @@ class LoginPageState extends State<LoginPage> with TickerProviderStateMixin {
                 elevation: 2,
               ),
               child: _isLoading
-                  ? SizedBox(
-                      height: 20,
-                      width: 20,
-                      child: CircularProgressIndicator(
-                        color: Colors.white,
-                        strokeWidth: 2,
-                      ),
-                    )
+                  ? const SkeletonActionIndicator(width: 24, height: 8)
                   : Text(
                       AppLocalizations.of(context)!.authLogin,
                       style: TextStyle(

--- a/lib/features/auth/presentation/register_page.dart
+++ b/lib/features/auth/presentation/register_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:clashkingapp/features/auth/presentation/maintenance_page.dart';
@@ -528,16 +529,9 @@ class RegisterPageState extends State<RegisterPage> {
                                 ),
                               ),
                               child: _isLoading
-                                  ? const SizedBox(
-                                      height: 20,
-                                      width: 20,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                        valueColor:
-                                            AlwaysStoppedAnimation<Color>(
-                                              Colors.white,
-                                            ),
-                                      ),
+                                  ? const SkeletonActionIndicator(
+                                      width: 24,
+                                      height: 8,
                                     )
                                   : Text(
                                       AppLocalizations.of(

--- a/lib/features/auth/presentation/reset_password_page.dart
+++ b/lib/features/auth/presentation/reset_password_page.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:flutter/material.dart';
@@ -497,15 +498,9 @@ class ResetPasswordPageState extends State<ResetPasswordPage> {
                               ),
                             ),
                             child: _isLoading
-                                ? const SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                      valueColor: AlwaysStoppedAnimation<Color>(
-                                        Colors.white,
-                                      ),
-                                    ),
+                                ? const SkeletonActionIndicator(
+                                    width: 24,
+                                    height: 8,
                                   )
                                 : Text(
                                     AppLocalizations.of(

--- a/lib/features/clan/presentation/clan_info/clan_members.dart
+++ b/lib/features/clan/presentation/clan_info/clan_members.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/common/widgets/search_sort_bar.dart';
@@ -173,7 +174,7 @@ class ClanMembersState extends State<ClanMembers> {
             context: context,
             useRootNavigator: false,
             barrierDismissible: false,
-            builder: (_) => const Center(child: CircularProgressIndicator()),
+            builder: (_) => const SkeletonLoadingDialog(),
           );
 
           try {

--- a/lib/features/clan/presentation/clan_info/clan_page.dart
+++ b/lib/features/clan/presentation/clan_info/clan_page.dart
@@ -1,6 +1,7 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/common/widgets/search_sort_bar.dart';
@@ -95,10 +96,13 @@ class _ClanInfoScreenState extends State<ClanInfoScreen> {
         nestedScrollPhysics: _NoImplicitScrollPhysics(
           parent: ScrollConfiguration.of(context).getScrollPhysics(context),
         ),
-        body: KeyedSubtree(
-          key: ValueKey(visibleTabs[activeIndex]),
-          child: _buildSelectedTab(context, visibleTabs[activeIndex]),
-        ),
+        pages: [
+          for (final tab in visibleTabs)
+            KeyedSubtree(
+              key: ValueKey(tab),
+              child: _buildSelectedTab(context, tab),
+            ),
+        ],
       ),
     );
   }
@@ -277,7 +281,7 @@ class _ClanJoinLeaveTabState extends State<_ClanJoinLeaveTab> {
     final isDesktopWeb = kIsWeb && MediaQuery.sizeOf(context).width >= 900;
 
     if (_isLoading && widget.clan.joinLeave == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const SkeletonPage(itemCount: 4, includeHeader: false);
     }
 
     return NotificationListener<ScrollNotification>(
@@ -370,7 +374,7 @@ class _ClanJoinLeaveTabState extends State<_ClanJoinLeaveTab> {
           if (_isLoadingMore)
             const Padding(
               padding: EdgeInsets.all(16),
-              child: Center(child: CircularProgressIndicator()),
+              child: SkeletonList(itemCount: 2),
             ),
         ],
       ),
@@ -1273,7 +1277,7 @@ class _ClanWarLogTabState extends State<_ClanWarLogTab> {
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
           child: _isLoading
-              ? const Center(child: CircularProgressIndicator())
+              ? const SkeletonList(itemCount: 4)
               : ClanWarLog(
                   clan: widget.clan,
                   selectedTypes: widget.selectedTypes,
@@ -1686,7 +1690,7 @@ class _ClanStatisticsTabState extends State<_ClanStatisticsTab> {
         if (_isLoadingStats)
           const Padding(
             padding: EdgeInsets.all(32),
-            child: Center(child: CircularProgressIndicator()),
+            child: SkeletonList(itemCount: 4),
           )
         else
           Padding(
@@ -1913,7 +1917,7 @@ class _ClanCwlHistoryTabState extends State<_ClanCwlHistoryTab> {
         future: _history,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const Center(child: CircularProgressIndicator());
+            return const SkeletonList(itemCount: 4);
           }
           final entries = snapshot.data ?? const [];
           if (entries.isEmpty) {

--- a/lib/features/coc_accounts/presentation/coc_account_management_page.dart
+++ b/lib/features/coc_accounts/presentation/coc_account_management_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/app_bar/coc_accounts_app_bar.dart';
 import 'package:clashkingapp/common/widgets/error/error_page.dart';
@@ -154,7 +155,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
             context: context,
             useRootNavigator: false,
             barrierDismissible: false,
-            builder: (_) => const Center(child: CircularProgressIndicator()),
+            builder: (_) => const SkeletonLoadingDialog(),
           );
           await _loadAllAccountData();
         }
@@ -248,9 +249,7 @@ class AddCocAccountPageState extends State<AddCocAccountPage> {
                                   context: context,
                                   useRootNavigator: false,
                                   barrierDismissible: false,
-                                  builder: (_) => const Center(
-                                    child: CircularProgressIndicator(),
-                                  ),
+                                  builder: (_) => const SkeletonLoadingDialog(),
                                 );
 
                                 await _loadAllAccountData();
@@ -647,7 +646,7 @@ class _AddAccountStickyPanel extends StatelessWidget {
                         width: 24,
                         child: Padding(
                           padding: EdgeInsets.all(8.0),
-                          child: CircularProgressIndicator(),
+                          child: SkeletonActionIndicator(width: 16, height: 5),
                         ),
                       )
                     : IconButton(
@@ -852,11 +851,7 @@ class _AccountRow extends StatelessWidget {
             IconButton(
               tooltip: AppLocalizations.of(context)!.tooltipRemoveAccount,
               icon: isDeleting
-                  ? const SizedBox(
-                      height: 20,
-                      width: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
+                  ? const SkeletonActionIndicator(width: 20, height: 6)
                   : Icon(Icons.delete_outline, color: colorScheme.primary),
               onPressed: isDeleting ? null : onRemove,
             ),

--- a/lib/features/coc_accounts/presentation/widgets/account_verification_dialog.dart
+++ b/lib/features/coc_accounts/presentation/widgets/account_verification_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -238,11 +239,7 @@ class _AccountVerificationDialogState extends State<AccountVerificationDialog> {
         ElevatedButton(
           onPressed: _isVerifying ? null : _verifyAccount,
           child: _isVerifying
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+              ? const SkeletonActionIndicator(width: 16, height: 5)
               : Text(AppLocalizations.of(context)!.accountVerify),
         ),
       ],

--- a/lib/features/pages/presentation/announcement_story_dialog.dart
+++ b/lib/features/pages/presentation/announcement_story_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/pages/data/announcement_story_cache_service.dart';
 import 'package:clashkingapp/features/pages/models/app_announcement.dart';
 import 'package:clashkingapp/features/pages/presentation/announcement_webview_page.dart';
@@ -209,12 +210,9 @@ class _AnnouncementStoryDialogState extends State<_AnnouncementStoryDialog> {
                     child: AnimatedOpacity(
                       opacity: _ready ? 0 : 1,
                       duration: const Duration(milliseconds: 120),
-                      child: const SizedBox.square(
-                        dimension: 26,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2.5,
-                          color: Colors.white70,
-                        ),
+                      child: const SkeletonActionIndicator(
+                        width: 26,
+                        height: 8,
                       ),
                     ),
                   ),

--- a/lib/features/pages/presentation/dashboard_page.dart
+++ b/lib/features/pages/presentation/dashboard_page.dart
@@ -332,10 +332,8 @@ class DashboardPage extends StatelessWidget {
   }) {
     if (isLoading && linkedPlayers.isEmpty) {
       return const [
-        Padding(
-          padding: EdgeInsets.only(top: 48),
-          child: Center(child: CircularProgressIndicator()),
-        ),
+        _HomeCardFrame(child: _RankedHomeSkeleton()),
+        _HomeCardFrame(child: _UpgradeHomeSkeleton()),
       ];
     }
     if (linkedPlayers.isEmpty) {

--- a/lib/features/pages/presentation/game_assets_page.dart
+++ b/lib/features/pages/presentation/game_assets_page.dart
@@ -1012,11 +1012,9 @@ class _GameAssetPreviewPageState extends State<GameAssetPreviewPage> {
                       FilledButton.tonalIcon(
                         onPressed: _sharing ? null : _share,
                         icon: _sharing
-                            ? const SizedBox.square(
-                                dimension: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
+                            ? const SkeletonActionIndicator(
+                                width: 18,
+                                height: 6,
                               )
                             : const Icon(Icons.ios_share_rounded),
                         label: Text(loc.gameAssetsShare),
@@ -1024,11 +1022,9 @@ class _GameAssetPreviewPageState extends State<GameAssetPreviewPage> {
                       FilledButton.icon(
                         onPressed: _saving ? null : _save,
                         icon: _saving
-                            ? const SizedBox.square(
-                                dimension: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
+                            ? const SkeletonActionIndicator(
+                                width: 18,
+                                height: 6,
                               )
                             : const Icon(Icons.download_rounded),
                         label: Text(

--- a/lib/features/pages/presentation/players_page.dart
+++ b/lib/features/pages/presentation/players_page.dart
@@ -4,6 +4,7 @@ import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/indicators/last_refresh_indicator.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/models/notification_preferences.dart';
@@ -455,7 +456,7 @@ class _PlayersPageState extends State<PlayersPage> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (context) => const Center(child: CircularProgressIndicator()),
+      builder: (context) => const SkeletonLoadingDialog(),
     );
 
     try {

--- a/lib/features/pages/presentation/search_page.dart
+++ b/lib/features/pages/presentation/search_page.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
@@ -279,7 +280,7 @@ class _SearchPageState extends State<SearchPage> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (context) => const Center(child: CircularProgressIndicator()),
+      builder: (context) => const SkeletonLoadingDialog(),
     );
 
     try {
@@ -321,7 +322,7 @@ class _SearchPageState extends State<SearchPage> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (context) => const Center(child: CircularProgressIndicator()),
+      builder: (context) => const SkeletonLoadingDialog(),
     );
 
     try {
@@ -455,10 +456,7 @@ class _SearchPageState extends State<SearchPage> {
                     if (_isSearching)
                       const Padding(
                         padding: EdgeInsets.symmetric(horizontal: 14),
-                        child: SizedBox.square(
-                          dimension: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        ),
+                        child: SkeletonActionIndicator(width: 18, height: 6),
                       )
                     else if (_controller.text.isNotEmpty)
                       IconButton(

--- a/lib/features/pages/widgets/clan_search_card.dart
+++ b/lib/features/pages/widgets/clan_search_card.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:clashkingapp/features/pages/widgets/clan_search_filters_dialog.dart';
 import 'package:clashkingapp/features/pages/widgets/clan_search_result_tiles.dart';
@@ -138,11 +139,7 @@ class ClanSearchCardState extends State<ClanSearchCard> {
                         color: Theme.of(context).colorScheme.onSurface,
                       ),
                       isSearching
-                          ? const SizedBox(
-                              width: 20.0,
-                              height: 20.0,
-                              child: CircularProgressIndicator(),
-                            )
+                          ? const SkeletonActionIndicator()
                           : !isEmpty
                           ? IconButton(
                               tooltip: AppLocalizations.of(

--- a/lib/features/pages/widgets/clan_search_result_tiles.dart
+++ b/lib/features/pages/widgets/clan_search_result_tiles.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -34,7 +35,7 @@ class ClanSearchResultTileState extends State<ClanSearchResultTile> {
             useRootNavigator: false,
             barrierDismissible: false,
             builder: (BuildContext context) {
-              return Center(child: CircularProgressIndicator());
+              return const SkeletonLoadingDialog();
             },
           );
 

--- a/lib/features/pages/widgets/player_search_card.dart
+++ b/lib/features/pages/widgets/player_search_card.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/services/api_service.dart';
 import 'package:clashkingapp/features/pages/widgets/player_search_result_tile.dart';
 import 'package:flutter/material.dart';
@@ -133,11 +134,7 @@ class PlayerSearchCardState extends State<PlayerSearchCard> {
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       isSearching
-                          ? SizedBox(
-                              width: 20.0,
-                              height: 20.0,
-                              child: CircularProgressIndicator(),
-                            )
+                          ? const SkeletonActionIndicator()
                           : !isEmpty
                           ? IconButton(
                               tooltip: AppLocalizations.of(

--- a/lib/features/pages/widgets/player_search_result_tile.dart
+++ b/lib/features/pages/widgets/player_search_result_tile.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/widgets/buttons/chip.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/player/data/player_service.dart';
@@ -48,7 +49,7 @@ class PlayerSearchResultTileState extends State<PlayerSearchResultTile> {
             useRootNavigator: false,
             barrierDismissible: false,
             builder: (context) {
-              return const Center(child: CircularProgressIndicator());
+              return const SkeletonLoadingDialog();
             },
           );
 

--- a/lib/features/player/presentation/player/player_header.dart
+++ b/lib/features/player/presentation/player/player_header.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:clashkingapp/common/widgets/dialogs/open_clash_dialog.dart';
 import 'package:clashkingapp/common/widgets/dialogs/snackbar.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/functions/functions.dart';
@@ -1050,7 +1051,7 @@ class _PlayerClanIdentityLineState extends State<_PlayerClanIdentityLine> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (context) => const Center(child: CircularProgressIndicator()),
+      builder: (context) => const SkeletonLoadingDialog(),
     );
 
     try {

--- a/lib/features/player/presentation/player/player_join_leave_tab.dart
+++ b/lib/features/player/presentation/player/player_join_leave_tab.dart
@@ -1,5 +1,6 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/inputs/filter_dropdown.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/summary_chips.dart';
 import 'package:clashkingapp/features/clan/models/clan_join_leave.dart';
@@ -154,7 +155,7 @@ class _PlayerJoinLeaveTabState extends State<PlayerJoinLeaveTab> {
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: const [
           SliverFillRemaining(
-            child: Center(child: CircularProgressIndicator()),
+            child: SkeletonPage(itemCount: 5, includeHeader: false),
           ),
         ],
       );
@@ -286,7 +287,7 @@ class _PlayerJoinLeaveTabState extends State<PlayerJoinLeaveTab> {
     if (_loadingMore)
       const Padding(
         padding: EdgeInsets.all(16),
-        child: Center(child: CircularProgressIndicator()),
+        child: SkeletonList(itemCount: 1),
       ),
   ];
 

--- a/lib/features/player/presentation/player/player_super_troop_section.dart
+++ b/lib/features/player/presentation/player/player_super_troop_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/features/player/models/player_super_troop.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
@@ -55,8 +56,11 @@ class PlayerSuperTroopSection extends StatelessWidget {
                       (troop) => ClipRRect(
                         borderRadius: BorderRadius.circular(6),
                         child: MobileWebImage(
-                          placeholder: (context, url) =>
-                              CircularProgressIndicator(),
+                          placeholder: (context, url) => SkeletonLoader(
+                            width: 50,
+                            height: 50,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
                           errorWidget: (context, url, error) =>
                               Icon(Icons.error),
                           imageUrl: troop.imageUrl,

--- a/lib/features/player/presentation/ranked/player_ranked_league_page.dart
+++ b/lib/features/player/presentation/ranked/player_ranked_league_page.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:clashkingapp/common/widgets/empty_state.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/navigation/page_dots_indicator.dart';
 import 'package:clashkingapp/common/theme/app_tokens.dart';
@@ -232,7 +233,7 @@ class _PlayerRankedLeagueScreenState extends State<PlayerRankedLeagueScreen> {
               switchAccountTooltip: switchAccountTooltip,
             ),
           ),
-          body: const Center(child: CircularProgressIndicator()),
+          body: const SkeletonPage(itemCount: 4),
         );
       }
       return Scaffold(
@@ -2046,7 +2047,7 @@ class _RankingRow extends StatelessWidget {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
+      builder: (_) => const SkeletonLoadingDialog(),
     );
     try {
       final selectedPlayer = await context

--- a/lib/features/player/presentation/war_stats/player_war_attacks_card.dart
+++ b/lib/features/player/presentation/war_stats/player_war_attacks_card.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/icons/build_stars.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
@@ -364,7 +365,7 @@ class _PlayerWarAttacksCardState extends State<PlayerWarAttacksCard> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
+      builder: (_) => const SkeletonLoadingDialog(),
     );
 
     try {

--- a/lib/features/player/presentation/war_stats/player_war_stats_profile_tab.dart
+++ b/lib/features/player/presentation/war_stats/player_war_stats_profile_tab.dart
@@ -561,14 +561,7 @@ class _PlayerWarStatsProfileTabState extends State<PlayerWarStatsProfileTab> {
         SnackBar(
           content: Row(
             children: [
-              SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: Theme.of(context).colorScheme.onInverseSurface,
-                ),
-              ),
+              const SkeletonActionIndicator(width: 16, height: 5),
               const SizedBox(width: 12),
               Text(
                 AppLocalizations.of(context)?.exportGenerating ??

--- a/lib/features/player/presentation/war_stats/war_stats_filter_dialog.dart
+++ b/lib/features/player/presentation/war_stats/war_stats_filter_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:clashkingapp/features/player/models/war_stats_filter.dart';
 import 'package:clashkingapp/features/player/models/filter_preset.dart';
@@ -2025,17 +2026,12 @@ class _WarStatsFilterDialogState extends State<WarStatsFilterDialog> {
           ),
           const SizedBox(height: 8),
           if (_isLoadingPresets)
-            Padding(
+            const Padding(
               padding: EdgeInsets.all(8.0),
-              child: Center(
-                child: SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                ),
+              child: SkeletonList(
+                itemCount: 1,
+                leading: false,
+                trailing: false,
               ),
             )
           else

--- a/lib/features/rankings/presentation/rankings_page.dart
+++ b/lib/features/rankings/presentation/rankings_page.dart
@@ -5,6 +5,7 @@ import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
 import 'package:clashkingapp/common/widgets/inputs/filter_dropdown.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
@@ -220,7 +221,7 @@ class _RankingsPageState extends State<RankingsPage> {
       context: context,
       useRootNavigator: false,
       barrierDismissible: false,
-      builder: (context) => const Center(child: CircularProgressIndicator()),
+      builder: (context) => const SkeletonLoadingDialog(),
     );
     try {
       if (entry.audience == RankingAudience.players) {

--- a/lib/features/settings/presentation/features_vote.dart
+++ b/lib/features/settings/presentation/features_vote.dart
@@ -22,9 +22,6 @@ class FeatureRequests extends StatelessWidget {
       ..setBackgroundColor(const Color(0x00000000))
       ..setNavigationDelegate(
         NavigationDelegate(
-          onProgress: (int progress) {
-            Center(child: CircularProgressIndicator(value: progress / 100));
-          },
           onPageStarted: (String url) {},
           onPageFinished: (String url) {},
           onWebResourceError: (WebResourceError error) {},

--- a/lib/features/settings/presentation/notification_settings_page.dart
+++ b/lib/features/settings/presentation/notification_settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/core/models/notification_preferences.dart';
 import 'package:clashkingapp/core/services/notification_debug_service.dart';
@@ -175,7 +176,7 @@ class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
         scrolledUnderElevation: 0,
       ),
       body: _loading
-          ? const Center(child: CircularProgressIndicator())
+          ? const SkeletonPage(itemCount: 4)
           : ListView(
               padding: const EdgeInsets.fromLTRB(16, 6, 16, 28),
               children: [
@@ -761,10 +762,7 @@ class _DebugNotificationSection extends StatelessWidget {
           child: FilledButton.icon(
             onPressed: sending ? null : onSend,
             icon: sending
-                ? const SizedBox.square(
-                    dimension: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
+                ? const SkeletonActionIndicator(width: 18, height: 6)
                 : const Icon(LucideIcons.bellRing),
             label: Text(
               AppLocalizations.of(context)!.notifSendTestNotification,

--- a/lib/features/settings/presentation/privacy_controls_page.dart
+++ b/lib/features/settings/presentation/privacy_controls_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/auth/data/auth_service.dart';
 import 'package:clashkingapp/features/auth/presentation/login_page.dart';
 import 'package:clashkingapp/features/coc_accounts/data/coc_account_service.dart';
@@ -97,10 +98,7 @@ class _PrivacyControlsPageState extends State<PrivacyControlsPage> {
           ),
           onPressed: _isDeleting ? null : _confirmDeletion,
           icon: _isDeleting
-              ? const SizedBox.square(
-                  dimension: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+              ? const SkeletonActionIndicator(width: 18, height: 6)
               : const Icon(Icons.delete_forever_outlined),
           label: const Text('Delete account'),
         ),
@@ -175,10 +173,7 @@ class _PrivacyControlsPageState extends State<PrivacyControlsPage> {
         FilledButton.icon(
           onPressed: _isExporting ? null : _requestExport,
           icon: _isExporting
-              ? const SizedBox.square(
-                  dimension: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+              ? const SkeletonActionIndicator(width: 18, height: 6)
               : const Icon(Icons.file_download_outlined),
           label: Text(hasPreparedExport ? 'Refresh export' : 'Prepare export'),
         ),

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/dialogs/logout_dialog.dart';
 import 'package:clashkingapp/common/widgets/dialogs/snackbar.dart';
@@ -1015,9 +1016,10 @@ class _LanguageChoiceTile extends StatelessWidget {
           width: 34,
           height: 34,
           fit: BoxFit.cover,
-          placeholder: (context, url) => const SizedBox.square(
-            dimension: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
+          placeholder: (context, url) => SkeletonLoader(
+            width: 34,
+            height: 34,
+            borderRadius: BorderRadius.circular(17),
           ),
           errorWidget: (context, url, error) =>
               const Icon(Icons.error_outline, size: 20),
@@ -1247,10 +1249,7 @@ class _WarWidgetClanTile extends StatelessWidget {
       title: Text(clan.name, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: Text(clan.tag),
       trailing: isPending
-          ? const SizedBox.square(
-              dimension: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
+          ? const SkeletonActionIndicator()
           : const Icon(Icons.add_rounded),
       onTap: onTap,
     );

--- a/lib/features/upgrade_tracker/presentation/upgrade_tracker_page.dart
+++ b/lib/features/upgrade_tracker/presentation/upgrade_tracker_page.dart
@@ -12,6 +12,7 @@ import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/info_profile_tabs.dart';
 import 'package:clashkingapp/common/widgets/inputs/filter_dropdown.dart';
 import 'package:clashkingapp/common/widgets/liquid_glass.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/search_sort_bar.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
@@ -713,7 +714,7 @@ class _UpgradeTrackerPageState extends State<UpgradeTrackerPage> {
     }
     final planData = _planData;
     if (planData == null) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+      return const Scaffold(body: SkeletonPage(itemCount: 5));
     }
     final tabs = [
       InfoProfileTabData(
@@ -914,7 +915,7 @@ class _UpgradeTrackerPageState extends State<UpgradeTrackerPage> {
   Widget _buildBody() {
     final l10n = AppLocalizations.of(context)!;
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const SkeletonPage(itemCount: 5);
     }
     if (_error != null) {
       return _TrackerEmptyState(
@@ -947,7 +948,7 @@ class _UpgradeTrackerPageState extends State<UpgradeTrackerPage> {
     }
     final planData = _planData;
     if (planData == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const SkeletonPage(itemCount: 5);
     }
     return PageView(
       controller: _pageController,
@@ -5687,10 +5688,7 @@ class _ShareCollectionSheetState extends State<_ShareCollectionSheet> {
             child: FilledButton.icon(
               onPressed: _sharing ? null : _share,
               icon: _sharing
-                  ? const SizedBox.square(
-                      dimension: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
+                  ? const SkeletonActionIndicator(width: 18, height: 6)
                   : const Icon(Icons.ios_share_rounded),
               label: Text(_sharing ? 'Preparing images…' : 'Share collection'),
             ),
@@ -6146,10 +6144,7 @@ class _ShareProgressSheetState extends State<_ShareProgressSheet> {
               child: FilledButton.icon(
                 onPressed: _sharing ? null : _share,
                 icon: _sharing
-                    ? const SizedBox.square(
-                        dimension: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const SkeletonActionIndicator(width: 18, height: 6)
                     : const Icon(Icons.ios_share_rounded),
                 label: Text(_sharing ? 'Preparing images…' : 'Share progress'),
               ),
@@ -10153,7 +10148,7 @@ class _SceneryMusicButtonState extends State<_SceneryMusicButton> {
         width: 36,
         child: Padding(
           padding: EdgeInsets.all(9),
-          child: CircularProgressIndicator(strokeWidth: 2),
+          child: SkeletonActionIndicator(width: 18, height: 6),
         ),
       );
     }
@@ -10170,11 +10165,7 @@ class _SceneryMusicButtonState extends State<_SceneryMusicButton> {
             padding: EdgeInsets.zero,
             onPressed: _loading ? null : _toggle,
             icon: _loading
-                ? const SizedBox(
-                    width: 17,
-                    height: 17,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
+                ? const SkeletonActionIndicator(width: 17, height: 5)
                 : Icon(
                     _playing ? Icons.pause_rounded : Icons.play_arrow_rounded,
                     size: 25,

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_member_card.dart
@@ -1,6 +1,7 @@
 import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/icons/build_stars.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/features/player/data/player_service.dart';
 import 'package:clashkingapp/features/player/presentation/player/player_page.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
@@ -388,8 +389,7 @@ class MembersCard extends StatelessWidget {
                         context: context,
                         useRootNavigator: false,
                         barrierDismissible: false,
-                        builder: (_) =>
-                            const Center(child: CircularProgressIndicator()),
+                        builder: (_) => const SkeletonLoadingDialog(),
                       );
                       final player = await PlayerService().getPlayerAndClanData(
                         member.tag,

--- a/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
+++ b/lib/features/war_cwl/presentation/cwl/widgets/cwl_team_card.dart
@@ -1,5 +1,6 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
 import 'package:clashkingapp/common/widgets/icons/build_stars.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
@@ -55,8 +56,7 @@ class CwlTeamCard extends StatelessWidget {
                 showDialog(
                   context: context,
                   barrierDismissible: false,
-                  builder: (_) =>
-                      const Center(child: CircularProgressIndicator()),
+                  builder: (_) => const SkeletonLoadingDialog(),
                 );
                 final Clan clanInfo = await ClanService().loadClanData(
                   clan.tag,

--- a/lib/features/war_cwl/presentation/war/widgets/war_header.dart
+++ b/lib/features/war_cwl/presentation/war/widgets/war_header.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:clashkingapp/common/widgets/dialogs/snackbar.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
 import 'package:clashkingapp/features/clan/data/clan_service.dart';
@@ -182,7 +183,7 @@ class _WarHeaderState extends State<WarHeader> {
     showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (_) => const Center(child: CircularProgressIndicator()),
+      builder: (_) => const SkeletonLoadingDialog(),
     );
 
     final Clan clanInfo = await ClanService().loadClanData(clan.tag);

--- a/lib/features/war_cwl/presentation/war_stats/clan_war_log.dart
+++ b/lib/features/war_cwl/presentation/war_stats/clan_war_log.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/common/widgets/summary_chips.dart';
@@ -159,7 +160,7 @@ class ClanWarLog extends StatelessWidget {
             useRootNavigator: false,
             barrierDismissible: false,
             builder: (BuildContext context) {
-              return Center(child: CircularProgressIndicator());
+              return const SkeletonLoadingDialog();
             },
           );
           try {

--- a/lib/features/war_cwl/presentation/war_stats/war_stats_players.dart
+++ b/lib/features/war_cwl/presentation/war_stats/war_stats_players.dart
@@ -1,4 +1,5 @@
 // Fichier : war_stats_page.dart
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
@@ -86,7 +87,7 @@ class ClanWarStatsPlayers extends StatelessWidget {
             context: context,
             useRootNavigator: false,
             barrierDismissible: false,
-            builder: (_) => const Center(child: CircularProgressIndicator()),
+            builder: (_) => const SkeletonLoadingDialog(),
           );
           try {
             final player = await context

--- a/lib/widgets/war_widget.dart
+++ b/lib/widgets/war_widget.dart
@@ -1,3 +1,4 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
@@ -618,7 +619,7 @@ class WarDisplayWidgetState extends State<WarDisplayWidget> {
       return const Card(
         child: Padding(
           padding: EdgeInsets.all(16.0),
-          child: Center(child: CircularProgressIndicator()),
+          child: SkeletonListItem(lines: 3),
         ),
       );
     }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,6 +25,7 @@ sonar.coverage.exclusions=\
   lib/**/*_service.dart,\
   lib/firebase_options.dart,\
   lib/core/config/**,\
+  lib/core/utils/deep_link_handler.dart,\
   lib/core/utils/discord_auth_helper*.dart,\
   lib/core/services/android_workmanager_service.dart,\
   lib/core/services/notification_debug_service.dart,\

--- a/test/common/widgets/info_profile_tabs_test.dart
+++ b/test/common/widgets/info_profile_tabs_test.dart
@@ -164,6 +164,35 @@ void main() {
     }
   });
 
+  testWidgets('external body tab changes reset the replacement content top', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: _SelectedBodyHarness()));
+    final state = tester.state<_SelectedBodyHarnessState>(
+      find.byType(_SelectedBodyHarness),
+    );
+
+    await tester.drag(
+      find.byKey(const ValueKey('selected-body-0')),
+      const Offset(0, -700),
+    );
+    await tester.pumpAndSettle();
+
+    state.selectExternally(1);
+    await tester.pump();
+
+    expect(find.text('Body 1 top'), findsOneWidget);
+    final initialTop = tester.getTopLeft(find.text('Body 1 top')).dy;
+    for (var frame = 0; frame < 20; frame++) {
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(
+        tester.getTopLeft(find.text('Body 1 top')).dy,
+        closeTo(initialTop, 1),
+        reason: 'external replacement body shifted after frame $frame',
+      );
+    }
+  });
+
   testWidgets(
     'pinned profile tabs stay hidden before reaching the scroll edge',
     (tester) async {
@@ -341,6 +370,10 @@ class _SelectedBodyHarness extends StatefulWidget {
 
 class _SelectedBodyHarnessState extends State<_SelectedBodyHarness> {
   var selectedIndex = 0;
+
+  void selectExternally(int index) {
+    setState(() => selectedIndex = index);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/test/common/widgets/liquid_glass_test.dart
+++ b/test/common/widgets/liquid_glass_test.dart
@@ -124,6 +124,33 @@ void main() {
     expect(style.fontSize, 13);
   });
 
+  testWidgets('app glass segmented control exposes stable semantic buttons', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 360,
+              child: AppGlassSegmentedControl<int>(
+                values: const [0, 1],
+                labels: const ['Discord', 'Email'],
+                selected: 0,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Discord'), findsOneWidget);
+      expect(find.bySemanticsLabel('Email'), findsOneWidget);
+    } finally {
+      semantics.dispose();
+    }
+  });
   testWidgets('segmented control uses thin CK-style translucent capsules', (
     tester,
   ) async {

--- a/test/common/widgets/loading/skeleton_loading_test.dart
+++ b/test/common/widgets/loading/skeleton_loading_test.dart
@@ -1,0 +1,80 @@
+import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('skeleton loader renders with configured dimensions', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SkeletonLoader(
+            width: 80,
+            height: 12,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(SkeletonLoader), findsOneWidget);
+    expect(tester.getSize(find.byType(SkeletonLoader)), const Size(80, 12));
+  });
+
+  testWidgets('skeleton action indicator keeps a compact square footprint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SkeletonActionIndicator(width: 24, height: 8)),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byType(SkeletonActionIndicator)),
+      const Size(24, 24),
+    );
+    expect(find.byType(SkeletonLoader), findsOneWidget);
+  });
+
+  testWidgets('skeleton page composes header and list placeholders', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: SkeletonPage(itemCount: 3))),
+    );
+
+    expect(find.byType(SkeletonPage), findsOneWidget);
+    expect(find.byType(SkeletonList), findsOneWidget);
+    expect(find.byType(SkeletonListItem), findsNWidgets(3));
+  });
+
+  testWidgets('skeleton loading dialog renders a bounded material surface', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: SkeletonLoadingDialog())),
+    );
+
+    expect(find.byType(SkeletonLoadingDialog), findsOneWidget);
+    expect(find.byType(Material), findsWidgets);
+    expect(find.byType(SkeletonLoader), findsNWidgets(3));
+  });
+
+  testWidgets('war and stat skeleton cards render their placeholder shapes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Column(children: [WarStatsSkeletonCard(), StatCardSkeleton()]),
+        ),
+      ),
+    );
+
+    expect(find.byType(WarStatsSkeletonCard), findsOneWidget);
+    expect(find.byType(StatCardSkeleton), findsOneWidget);
+    expect(find.byType(SkeletonLoader), findsWidgets);
+  });
+}

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,3 +1,4 @@
+- Replaced loading spinners across the app with skeleton placeholders that match the loaded layouts.
 - Empty/no-result screens now share the same visual treatment across side pages and rankings.
 - Settings language and theme pickers now match the app's current settings styling in light and dark mode
 - Refined notification audience settings with clearer account scope controls.


### PR DESCRIPTION
## Summary
- Replaced loading spinners across the app with skeleton placeholders that preserve the shape of the loaded UI.
- Added shared skeleton building blocks for compact action states, list placeholders, full-page placeholders, and blocking loading dialogs.
- Removed the automatic tab snap that caused Clan/Player detail pages to jump when switching sticky tabs.
- Updated Play Store release notes for the user-facing loading-state polish.

## Why
Loading states should feel stable and match the final layout instead of showing centered circular spinners. The shared detail tab scaffold also forced the outer scroll position to the sticky threshold during tab changes, which made the screen visibly jump.

## Validation
- flutter analyze
- rg "CircularProgressIndicator|RefreshProgressIndicator|CupertinoActivityIndicator" lib
  - Only remaining occurrence is the achievements progress ring in player_page.dart, which is a real progress visualization (`value: ratio`), not a loading state.
- git diff --check