### PR TITLE
style: polish sparse collection pages on web

### DIFF
--- a/lib/common/widgets/responsive_card_grid.dart
+++ b/lib/common/widgets/responsive_card_grid.dart
@@ -8,6 +8,7 @@ class ResponsiveCardGrid extends StatelessWidget {
     this.minItemWidth = 420,
     this.maxColumns = 3,
     this.spacing = 12,
+    this.alignment = WrapAlignment.start,
   });
 
   final int itemCount;
@@ -15,6 +16,7 @@ class ResponsiveCardGrid extends StatelessWidget {
   final double minItemWidth;
   final int maxColumns;
   final double spacing;
+  final WrapAlignment alignment;
 
   @override
   Widget build(BuildContext context) {
@@ -27,13 +29,19 @@ class ResponsiveCardGrid extends StatelessWidget {
         final itemWidth =
             (availableWidth - (spacing * (columns - 1))) / columns;
 
-        return Wrap(
-          spacing: spacing,
-          runSpacing: spacing,
-          children: List.generate(
-            itemCount,
-            (index) =>
-                SizedBox(width: itemWidth, child: itemBuilder(context, index)),
+        return SizedBox(
+          width: availableWidth,
+          child: Wrap(
+            alignment: alignment,
+            spacing: spacing,
+            runSpacing: spacing,
+            children: List.generate(
+              itemCount,
+              (index) => SizedBox(
+                width: itemWidth,
+                child: itemBuilder(context, index),
+              ),
+            ),
           ),
         );
       },

--- a/lib/features/pages/presentation/clan_page.dart
+++ b/lib/features/pages/presentation/clan_page.dart
@@ -125,6 +125,7 @@ class _ClanPageState extends State<ClanPage> {
                       ? SliverToBoxAdapter(
                           child: ResponsiveCardGrid(
                             itemCount: clans.length,
+                            alignment: WrapAlignment.center,
                             itemBuilder: (context, index) {
                               final item = clans[index];
                               return _ClanCard(

--- a/lib/features/pages/presentation/game_assets_page.dart
+++ b/lib/features/pages/presentation/game_assets_page.dart
@@ -10,7 +10,6 @@ import 'package:clashkingapp/features/game_assets/presentation/game_asset_image.
 import 'package:clashkingapp/features/war_cwl/presentation/war/widgets/war_search_field.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
 import 'side_page_components.dart';
@@ -303,8 +302,12 @@ class _GameAssetsHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    final isDesktop = kIsWeb && MediaQuery.sizeOf(context).width >= 900;
-    final height = MediaQuery.paddingOf(context).top + (isDesktop ? 198 : 264);
+    final viewport = MediaQuery.sizeOf(context);
+    final isDesktop = viewport.width >= 900;
+    final isCompactLandscape = viewport.width >= 600 && viewport.height < 600;
+    final height =
+        MediaQuery.paddingOf(context).top +
+        (isCompactLandscape ? 144 : (isDesktop ? 240 : 264));
     final maxWidth = isDesktop ? 1120.0 : double.infinity;
     final category = this.category;
     final imageCount = category == null
@@ -327,6 +330,7 @@ class _GameAssetsHeader extends StatelessWidget {
           ),
         ),
         SizedBox(
+          key: const ValueKey('game-assets-header'),
           height: height,
           child: SafeArea(
             bottom: false,
@@ -362,7 +366,9 @@ class _GameAssetsHeader extends StatelessWidget {
                       ),
                     ],
                   ),
-                  SizedBox(height: isDesktop ? 4 : 8),
+                  SizedBox(
+                    height: isCompactLandscape ? 0 : (isDesktop ? 4 : 8),
+                  ),
                   Center(
                     child: ConstrainedBox(
                       constraints: BoxConstraints(maxWidth: maxWidth),
@@ -373,6 +379,7 @@ class _GameAssetsHeader extends StatelessWidget {
                         extensions: category?.extensions,
                         category: category,
                         buildImage: buildImage,
+                        compact: isCompactLandscape,
                       ),
                     ),
                   ),
@@ -394,6 +401,7 @@ class _GameAssetHeaderIdentity extends StatelessWidget {
     required this.extensions,
     required this.category,
     required this.buildImage,
+    required this.compact,
   });
 
   final String title;
@@ -402,6 +410,7 @@ class _GameAssetHeaderIdentity extends StatelessWidget {
   final List<String>? extensions;
   final GameAssetCategory? category;
   final GameAssetImageBuilder buildImage;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -412,6 +421,16 @@ class _GameAssetHeaderIdentity extends StatelessWidget {
         ? loc.gameAssetsAllFormats
         : extensions.take(2).map((value) => value.toUpperCase()).join(' / ');
     final category = this.category;
+    if (compact) {
+      return _GameAssetCompactHeaderIdentity(
+        title: title,
+        subtitle: subtitle,
+        imageCount: imageCount,
+        extensionText: extensionText,
+        category: category,
+        buildImage: buildImage,
+      );
+    }
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -478,6 +497,93 @@ class _GameAssetHeaderIdentity extends StatelessWidget {
             ),
         ],
       ),
+    );
+  }
+}
+
+class _GameAssetCompactHeaderIdentity extends StatelessWidget {
+  const _GameAssetCompactHeaderIdentity({
+    required this.title,
+    required this.subtitle,
+    required this.imageCount,
+    required this.extensionText,
+    required this.category,
+    required this.buildImage,
+  });
+
+  final String title;
+  final String subtitle;
+  final String? imageCount;
+  final String extensionText;
+  final GameAssetCategory? category;
+  final GameAssetImageBuilder buildImage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        SizedBox(
+          key: const ValueKey('game-assets-compact-header-image'),
+          width: 56,
+          height: 56,
+          child: category == null
+              ? const SkeletonLoader(
+                  width: 48,
+                  height: 48,
+                  borderRadius: BorderRadius.all(Radius.circular(14)),
+                )
+              : buildImage(
+                  context,
+                  category!.representativeAsset,
+                  BoxFit.contain,
+                ),
+        ),
+        const SizedBox(width: 12),
+        Flexible(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              Text(
+                subtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.white.withValues(alpha: 0.72),
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 20),
+        if (imageCount == null)
+          const _GameAssetHeaderStatsSkeleton()
+        else
+          Wrap(
+            spacing: 7,
+            children: [
+              _GameAssetHeaderStat(
+                icon: Icons.photo_library_rounded,
+                value: imageCount!,
+              ),
+              _GameAssetHeaderStat(
+                icon: Icons.file_present_rounded,
+                value: extensionText,
+              ),
+            ],
+          ),
+      ],
     );
   }
 }
@@ -636,81 +742,7 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
     final hasCategoryOptions = widget.categories.isNotEmpty;
     return Column(
       children: [
-        if (hasCategoryOptions)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 7),
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final filterWidth = (constraints.maxWidth - 8) / 2;
-                final categoryOptions = {
-                  for (final category in widget.categories)
-                    _gameAssetCategoryFilterLabel(
-                      context,
-                      loc,
-                      category,
-                      buildImage,
-                    ): category.id,
-                };
-                return Row(
-                  children: [
-                    FilterDropdown(
-                      sortBy: widget.selectedCategoryId ?? widget.category.id,
-                      updateSortBy: (value) {
-                        _searchController.clear();
-                        setState(() => _extension = '');
-                        widget.onCategorySelected?.call(value);
-                      },
-                      sortByOptions: categoryOptions,
-                      height: 36,
-                      maxWidth: filterWidth,
-                    ),
-                    const SizedBox(width: 8),
-                    FilterDropdown(
-                      sortBy: _extension,
-                      updateSortBy: (value) =>
-                          setState(() => _extension = value),
-                      sortByOptions: {
-                        loc.gameAssetsAllFormats: '',
-                        for (final extension in widget.category.extensions)
-                          extension.toUpperCase(): extension,
-                      },
-                      height: 36,
-                      leadingIcon: Icons.file_present_rounded,
-                      maxWidth: filterWidth,
-                    ),
-                  ],
-                );
-              },
-            ),
-          )
-        else
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 7),
-            child: Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: FilterDropdown(
-                sortBy: _extension,
-                updateSortBy: (value) => setState(() => _extension = value),
-                sortByOptions: {
-                  loc.gameAssetsAllFormats: '',
-                  for (final extension in widget.category.extensions)
-                    extension.toUpperCase(): extension,
-                },
-                height: 36,
-                leadingIcon: Icons.file_present_rounded,
-                maxWidth: 164,
-              ),
-            ),
-          ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 7),
-          child: WarSearchField(
-            key: const ValueKey('game-assets-search'),
-            controller: _searchController,
-            query: _query,
-            hintText: loc.gameAssetsSearchHint,
-          ),
-        ),
+        _buildAssetControls(loc, buildImage, hasCategoryOptions),
         Padding(
           padding: const EdgeInsets.fromLTRB(18, 0, 18, 7),
           child: Align(
@@ -758,6 +790,147 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
       ],
     );
   }
+
+  Widget _buildAssetControls(
+    AppLocalizations loc,
+    GameAssetImageBuilder buildImage,
+    bool hasCategoryOptions,
+  ) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isDesktopToolbar = constraints.maxWidth >= 600;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 7),
+          child: isDesktopToolbar
+              ? _buildDesktopAssetControls(loc, buildImage, hasCategoryOptions)
+              : _buildCompactAssetControls(
+                  loc,
+                  buildImage,
+                  hasCategoryOptions,
+                  constraints.maxWidth - 32,
+                ),
+        );
+      },
+    );
+  }
+
+  Widget _buildDesktopAssetControls(
+    AppLocalizations loc,
+    GameAssetImageBuilder buildImage,
+    bool hasCategoryOptions,
+  ) {
+    return Row(
+      key: const ValueKey('game-assets-desktop-toolbar'),
+      children: [
+        if (hasCategoryOptions) ...[
+          Expanded(
+            flex: 3,
+            child: FilterDropdown(
+              sortBy: widget.selectedCategoryId ?? widget.category.id,
+              updateSortBy: _selectCategory,
+              sortByOptions: _categoryOptions(loc, buildImage),
+              height: 44,
+              maxWidth: double.infinity,
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+        SizedBox(
+          width: 190,
+          child: FilterDropdown(
+            sortBy: _extension,
+            updateSortBy: _selectExtension,
+            sortByOptions: _formatOptions(loc),
+            height: 44,
+            leadingIcon: Icons.file_present_rounded,
+            maxWidth: 190,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          flex: 4,
+          child: WarSearchField(
+            key: const ValueKey('game-assets-search'),
+            controller: _searchController,
+            query: _query,
+            hintText: loc.gameAssetsSearchHint,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompactAssetControls(
+    AppLocalizations loc,
+    GameAssetImageBuilder buildImage,
+    bool hasCategoryOptions,
+    double width,
+  ) {
+    final filterWidth = hasCategoryOptions ? (width - 8) / 2 : 164.0;
+    return Column(
+      children: [
+        Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: Row(
+            children: [
+              if (hasCategoryOptions) ...[
+                FilterDropdown(
+                  sortBy: widget.selectedCategoryId ?? widget.category.id,
+                  updateSortBy: _selectCategory,
+                  sortByOptions: _categoryOptions(loc, buildImage),
+                  height: 36,
+                  maxWidth: filterWidth,
+                ),
+                const SizedBox(width: 8),
+              ],
+              FilterDropdown(
+                sortBy: _extension,
+                updateSortBy: _selectExtension,
+                sortByOptions: _formatOptions(loc),
+                height: 36,
+                leadingIcon: Icons.file_present_rounded,
+                maxWidth: filterWidth,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 7),
+        WarSearchField(
+          key: const ValueKey('game-assets-search'),
+          controller: _searchController,
+          query: _query,
+          hintText: loc.gameAssetsSearchHint,
+        ),
+      ],
+    );
+  }
+
+  Map<List<Widget>, String> _categoryOptions(
+    AppLocalizations loc,
+    GameAssetImageBuilder buildImage,
+  ) {
+    return {
+      for (final category in widget.categories)
+        _gameAssetCategoryFilterLabel(context, loc, category, buildImage):
+            category.id,
+    };
+  }
+
+  Map<String, String> _formatOptions(AppLocalizations loc) {
+    return {
+      loc.gameAssetsAllFormats: '',
+      for (final extension in widget.category.extensions)
+        extension.toUpperCase(): extension,
+    };
+  }
+
+  void _selectCategory(String value) {
+    _searchController.clear();
+    setState(() => _extension = '');
+    widget.onCategorySelected?.call(value);
+  }
+
+  void _selectExtension(String value) => setState(() => _extension = value);
 
   Widget _buildEmbeddedContent(Widget content) {
     return LayoutBuilder(

--- a/lib/features/pages/presentation/game_assets_page.dart
+++ b/lib/features/pages/presentation/game_assets_page.dart
@@ -738,7 +738,24 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
       ],
     );
 
-    if (widget.embedded) return content;
+    if (widget.embedded) {
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth > 1120
+              ? 1120.0
+              : constraints.maxWidth;
+          return Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              key: const ValueKey('game-assets-content-bound'),
+              width: width,
+              height: constraints.maxHeight,
+              child: content,
+            ),
+          );
+        },
+      );
+    }
     return SidePageScaffold(
       title: categoryName,
       subtitle: formatGameAssetImageCount(

--- a/lib/features/pages/presentation/game_assets_page.dart
+++ b/lib/features/pages/presentation/game_assets_page.dart
@@ -604,7 +604,6 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
       loc,
       widget.category.id,
     );
-    final hasCategoryOptions = widget.categories.isNotEmpty;
     final buildImage =
         widget.imageBuilder ??
         (context, asset, fit) => GameAssetImage(asset: asset, fit: fit);
@@ -613,8 +612,29 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
       query: _query,
       extension: _extension,
     );
+    final content = _buildContent(loc, buildImage, filteredAssets);
 
-    final content = Column(
+    if (widget.embedded) {
+      return _buildEmbeddedContent(content);
+    }
+    return SidePageScaffold(
+      title: categoryName,
+      subtitle: formatGameAssetImageCount(
+        loc,
+        widget.category.count,
+        Localizations.localeOf(context),
+      ),
+      child: content,
+    );
+  }
+
+  Widget _buildContent(
+    AppLocalizations loc,
+    GameAssetImageBuilder buildImage,
+    List<GameAsset> filteredAssets,
+  ) {
+    final hasCategoryOptions = widget.categories.isNotEmpty;
+    return Column(
       children: [
         if (hasCategoryOptions)
           Padding(
@@ -737,33 +757,24 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
         ),
       ],
     );
+  }
 
-    if (widget.embedded) {
-      return LayoutBuilder(
-        builder: (context, constraints) {
-          final width = constraints.maxWidth > 1120
-              ? 1120.0
-              : constraints.maxWidth;
-          return Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox(
-              key: const ValueKey('game-assets-content-bound'),
-              width: width,
-              height: constraints.maxHeight,
-              child: content,
-            ),
-          );
-        },
-      );
-    }
-    return SidePageScaffold(
-      title: categoryName,
-      subtitle: formatGameAssetImageCount(
-        loc,
-        widget.category.count,
-        Localizations.localeOf(context),
-      ),
-      child: content,
+  Widget _buildEmbeddedContent(Widget content) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth > 1120
+            ? 1120.0
+            : constraints.maxWidth;
+        return Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            key: const ValueKey('game-assets-content-bound'),
+            width: width,
+            height: constraints.maxHeight,
+            child: content,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/pages/presentation/game_assets_page.dart
+++ b/lib/features/pages/presentation/game_assets_page.dart
@@ -825,12 +825,14 @@ class _GameAssetCategoryPageState extends State<GameAssetCategoryPage> {
         if (hasCategoryOptions) ...[
           Expanded(
             flex: 3,
-            child: FilterDropdown(
-              sortBy: widget.selectedCategoryId ?? widget.category.id,
-              updateSortBy: _selectCategory,
-              sortByOptions: _categoryOptions(loc, buildImage),
-              height: 44,
-              maxWidth: double.infinity,
+            child: LayoutBuilder(
+              builder: (context, constraints) => FilterDropdown(
+                sortBy: widget.selectedCategoryId ?? widget.category.id,
+                updateSortBy: _selectCategory,
+                sortByOptions: _categoryOptions(loc, buildImage),
+                height: 44,
+                maxWidth: constraints.maxWidth,
+              ),
             ),
           ),
           const SizedBox(width: 8),

--- a/lib/features/pages/presentation/posts_page.dart
+++ b/lib/features/pages/presentation/posts_page.dart
@@ -1,4 +1,5 @@
 import 'package:clashkingapp/common/theme/app_tokens.dart';
+import 'package:clashkingapp/common/widgets/empty_state.dart';
 import 'package:clashkingapp/common/widgets/loading/skeleton_loading.dart';
 import 'package:clashkingapp/common/widgets/mobile_web_image.dart';
 import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
@@ -640,19 +641,16 @@ class _PostsMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 48),
-      child: Column(
-        children: [
-          Icon(icon, size: 42, color: colors.onSurfaceVariant),
-          const SizedBox(height: 12),
-          Text(title, textAlign: TextAlign.center),
-          if (actionLabel != null && onAction != null) ...[
-            const SizedBox(height: 16),
-            FilledButton.tonal(onPressed: onAction, child: Text(actionLabel!)),
-          ],
-        ],
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 720),
+        child: AppEmptyState(
+          title: title,
+          icon: icon,
+          actionLabel: actionLabel,
+          onAction: onAction,
+          padding: const EdgeInsets.only(top: 24),
+        ),
       ),
     );
   }

--- a/lib/features/pages/presentation/war_cwl_page.dart
+++ b/lib/features/pages/presentation/war_cwl_page.dart
@@ -223,6 +223,7 @@ class _WarCwlPageState extends State<WarCwlPage> {
                       ? SliverToBoxAdapter(
                           child: ResponsiveCardGrid(
                             itemCount: items.length,
+                            alignment: WrapAlignment.center,
                             itemBuilder: (context, index) =>
                                 _WarListCard(item: items[index]),
                           ),

--- a/lib/features/player/presentation/ranked/player_ranked_league_page.dart
+++ b/lib/features/player/presentation/ranked/player_ranked_league_page.dart
@@ -294,20 +294,24 @@ class _PlayerRankedLeagueScreenState extends State<PlayerRankedLeagueScreen> {
               ),
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
               children: [
-                _CurrentPeriodTab(
-                  data: data,
-                  period: selectedPeriod,
-                  onOlderSeason: selectedSeason < periods.length - 1
-                      ? () =>
-                            setState(() => _selectedSeason = selectedSeason + 1)
-                      : null,
-                  onNewerSeason: selectedSeason > 0
-                      ? () =>
-                            setState(() => _selectedSeason = selectedSeason - 1)
-                      : null,
-                  showRanking: _showCurrentRanking,
-                  onViewChanged: (showRanking) =>
-                      setState(() => _showCurrentRanking = showRanking),
+                _RankedContentBound(
+                  child: _CurrentPeriodTab(
+                    data: data,
+                    period: selectedPeriod,
+                    onOlderSeason: selectedSeason < periods.length - 1
+                        ? () => setState(
+                            () => _selectedSeason = selectedSeason + 1,
+                          )
+                        : null,
+                    onNewerSeason: selectedSeason > 0
+                        ? () => setState(
+                            () => _selectedSeason = selectedSeason - 1,
+                          )
+                        : null,
+                    showRanking: _showCurrentRanking,
+                    onViewChanged: (showRanking) =>
+                        setState(() => _showCurrentRanking = showRanking),
+                  ),
                 ),
               ],
             ),
@@ -319,16 +323,35 @@ class _PlayerRankedLeagueScreenState extends State<PlayerRankedLeagueScreen> {
               ),
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
               children: [
-                _HistoryTab(
-                  data: data,
-                  showTable: _showHistoryTable,
-                  onToggleView: () =>
-                      setState(() => _showHistoryTable = !_showHistoryTable),
+                _RankedContentBound(
+                  child: _HistoryTab(
+                    data: data,
+                    showTable: _showHistoryTable,
+                    onToggleView: () =>
+                        setState(() => _showHistoryTable = !_showHistoryTable),
+                  ),
                 ),
               ],
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _RankedContentBound extends StatelessWidget {
+  const _RankedContentBound({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        key: const ValueKey('ranked-content-bound'),
+        constraints: const BoxConstraints(maxWidth: 1120),
+        child: child,
       ),
     );
   }

--- a/lib/features/player/presentation/to_do/player_to_do_page.dart
+++ b/lib/features/player/presentation/to_do/player_to_do_page.dart
@@ -113,30 +113,37 @@ class PlayerToDoScreenState extends State<PlayerToDoScreen> {
             players: searchedPlayers,
             memberPresenceMap: widget.memberPresenceMap,
           ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            child: Column(
-              children: [
-                _TodoControls(
-                  controller: _searchController,
-                  query: _query,
-                  filter: _filter,
-                  counts: filterCounts,
-                  onQueryChanged: (value) => setState(() => _query = value),
-                  onClearQuery: _query.isEmpty
-                      ? null
-                      : () {
-                          _searchController.clear();
-                          setState(() => _query = '');
-                        },
-                  onFilterChanged: (value) => setState(() => _filter = value),
+          Center(
+            child: ConstrainedBox(
+              key: const ValueKey('todo-content-bound'),
+              constraints: const BoxConstraints(maxWidth: 1120),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                child: Column(
+                  children: [
+                    _TodoControls(
+                      controller: _searchController,
+                      query: _query,
+                      filter: _filter,
+                      counts: filterCounts,
+                      onQueryChanged: (value) => setState(() => _query = value),
+                      onClearQuery: _query.isEmpty
+                          ? null
+                          : () {
+                              _searchController.clear();
+                              setState(() => _query = '');
+                            },
+                      onFilterChanged: (value) =>
+                          setState(() => _filter = value),
+                    ),
+                    PlayerToDoBody(
+                      players: filteredPlayers,
+                      memberPresenceMap: widget.memberPresenceMap,
+                      emptyText: _emptyText(),
+                    ),
+                  ],
                 ),
-                PlayerToDoBody(
-                  players: filteredPlayers,
-                  memberPresenceMap: widget.memberPresenceMap,
-                  emptyText: _emptyText(),
-                ),
-              ],
+              ),
             ),
           ),
         ],

--- a/lib/features/player/presentation/to_do/widget/player_to_do_body.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_body.dart
@@ -2,6 +2,7 @@ import 'package:clashkingapp/features/player/models/player.dart';
 import 'package:clashkingapp/features/player/presentation/to_do/widget/player_to_do_body_card.dart';
 import 'package:clashkingapp/features/war_cwl/models/war_member_presence.dart';
 import 'package:clashkingapp/common/widgets/empty_state.dart';
+import 'package:clashkingapp/common/widgets/responsive_card_grid.dart';
 import 'package:flutter/material.dart';
 import 'package:clashkingapp/l10n/app_localizations.dart';
 
@@ -24,20 +25,24 @@ class PlayerToDoBody extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.only(top: 10),
-      child: Column(
-        children: [
-          if (visiblePlayers.isEmpty)
-            _EmptyTodoCard(text: emptyText)
-          else
-            ...visiblePlayers.map(
-              (player) => PlayerToDoBodyCard(
-                player: player,
-                member:
-                    memberPresenceMap[player.tag] ?? WarMemberPresence.empty(),
-              ),
+      child: visiblePlayers.isEmpty
+          ? _EmptyTodoCard(text: emptyText)
+          : ResponsiveCardGrid(
+              itemCount: visiblePlayers.length,
+              minItemWidth: 330,
+              maxColumns: 3,
+              spacing: 12,
+              alignment: WrapAlignment.center,
+              itemBuilder: (context, index) {
+                final player = visiblePlayers[index];
+                return PlayerToDoBodyCard(
+                  player: player,
+                  member:
+                      memberPresenceMap[player.tag] ??
+                      WarMemberPresence.empty(),
+                );
+              },
             ),
-        ],
-      ),
     );
   }
 }

--- a/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
+++ b/lib/features/player/presentation/to_do/widget/player_to_do_body_card.dart
@@ -35,7 +35,7 @@ class PlayerToDoBodyCard extends StatelessWidget {
     );
 
     return Card(
-      margin: const EdgeInsets.only(bottom: 10),
+      margin: EdgeInsets.zero,
       child: InkWell(
         borderRadius: BorderRadius.circular(28),
         onTap: () => Navigator.push(

--- a/lib/features/rankings/presentation/rankings_page.dart
+++ b/lib/features/rankings/presentation/rankings_page.dart
@@ -392,6 +392,7 @@ class _RankingsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final entries = provider.result?.entries ?? const <RankingEntry>[];
+    final horizontalPadding = _rankingsHorizontalPadding(context);
     final hasFilters =
         provider.board.supportsLocation ||
         provider.board.supportsHistory ||
@@ -402,7 +403,12 @@ class _RankingsBody extends StatelessWidget {
       slivers: [
         if (hasFilters)
           SliverPadding(
-            padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              14,
+              horizontalPadding,
+              10,
+            ),
             sliver: SliverToBoxAdapter(
               child: _RankingControls(
                 provider: provider,
@@ -419,7 +425,12 @@ class _RankingsBody extends StatelessWidget {
           ),
         if (provider.error != null)
           SliverPadding(
-            padding: const EdgeInsets.fromLTRB(16, 14, 16, 28),
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              14,
+              horizontalPadding,
+              28,
+            ),
             sliver: SliverToBoxAdapter(
               child: SidePageErrorPanel(
                 message: AppLocalizations.of(context)!.sideRankingsLoadError,
@@ -431,14 +442,19 @@ class _RankingsBody extends StatelessWidget {
         else if (!provider.isLoading && entries.isEmpty)
           SliverFillRemaining(
             hasScrollBody: false,
-            child: _RankingEmptyState(provider: provider),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1120),
+                child: _RankingEmptyState(provider: provider),
+              ),
+            ),
           )
         else ...[
           SliverPadding(
             padding: EdgeInsets.fromLTRB(
-              16,
+              horizontalPadding,
               hasFilters ? 0 : 14,
-              16,
+              horizontalPadding,
               24 + MediaQuery.paddingOf(context).bottom,
             ),
             sliver: SliverList.builder(
@@ -454,6 +470,11 @@ class _RankingsBody extends StatelessWidget {
       ],
     );
   }
+}
+
+double _rankingsHorizontalPadding(BuildContext context) {
+  final width = MediaQuery.sizeOf(context).width;
+  return ((width - 1120) / 2).clamp(16.0, double.infinity);
 }
 
 class _RankingControls extends StatelessWidget {

--- a/lib/features/rankings/presentation/rankings_page.dart
+++ b/lib/features/rankings/presentation/rankings_page.dart
@@ -392,88 +392,97 @@ class _RankingsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final entries = provider.result?.entries ?? const <RankingEntry>[];
-    final horizontalPadding = _rankingsHorizontalPadding(context);
     final hasFilters =
         provider.board.supportsLocation ||
         provider.board.supportsHistory ||
         provider.board == RankingBoard.playerTownHall ||
         provider.board == RankingBoard.playerRanked;
-    return CustomScrollView(
-      key: PageStorageKey(provider.board),
-      slivers: [
-        if (hasFilters)
-          SliverPadding(
-            padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
-              14,
-              horizontalPadding,
-              10,
-            ),
-            sliver: SliverToBoxAdapter(
-              child: _RankingControls(
-                provider: provider,
-                onOpenLocationPicker: onOpenLocationPicker,
-                onOpenTownHallPicker: onOpenTownHallPicker,
-                onOpenLeaguePicker: onOpenLeaguePicker,
-                onOpenHistoryDatePicker: onOpenHistoryDatePicker,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final horizontalPadding = _rankingsHorizontalPadding(
+          constraints.maxWidth,
+        );
+        return CustomScrollView(
+          key: PageStorageKey(provider.board),
+          slivers: [
+            if (hasFilters)
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  14,
+                  horizontalPadding,
+                  10,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: _RankingControls(
+                    provider: provider,
+                    onOpenLocationPicker: onOpenLocationPicker,
+                    onOpenTownHallPicker: onOpenTownHallPicker,
+                    onOpenLeaguePicker: onOpenLeaguePicker,
+                    onOpenHistoryDatePicker: onOpenHistoryDatePicker,
+                  ),
+                ),
               ),
-            ),
-          ),
-        if (provider.isLoading)
-          const SliverToBoxAdapter(
-            child: LinearProgressIndicator(minHeight: 2),
-          ),
-        if (provider.error != null)
-          SliverPadding(
-            padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
-              14,
-              horizontalPadding,
-              28,
-            ),
-            sliver: SliverToBoxAdapter(
-              child: SidePageErrorPanel(
-                message: AppLocalizations.of(context)!.sideRankingsLoadError,
-                detail: provider.error.toString(),
-                onRetry: provider.reload,
+            if (provider.isLoading)
+              const SliverToBoxAdapter(
+                child: LinearProgressIndicator(minHeight: 2),
               ),
-            ),
-          )
-        else if (!provider.isLoading && entries.isEmpty)
-          SliverFillRemaining(
-            hasScrollBody: false,
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 1120),
-                child: _RankingEmptyState(provider: provider),
+            if (provider.error != null)
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  14,
+                  horizontalPadding,
+                  28,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: SidePageErrorPanel(
+                    message: AppLocalizations.of(
+                      context,
+                    )!.sideRankingsLoadError,
+                    detail: provider.error.toString(),
+                    onRetry: provider.reload,
+                  ),
+                ),
+              )
+            else if (!provider.isLoading && entries.isEmpty)
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 1120),
+                    child: _RankingEmptyState(provider: provider),
+                  ),
+                ),
+              )
+            else ...[
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  hasFilters ? 0 : 14,
+                  horizontalPadding,
+                  24 + MediaQuery.paddingOf(context).bottom,
+                ),
+                sliver: SliverList.builder(
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) => RankingRow(
+                    key: ValueKey(
+                      '${provider.board.name}-${entries[index].tag}',
+                    ),
+                    entry: entries[index],
+                    onTap: () => onOpenEntry(entries[index]),
+                  ),
+                ),
               ),
-            ),
-          )
-        else ...[
-          SliverPadding(
-            padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
-              hasFilters ? 0 : 14,
-              horizontalPadding,
-              24 + MediaQuery.paddingOf(context).bottom,
-            ),
-            sliver: SliverList.builder(
-              itemCount: entries.length,
-              itemBuilder: (context, index) => RankingRow(
-                key: ValueKey('${provider.board.name}-${entries[index].tag}'),
-                entry: entries[index],
-                onTap: () => onOpenEntry(entries[index]),
-              ),
-            ),
-          ),
-        ],
-      ],
+            ],
+          ],
+        );
+      },
     );
   }
 }
 
-double _rankingsHorizontalPadding(BuildContext context) {
-  final width = MediaQuery.sizeOf(context).width;
+double _rankingsHorizontalPadding(double width) {
   return ((width - 1120) / 2).clamp(16.0, double.infinity);
 }
 

--- a/test/common/widgets/responsive_card_grid_test.dart
+++ b/test/common/widgets/responsive_card_grid_test.dart
@@ -47,4 +47,28 @@ void main() {
     expect(fourth.left, first.left);
     expect(fourth.top, greaterThan(first.top));
   });
+
+  testWidgets('can center a sparse final row', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1400, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ResponsiveCardGrid(
+            itemCount: 2,
+            alignment: WrapAlignment.center,
+            itemBuilder: (context, index) =>
+                SizedBox(key: ValueKey('card-$index'), height: 100),
+          ),
+        ),
+      ),
+    );
+
+    final first = tester.getRect(find.byKey(const ValueKey('card-0')));
+    final second = tester.getRect(find.byKey(const ValueKey('card-1')));
+
+    expect(first.left, greaterThan(0));
+    expect(1400 - second.right, closeTo(first.left, 0.1));
+  });
 }

--- a/test/features/pages/presentation/game_assets_page_test.dart
+++ b/test/features/pages/presentation/game_assets_page_test.dart
@@ -96,6 +96,52 @@ void main() {
           .width,
       1120,
     );
+    expect(
+      find.byKey(const ValueKey('game-assets-desktop-toolbar')),
+      findsOneWidget,
+    );
+    expect(
+      tester.getCenter(find.byType(FilterDropdown).first).dy,
+      closeTo(
+        tester.getCenter(find.byKey(const ValueKey('game-assets-search'))).dy,
+        0.1,
+      ),
+    );
+  });
+
+  testWidgets('short web pane uses compact horizontal controls', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(665, 360);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final repository = _FakeRepository([_manifest]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: GameAssetsPage(
+          repository: repository,
+          imageBuilder: (_, _, _) => const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('game-assets-header'))).height,
+      144,
+    );
+    expect(
+      find.byKey(const ValueKey('game-assets-compact-header-image')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('game-assets-desktop-toolbar')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('error retry and empty manifest states are visible', (

--- a/test/features/pages/presentation/game_assets_page_test.dart
+++ b/test/features/pages/presentation/game_assets_page_test.dart
@@ -69,6 +69,35 @@ void main() {
     expect(find.text('Wizard'), findsOneWidget);
   });
 
+  testWidgets('wide web content stays inside the desktop reading width', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final repository = _FakeRepository([_manifest]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: GameAssetsPage(
+          repository: repository,
+          imageBuilder: (_, _, _) => const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('game-assets-content-bound')))
+          .width,
+      1120,
+    );
+  });
+
   testWidgets('error retry and empty manifest states are visible', (
     tester,
   ) async {

--- a/test/features/pages/presentation/game_assets_page_test.dart
+++ b/test/features/pages/presentation/game_assets_page_test.dart
@@ -107,6 +107,11 @@ void main() {
         0.1,
       ),
     );
+
+    await tester.tap(find.byType(FilterDropdown).first);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('Troops'), findsOneWidget);
   });
 
   testWidgets('short web pane uses compact horizontal controls', (

--- a/test/features/player/presentation/to_do/player_to_do_body_test.dart
+++ b/test/features/player/presentation/to_do/player_to_do_body_test.dart
@@ -1,0 +1,56 @@
+import 'package:clashkingapp/core/services/bookmark_service.dart';
+import 'package:clashkingapp/features/player/models/player.dart';
+import 'package:clashkingapp/features/player/presentation/to_do/widget/player_to_do_body.dart';
+import 'package:clashkingapp/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets('wide layouts show account cards in a bounded grid', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1120, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final players = List.generate(
+      3,
+      (index) => Player.fromJson({
+        'name': 'Account ${index + 1}',
+        'tag': '#PLAYER$index',
+        'townHallLevel': 18 - index,
+      }),
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => BookmarkService(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: PlayerToDoBody(
+              players: players,
+              memberPresenceMap: const {},
+              emptyText: 'Empty',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final cards = find.byType(Card);
+    expect(cards, findsNWidgets(3));
+    expect(tester.getSize(cards.first).width, lessThan(370));
+    expect(
+      tester.getTopLeft(cards.at(0)).dy,
+      tester.getTopLeft(cards.at(1)).dy,
+    );
+    expect(
+      tester.getTopLeft(cards.at(1)).dy,
+      tester.getTopLeft(cards.at(2)).dy,
+    );
+  });
+}

--- a/test/features/rankings/presentation/rankings_page_test.dart
+++ b/test/features/rankings/presentation/rankings_page_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('wide web header fits without vertical overflow', (tester) async {
-    tester.view.physicalSize = const Size(1440, 900);
+  testWidgets('wide web content uses its local pane width', (tester) async {
+    tester.view.physicalSize = const Size(1600, 900);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -26,7 +26,10 @@ void main() {
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: RankingsPage(provider: provider),
+        home: Align(
+          alignment: Alignment.centerRight,
+          child: SizedBox(width: 1335, child: RankingsPage(provider: provider)),
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -34,7 +37,7 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(
       tester.getSize(find.byType(RankingRow).first).width,
-      lessThanOrEqualTo(1120),
+      closeTo(1120, 0.1),
     );
   });
 

--- a/test/features/rankings/presentation/rankings_page_test.dart
+++ b/test/features/rankings/presentation/rankings_page_test.dart
@@ -32,6 +32,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
+    expect(
+      tester.getSize(find.byType(RankingRow).first).width,
+      lessThanOrEqualTo(1120),
+    );
   });
 
   testWidgets('location picker is opaque, searchable, and pins Worldwide', (


### PR DESCRIPTION
## Summary
- center sparse Clan and War card rows on desktop while preserving dense-grid behavior elsewhere
- replace the floating Posts empty message with the shared bounded empty-state card and Clash illustration
- add regression coverage for centered sparse rows

## Validation
- `flutter test test/common/widgets/responsive_card_grid_test.dart`
- `flutter analyze lib/common/widgets/responsive_card_grid.dart lib/features/pages/presentation/clan_page.dart lib/features/pages/presentation/war_cwl_page.dart lib/features/pages/presentation/posts_page.dart`
- `flutter build web --dart-define-from-file=tooling/dev-app.staging.env`
- visually checked at 1813x900 and 1366x768 in the authenticated T3 preview

## Stack
This PR is based on #200 and should merge after it. Once #200 lands, this PR can be retargeted to `main`.