### PR TITLE
refactor: align to-do chips with shared components

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -91,11 +91,22 @@ export function authSegment(page: Page, name: RegExp): Locator {
       ? /^discord$/i
       : name;
 
-  return page
+  const ariaLabelSelector = /email/i.test(name.source)
+    ? 'flt-semantics[aria-label*="Email" i]'
+    : /discord/i.test(name.source)
+      ? 'flt-semantics[aria-label*="Discord" i]'
+      : null;
+
+  let segment = page
     .getByRole('tab', { name: exactName })
     .or(page.getByRole('button', { name: exactName }))
-    .or(page.locator('flt-semantics').filter({ hasText: exactName }))
-    .first();
+    .or(page.locator('flt-semantics').filter({ hasText: exactName }));
+
+  if (ariaLabelSelector) {
+    segment = segment.or(page.locator(ariaLabelSelector));
+  }
+
+  return segment.first();
 }
 
 export async function clickAuthSegment(page: Page, name: RegExp) {

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -93,7 +93,7 @@ export function authSegment(page: Page, name: RegExp): Locator {
 
   if (/email/i.test(name.source)) {
     return page
-      .locator('flt-semantics[aria-label*="Email" i]')
+      .locator('flt-semantics[aria-label="Email" i]')
       .or(page.getByRole('tab', { name: exactName }))
       .or(page.getByRole('button', { name: exactName }))
       .first();
@@ -101,7 +101,7 @@ export function authSegment(page: Page, name: RegExp): Locator {
 
   if (/discord/i.test(name.source)) {
     return page
-      .locator('flt-semantics[aria-label*="Discord" i]')
+      .locator('flt-semantics[aria-label="Discord" i]')
       .or(page.getByRole('tab', { name: exactName }))
       .or(page.getByRole('button', { name: exactName }))
       .first();

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -91,22 +91,27 @@ export function authSegment(page: Page, name: RegExp): Locator {
       ? /^discord$/i
       : name;
 
-  const ariaLabelSelector = /email/i.test(name.source)
-    ? 'flt-semantics[aria-label*="Email" i]'
-    : /discord/i.test(name.source)
-      ? 'flt-semantics[aria-label*="Discord" i]'
-      : null;
-
-  let segment = page
-    .getByRole('tab', { name: exactName })
-    .or(page.getByRole('button', { name: exactName }))
-    .or(page.locator('flt-semantics').filter({ hasText: exactName }));
-
-  if (ariaLabelSelector) {
-    segment = segment.or(page.locator(ariaLabelSelector));
+  if (/email/i.test(name.source)) {
+    return page
+      .locator('flt-semantics[aria-label*="Email" i]')
+      .or(page.getByRole('tab', { name: exactName }))
+      .or(page.getByRole('button', { name: exactName }))
+      .first();
   }
 
-  return segment.first();
+  if (/discord/i.test(name.source)) {
+    return page
+      .locator('flt-semantics[aria-label*="Discord" i]')
+      .or(page.getByRole('tab', { name: exactName }))
+      .or(page.getByRole('button', { name: exactName }))
+      .first();
+  }
+
+  return page
+    .getByRole('tab', { name: exactName })
+    .or(page.getByRole('button', { name: exactName }))
+    .or(page.locator('flt-semantics').filter({ hasText: exactName }))
+    .first();
 }
 
 export async function clickAuthSegment(page: Page, name: RegExp) {

--- a/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
@@ -1,15 +1,15 @@
+import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/home_metric_pill.dart';
 import 'package:clashkingapp/common/widgets/indicators/progress_ring_painter.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/core/constants/image_assets.dart';
-import 'package:clashkingapp/core/functions/functions.dart';
 import 'package:clashkingapp/core/services/bookmark_service.dart';
 import 'package:clashkingapp/features/player/models/player.dart';
 import 'package:clashkingapp/features/player/presentation/player/player_page.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_member_presence.dart';
 import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class PlayerToDoBodyCard extends StatelessWidget {
@@ -27,8 +27,8 @@ class PlayerToDoBodyCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final ratio = player.getTodoProgressRatio(memberCwl: member);
     final percent = (ratio * 100).round();
-    final tasks = _TodoTask.build(context, player, member);
-    final openTasks = tasks.where((task) => !task.done).length;
+    final metrics = _TodoCardMetric.build(context, player, member);
+    final openTasks = metrics.where((metric) => !metric.done).length;
     final statusColor = openTasks == 0 ? StatColors.win : colorScheme.primary;
     final bookmarked = context.watch<BookmarkService>().isPlayerBookmarked(
       player.tag,
@@ -65,14 +65,13 @@ class PlayerToDoBodyCard extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 12),
-              if (tasks.isEmpty)
+              if (metrics.isEmpty)
                 _QuietState(color: statusColor)
               else
-                Wrap(
-                  spacing: 7,
-                  runSpacing: 7,
-                  children: tasks
-                      .map((task) => _TaskPill(task: task))
+                CKMetricChipGrid(
+                  spacing: HomeMetricPill.gap,
+                  chips: metrics
+                      .map((metric) => _TodoMetricPill(metric: metric))
                       .toList(growable: false),
                 ),
             ],
@@ -281,207 +280,92 @@ class _QuietState extends StatelessWidget {
   }
 }
 
-class _TaskPill extends StatelessWidget {
-  final _TodoTask task;
+class _TodoMetricPill extends StatelessWidget {
+  final _TodoCardMetric metric;
 
-  const _TaskPill({required this.task});
+  const _TodoMetricPill({required this.metric});
 
   @override
   Widget build(BuildContext context) {
-    final color = task.done ? StatColors.win : task.color;
-    final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: isDark ? 0.26 : 0.32),
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(7, 6, 10, 6),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: colorScheme.surface.withValues(alpha: 0.72),
-                shape: BoxShape.circle,
-              ),
-              child: SizedBox.square(
-                dimension: 27,
-                child: Padding(
-                  padding: const EdgeInsets.all(5),
-                  child: MobileWebImage(imageUrl: task.imageUrl),
-                ),
-              ),
-            ),
-            const SizedBox(width: 7),
-            Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 118),
-                  child: Text(
-                    task.label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                ),
-                Text(
-                  task.value,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: color,
-                    fontWeight: FontWeight.w900,
-                    height: 1.1,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
+    return HomeMetricPill(
+      label: metric.label,
+      value: metric.value,
+      progress: metric.progress,
+      imageUrl: metric.imageUrl,
+      fallbackIcon: metric.fallbackIcon,
+      semanticLabel: '${metric.label}: ${metric.value}',
     );
   }
 }
 
-class _TodoTask {
-  const _TodoTask({
+class _TodoCardMetric {
+  const _TodoCardMetric({
     required this.label,
     required this.value,
     required this.imageUrl,
-    required this.color,
-    required this.done,
+    required this.progress,
+    required this.fallbackIcon,
   });
 
   final String label;
   final String value;
   final String imageUrl;
-  final Color color;
-  final bool done;
+  final double progress;
+  final IconData fallbackIcon;
 
-  static List<_TodoTask> build(
+  bool get done => progress >= 1;
+
+  static List<_TodoCardMetric> build(
     BuildContext context,
     Player player,
     WarMemberPresence member,
   ) {
     final loc = AppLocalizations.of(context)!;
-    final locale = Localizations.localeOf(context).toString();
-    final compact = NumberFormat.compact(locale: locale);
-    final tasks = <_TodoTask>[
-      ..._legendTask(loc, player),
-      ..._warTask(loc, player, member),
-      ..._clanGamesTask(loc, compact, player),
-      _seasonPassTask(loc, compact, player),
-    ];
+    final metrics = player
+        .getTodoProgressMetrics(memberCwl: member)
+        .map((metric) => _TodoCardMetric.fromProgressMetric(metric, loc))
+        .toList(growable: false);
 
-    tasks.sort((a, b) {
+    metrics.sort((a, b) {
       if (a.done != b.done) return a.done ? 1 : -1;
       return a.label.compareTo(b.label);
     });
-    return tasks;
+    return metrics;
   }
 
-  static List<_TodoTask> _legendTask(AppLocalizations loc, Player player) {
-    if (player.league != 'Legend League' ||
-        player.currentLegendSeason?.currentDay == null) {
-      return const [];
-    }
-    final done = player.currentLegendSeason?.currentDay?.totalAttacks ?? 0;
-    return [
-      _TodoTask(
-        label: loc.legendsTitle,
-        value: '$done/8',
-        imageUrl: ImageAssets.legendBlazonNoPadding,
-        color: const Color(0xFF4E7DF2),
-        done: done >= 8,
-      ),
-    ];
-  }
-
-  // `clan.warCwl.warInfo` is the primary source of "this clan's current
-  // war" — used for both regular wars and CWL rounds, so `isInCwl` decides
-  // the label/icon, not which field the data came from. `player.warData`
-  // (from the player endpoint directly) is the fallback for players
-  // hydrated without a linked `clan.warCwl` (e.g. bookmarked/public
-  // accounts).
-  static List<_TodoTask> _warTask(
+  factory _TodoCardMetric.fromProgressMetric(
+    TodoProgressMetric metric,
     AppLocalizations loc,
-    Player player,
-    WarMemberPresence member,
   ) {
-    final currentWar = player.clan?.warCwl?.warInfo ?? player.warData;
-    final isActuallyInCwl = player.clan?.warCwl?.isInCwl == true;
-    if (currentWar != null &&
-        currentWar.state == 'inWar' &&
-        currentWar.isPlayerInWar(player.tag, player.clanTag)) {
-      final total = currentWar.attacksPerMember ?? (isActuallyInCwl ? 1 : 2);
-      final done = currentWar.getAttacksDoneByPlayer(
-        player.tag,
-        player.clanTag,
-      );
-      return [
-        _TodoTask(
-          label: isActuallyInCwl ? loc.cwlTitle : loc.warTitle,
-          value: '$done/$total',
-          imageUrl: isActuallyInCwl
-              ? ImageAssets.cwlSwordsNoBorder
-              : ImageAssets.war,
-          color: isActuallyInCwl ? const Color(0xFF8D63D9) : StatColors.loss,
-          done: done >= total,
-        ),
-      ];
-    }
-    if (isActuallyInCwl &&
-        isInTimeFrameForCwl() &&
-        member.attacksAvailable > 0) {
-      return [
-        _TodoTask(
-          label: loc.cwlTitle,
-          value: '${member.attacksDone}/${member.attacksAvailable}',
-          imageUrl: ImageAssets.cwlSwordsNoBorder,
-          color: const Color(0xFF8D63D9),
-          done: member.attacksDone >= member.attacksAvailable,
-        ),
-      ];
-    }
-    return const [];
-  }
-
-  static List<_TodoTask> _clanGamesTask(
-    AppLocalizations loc,
-    NumberFormat compact,
-    Player player,
-  ) {
-    if (!isInTimeFrameForClanGames()) return const [];
-    return [
-      _TodoTask(
-        label: loc.gameClanGames,
-        value: compact.format(player.currentClanGamesPoints),
-        imageUrl: ImageAssets.clanGamesMedals,
-        color: StatColors.win,
-        done: player.clanGamesRatio >= 1,
-      ),
-    ];
-  }
-
-  static _TodoTask _seasonPassTask(
-    AppLocalizations loc,
-    NumberFormat compact,
-    Player player,
-  ) {
-    return _TodoTask(
-      label: loc.gameSeasonPassShort,
-      value: compact.format(player.currentSeasonPoints),
-      imageUrl: ImageAssets.iconGoldPass,
-      color: StatColors.warStarGold,
-      done: player.seasonPassRatio >= 1,
+    return _TodoCardMetric(
+      label: _displayLabel(metric.label, loc),
+      value: '${metric.done}/${metric.total}',
+      progress: metric.progressRatio,
+      imageUrl: switch (metric.label) {
+        'legend_attacks' => ImageAssets.legendBlazonNoPadding,
+        'war_attacks' => ImageAssets.war,
+        'cwl_attacks' => ImageAssets.cwlSwordsNoBorder,
+        'clan_games' => ImageAssets.clanGamesMedals,
+        _ => ImageAssets.iconGoldPass,
+      },
+      fallbackIcon: switch (metric.label) {
+        'legend_attacks' => Icons.shield_rounded,
+        'war_attacks' => Icons.local_fire_department_rounded,
+        'cwl_attacks' => Icons.military_tech_rounded,
+        'clan_games' => Icons.emoji_events_rounded,
+        _ => Icons.confirmation_number_rounded,
+      },
     );
+  }
+
+  static String _displayLabel(String label, AppLocalizations loc) {
+    return switch (label) {
+      'legend_attacks' => loc.todoLegendAttacks,
+      'war_attacks' => loc.todoWarAttacks,
+      'cwl_attacks' => loc.todoCwlAttacks,
+      'clan_games' => loc.gameClanGames,
+      'season_pass' => loc.gameSeasonPassShort,
+      _ => label,
+    };
   }
 }

--- a/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
@@ -305,6 +305,7 @@ class _TodoCardMetric {
     required this.imageUrl,
     required this.progress,
     required this.fallbackIcon,
+    required this.done,
   });
 
   final String label;
@@ -313,7 +314,7 @@ class _TodoCardMetric {
   final double progress;
   final IconData fallbackIcon;
 
-  bool get done => progress >= 1;
+  final bool done;
 
   static List<_TodoCardMetric> build(
     BuildContext context,
@@ -323,7 +324,9 @@ class _TodoCardMetric {
     final loc = AppLocalizations.of(context)!;
     final metrics = player
         .getTodoProgressMetrics(memberCwl: member)
-        .map((metric) => _TodoCardMetric.fromProgressMetric(metric, loc))
+        .map(
+          (metric) => _TodoCardMetric.fromProgressMetric(metric, loc, player),
+        )
         .toList(growable: false);
 
     metrics.sort((a, b) {
@@ -336,11 +339,15 @@ class _TodoCardMetric {
   factory _TodoCardMetric.fromProgressMetric(
     TodoProgressMetric metric,
     AppLocalizations loc,
+    Player player,
   ) {
     return _TodoCardMetric(
       label: _displayLabel(metric.label, loc),
       value: '${metric.done}/${metric.total}',
       progress: metric.progressRatio,
+      done: metric.label == 'clan_games'
+          ? player.clanGamesRatio >= 1
+          : metric.progressRatio >= 1,
       imageUrl: switch (metric.label) {
         'legend_attacks' => ImageAssets.legendBlazonNoPadding,
         'war_attacks' => ImageAssets.war,

--- a/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
@@ -1,4 +1,3 @@
-import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/widgets/buttons/info_button.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/indicators/progress_ring_painter.dart';
@@ -251,50 +250,44 @@ class _TodoStatsPanel extends StatelessWidget {
         const SizedBox(height: 8),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: MetricChipGrid(
-            spacing: 7,
+          child: _TodoHeaderQuickStats(
             chips: [
               if (summary.legendTotal > 0)
-                MetricChip(
-                  label: loc.legendsTitle,
+                _TodoHeaderQuickChip(
                   value: '${summary.legendDone}/${summary.legendTotal}',
                   imageUrl: ImageAssets.legendBlazonNoPadding,
-                  color: CKColors.legendBlue,
+                  tooltip: loc.legendsTitle,
                 ),
               if (summary.warTotal > 0)
-                MetricChip(
-                  label: loc.warTitle,
+                _TodoHeaderQuickChip(
                   value: '${summary.warDone}/${summary.warTotal}',
                   imageUrl: ImageAssets.war,
-                  color: CKColors.lossRed,
+                  tooltip: loc.warTitle,
                 ),
               if (summary.cwlTotal > 0)
-                MetricChip(
-                  label: loc.cwlTitle,
+                _TodoHeaderQuickChip(
                   value: '${summary.cwlDone}/${summary.cwlTotal}',
                   imageUrl: ImageAssets.cwlSwordsNoBorder,
-                  color: CKColors.capitalPurple,
+                  tooltip: loc.cwlTitle,
                 ),
               if (summary.clanGamesTotal > 0)
-                MetricChip(
-                  label: loc.gameClanGames,
+                _TodoHeaderQuickChip(
                   value: summary.compactValue(
                     context,
                     summary.clanGamesDone,
                     summary.clanGamesTotal,
                   ),
                   imageUrl: ImageAssets.clanGamesMedals,
-                  color: CKColors.donationGreen,
+                  tooltip: loc.gameClanGames,
                 ),
-              MetricChip(
-                label: loc.gameSeasonPassShort,
+              _TodoHeaderQuickChip(
                 value: summary.compactValue(
                   context,
                   summary.seasonDone,
                   summary.seasonTotal,
                 ),
                 imageUrl: ImageAssets.iconGoldPass,
-                color: CKColors.warGold,
+                tooltip: loc.gameSeasonPass,
               ),
             ],
           ),
@@ -317,9 +310,7 @@ class _TodoProgressSummaryTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final loc = AppLocalizations.of(context)!;
-    final color = summary.openTasks == 0
-        ? CKColors.donationGreen
-        : colorScheme.primary;
+    final color = summary.openTasks == 0 ? Colors.green : colorScheme.primary;
     final completedTasks = summary.totalTasks - summary.openTasks;
 
     const height = 76.0;
@@ -376,6 +367,89 @@ class _TodoProgressSummaryTile extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _TodoHeaderQuickStats extends StatelessWidget {
+  const _TodoHeaderQuickStats({required this.chips});
+
+  final List<_TodoHeaderQuickChip> chips;
+
+  @override
+  Widget build(BuildContext context) {
+    if (chips.isEmpty) return const SizedBox.shrink();
+
+    return SizedBox(
+      width: double.infinity,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.center,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (var index = 0; index < chips.length; index++) ...[
+              if (index > 0) const SizedBox(width: 7),
+              chips[index],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TodoHeaderQuickChip extends StatelessWidget {
+  const _TodoHeaderQuickChip({
+    required this.value,
+    required this.imageUrl,
+    required this.tooltip,
+  });
+
+  final String value;
+  final String imageUrl;
+  final String tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final foreground = colorScheme.onSurface;
+
+    return Tooltip(
+      message: tooltip,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: colorScheme.surface.withValues(alpha: 0.58),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            MobileWebImage(
+              imageUrl: imageUrl,
+              width: 19,
+              height: 19,
+              fit: BoxFit.contain,
+            ),
+            const SizedBox(width: 5),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 132),
+              child: Text(
+                value,
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: foreground,
+                  fontWeight: FontWeight.w700,
+                  height: 1,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
@@ -313,54 +313,42 @@ class _TodoProgressSummaryTile extends StatelessWidget {
     final color = summary.openTasks == 0 ? Colors.green : colorScheme.primary;
     final completedTasks = summary.totalTasks - summary.openTasks;
 
-    const height = 76.0;
-    return SizedBox(
-      height: height,
-      child: Stack(
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Positioned.fill(
-            child: HeaderPanelBackground(height: height, cornerRadius: 16),
+          _HeaderProgressRing(
+            ratio: summary.progressRatio,
+            percent: percent,
+            color: color,
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            child: Row(
+          const SizedBox(width: 12),
+          Flexible(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _HeaderProgressRing(
-                  ratio: summary.progressRatio,
-                  percent: percent,
-                  color: color,
+                Text(
+                  summary.openTasks == 0
+                      ? loc.generalCompleted
+                      : '${summary.openTasks} ${loc.generalRemaining}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                    height: 1,
+                  ),
                 ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        summary.openTasks == 0
-                            ? loc.generalCompleted
-                            : '${summary.openTasks} ${loc.generalRemaining}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.titleMedium
-                            ?.copyWith(
-                              color: colorScheme.onSurface,
-                              fontWeight: FontWeight.w800,
-                              height: 1,
-                            ),
-                      ),
-                      const SizedBox(height: 5),
-                      Text(
-                        '$completedTasks/${summary.totalTasks} ${loc.generalCompleted} · ${loc.todoAccountsNumber(summary.totalAccounts)}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.labelMedium
-                            ?.copyWith(
-                              color: colorScheme.onSurfaceVariant,
-                              fontWeight: FontWeight.w700,
-                            ),
-                      ),
-                    ],
+                const SizedBox(height: 5),
+                Text(
+                  '$completedTasks/${summary.totalTasks} ${loc.generalCompleted} · ${loc.todoAccountsNumber(summary.totalAccounts)}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.72),
+                    fontWeight: FontWeight.w700,
                   ),
                 ),
               ],

--- a/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
@@ -1,3 +1,4 @@
+import 'package:clashking_design_system/clashking_design_system.dart';
 import 'package:clashkingapp/common/widgets/buttons/info_button.dart';
 import 'package:clashkingapp/common/widgets/header_widgets.dart';
 import 'package:clashkingapp/common/widgets/indicators/progress_ring_painter.dart';
@@ -250,44 +251,50 @@ class _TodoStatsPanel extends StatelessWidget {
         const SizedBox(height: 8),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: _TodoChipRows(
-            children: [
+          child: MetricChipGrid(
+            spacing: 7,
+            chips: [
               if (summary.legendTotal > 0)
-                _TodoQuickChip(
+                MetricChip(
+                  label: loc.legendsTitle,
                   value: '${summary.legendDone}/${summary.legendTotal}',
                   imageUrl: ImageAssets.legendBlazonNoPadding,
-                  tooltip: loc.legendsTitle,
+                  color: CKColors.legendBlue,
                 ),
               if (summary.warTotal > 0)
-                _TodoQuickChip(
+                MetricChip(
+                  label: loc.warTitle,
                   value: '${summary.warDone}/${summary.warTotal}',
                   imageUrl: ImageAssets.war,
-                  tooltip: loc.warTitle,
+                  color: CKColors.lossRed,
                 ),
               if (summary.cwlTotal > 0)
-                _TodoQuickChip(
+                MetricChip(
+                  label: loc.cwlTitle,
                   value: '${summary.cwlDone}/${summary.cwlTotal}',
                   imageUrl: ImageAssets.cwlSwordsNoBorder,
-                  tooltip: loc.cwlTitle,
+                  color: CKColors.capitalPurple,
                 ),
               if (summary.clanGamesTotal > 0)
-                _TodoQuickChip(
+                MetricChip(
+                  label: loc.gameClanGames,
                   value: summary.compactValue(
                     context,
                     summary.clanGamesDone,
                     summary.clanGamesTotal,
                   ),
                   imageUrl: ImageAssets.clanGamesMedals,
-                  tooltip: loc.gameClanGames,
+                  color: CKColors.donationGreen,
                 ),
-              _TodoQuickChip(
+              MetricChip(
+                label: loc.gameSeasonPassShort,
                 value: summary.compactValue(
                   context,
                   summary.seasonDone,
                   summary.seasonTotal,
                 ),
                 imageUrl: ImageAssets.iconGoldPass,
-                tooltip: loc.gameSeasonPass,
+                color: CKColors.warGold,
               ),
             ],
           ),
@@ -310,49 +317,59 @@ class _TodoProgressSummaryTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final loc = AppLocalizations.of(context)!;
-    final color = summary.openTasks == 0 ? Colors.green : colorScheme.primary;
+    final color = summary.openTasks == 0
+        ? CKColors.donationGreen
+        : colorScheme.primary;
     final completedTasks = summary.totalTasks - summary.openTasks;
 
-    return Container(
-      height: 76,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: colorScheme.surface.withValues(alpha: 0.58),
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Row(
+    const height = 76.0;
+    return SizedBox(
+      height: height,
+      child: Stack(
         children: [
-          _HeaderProgressRing(
-            ratio: summary.progressRatio,
-            percent: percent,
-            color: color,
+          const Positioned.fill(
+            child: HeaderPanelBackground(height: height, cornerRadius: 16),
           ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.center,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
               children: [
-                Text(
-                  summary.openTasks == 0
-                      ? loc.generalCompleted
-                      : '${summary.openTasks} ${loc.generalRemaining}',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: colorScheme.onSurface,
-                    fontWeight: FontWeight.w800,
-                    height: 1,
-                  ),
+                _HeaderProgressRing(
+                  ratio: summary.progressRatio,
+                  percent: percent,
+                  color: color,
                 ),
-                const SizedBox(height: 5),
-                Text(
-                  '$completedTasks/${summary.totalTasks} ${loc.generalCompleted} · ${loc.todoAccountsNumber(summary.totalAccounts)}',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        summary.openTasks == 0
+                            ? loc.generalCompleted
+                            : '${summary.openTasks} ${loc.generalRemaining}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurface,
+                              fontWeight: FontWeight.w800,
+                              height: 1,
+                            ),
+                      ),
+                      const SizedBox(height: 5),
+                      Text(
+                        '$completedTasks/${summary.totalTasks} ${loc.generalCompleted} · ${loc.todoAccountsNumber(summary.totalAccounts)}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.labelMedium
+                            ?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                              fontWeight: FontWeight.w700,
+                            ),
+                      ),
+                    ],
                   ),
                 ),
               ],
@@ -398,77 +415,6 @@ class _HeaderProgressRing extends StatelessWidget {
               height: 1,
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _TodoChipRows extends StatelessWidget {
-  final List<_TodoQuickChip> children;
-
-  const _TodoChipRows({required this.children});
-
-  @override
-  Widget build(BuildContext context) {
-    if (children.isEmpty) return const SizedBox.shrink();
-
-    return Wrap(
-      alignment: WrapAlignment.center,
-      spacing: 7,
-      runSpacing: 7,
-      children: children,
-    );
-  }
-}
-
-class _TodoQuickChip extends StatelessWidget {
-  final String value;
-  final String? imageUrl;
-  final String tooltip;
-
-  const _TodoQuickChip({
-    required this.value,
-    this.imageUrl,
-    required this.tooltip,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final foreground = colorScheme.onSurface;
-
-    return Tooltip(
-      message: tooltip,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        decoration: BoxDecoration(
-          color: colorScheme.surface.withValues(alpha: 0.58),
-          borderRadius: BorderRadius.circular(999),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (imageUrl != null && imageUrl!.isNotEmpty)
-              MobileWebImage(imageUrl: imageUrl!, width: 19, height: 19)
-            else
-              Icon(Icons.info_rounded, size: 19, color: foreground),
-            const SizedBox(width: 5),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 132),
-              child: Text(
-                value,
-                maxLines: 1,
-                softWrap: false,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: foreground,
-                  fontWeight: FontWeight.w700,
-                  height: 1,
-                ),
-              ),
-            ),
-          ],
         ),
       ),
     );

--- a/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_header.dart
@@ -322,6 +322,7 @@ class _TodoProgressSummaryTile extends StatelessWidget {
             ratio: summary.progressRatio,
             percent: percent,
             color: color,
+            foregroundColor: Colors.white,
           ),
           const SizedBox(width: 12),
           Flexible(
@@ -447,11 +448,13 @@ class _HeaderProgressRing extends StatelessWidget {
   final double ratio;
   final int percent;
   final Color color;
+  final Color? foregroundColor;
 
   const _HeaderProgressRing({
     required this.ratio,
     required this.percent,
     required this.color,
+    this.foregroundColor,
   });
 
   @override
@@ -471,7 +474,7 @@ class _HeaderProgressRing extends StatelessWidget {
           child: Text(
             '$percent%',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: colorScheme.onSurface,
+              color: foregroundColor ?? colorScheme.onSurface,
               fontSize: 13,
               fontWeight: FontWeight.w900,
               height: 1,

--- a/update-news/whatsnew-en-US
+++ b/update-news/whatsnew-en-US
@@ -1,3 +1,5 @@
+- To Do header stats now sit directly on the hero image and match the compact quick-stat style used by other headers.
+- To Do account cards now use the same metric chips as the Home to-do card.
 - Replaced loading spinners across the app with skeleton placeholders that match the loaded layouts.
 - Empty/no-result screens now share the same visual treatment across side pages and rankings.
 - Settings language and theme pickers now match the app's current settings styling in light and dark mode


### PR DESCRIPTION
## Summary
- Reuse the Home to-do metric chip layout on the detailed To Do account cards.
- Align the To Do hero header with the compact quick-stat style used by other headers, without wrapping the summary in a header card.
- Update Play Store release notes for the To Do visual polish.

## Why
The detailed To Do page had custom account-card chips and a header stat treatment that diverged from the Home to-do card and the surrounding ClashKing hero-header language. This keeps the account cards on the shared Home/DevKit metric chip system while making the header read like an overlay on the hero image instead of a nested card.

## Validation
- `flutter analyze --no-pub lib\features\player\presentation\to_do\widget\player_to_do_body_card.dart lib\features\player\presentation\to_do\widget\player_to_do_header.dart`

## Notes
- Phone build/install was not completed in this session because the Android debug build failed during the CMake x86_64 configuration before retrying the arm64-only build.