### PR TITLE
feat(config): add staging API environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ The deployed web build uses `CK_API_V2_BASE_URL=https://v2-api.clashk.ing/v2`.
 Browser authentication uses the `/v2/auth/web/*` cookie endpoints; native iOS
 and Android builds keep the JSON access/refresh-token contract.
 
+Set `CK_API_ENV=staging` to use `https://dev-api.clashk.ing` for legacy, v2,
+and Clash proxy requests. Local mode uses `http://localhost:8000`, while
+production continues to use `https://v2-api.clashk.ing/v2` for v2 requests and
+`https://proxy.clashk.ing/v1` for Clash API requests.
+
 ## 🌐 ClashKing Ecosystem
 
 ClashKing is a comprehensive platform with multiple tools:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,7 +47,7 @@ If `CK_SENTRY_DSN` is empty, the built-in Better Stack DSN is used.
 | Define | Default | Notes |
 |--------|---------|-------|
 | `CK_SENTRY_DSN` | built-in Better Stack DSN | Optional override for local/staging/rotation. |
-| `CK_API_ENV` | `prod` | Also drives the Better Stack environment: `prod`/`production` -> `production`, `local`/`dev`/`development` -> `development`. |
+| `CK_API_ENV` | `prod` | Also drives the Better Stack environment: `prod`/`production` -> `production`, `stage`/`staging` -> `staging`, `local`/`dev`/`development` -> `development`. |
 | `CK_SENTRY_TRACES_SAMPLE_RATE_PERCENT` | `0` | Use a low value in production, for example `1` to `5`. |
 | `CK_SENTRY_REPLAY_SESSION_SAMPLE_RATE_PERCENT` | `0` | Keep disabled for Better Stack; debug symbols/replay support is not equivalent to Sentry. |
 | `CK_SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE_PERCENT` | `0` | Keep disabled unless we intentionally test replay support. |

--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -1,4 +1,4 @@
-enum ApiEnvironment { production, local }
+enum ApiEnvironment { production, staging, local }
 
 class ApiConfig {
   ApiConfig._();
@@ -17,12 +17,17 @@ class ApiConfig {
     'CK_PROXY_BASE_URL',
   );
 
-  static ApiEnvironment get environment {
-    switch (_environmentName.toLowerCase()) {
+  static ApiEnvironment get environment => environmentForName(_environmentName);
+
+  static ApiEnvironment environmentForName(String name) {
+    switch (name.toLowerCase()) {
       case 'local':
       case 'dev':
       case 'development':
         return ApiEnvironment.local;
+      case 'stage':
+      case 'staging':
+        return ApiEnvironment.staging;
       case 'prod':
       case 'production':
       default:
@@ -54,12 +59,14 @@ class ApiConfig {
 
     return switch (environment) {
       ApiEnvironment.local => '$apiBaseUrl/proxy/v1',
+      ApiEnvironment.staging => '$apiBaseUrl/proxy/v1',
       ApiEnvironment.production => 'https://proxy.clashk.ing/v1',
     };
   }
 
   static String defaultApiBaseUrlFor(ApiEnvironment target) => switch (target) {
     ApiEnvironment.local => 'http://localhost:8000',
+    ApiEnvironment.staging => 'https://dev-api.clashk.ing',
     ApiEnvironment.production => 'https://api.clashk.ing',
   };
 
@@ -77,11 +84,13 @@ class ApiConfig {
 
   static String _defaultApiV2UrlFor(ApiEnvironment target) => switch (target) {
     ApiEnvironment.local => '${defaultApiBaseUrlFor(target)}/v2',
+    ApiEnvironment.staging => '${defaultApiBaseUrlFor(target)}/v2',
     ApiEnvironment.production => 'https://v2-api.clashk.ing/v2',
   };
 
   static String defaultProxyUrlFor(ApiEnvironment target) => switch (target) {
     ApiEnvironment.local => '${defaultApiBaseUrlFor(target)}/proxy/v1',
+    ApiEnvironment.staging => '${defaultApiBaseUrlFor(target)}/proxy/v1',
     ApiEnvironment.production => 'https://proxy.clashk.ing/v1',
   };
 

--- a/lib/core/config/observability_config.dart
+++ b/lib/core/config/observability_config.dart
@@ -31,6 +31,7 @@ class ObservabilityConfig {
   static String get environment {
     return switch (_apiEnvironment.toLowerCase()) {
       'local' || 'dev' || 'development' => 'development',
+      'stage' || 'staging' => 'staging',
       'prod' || 'production' => 'production',
       final value when value.isNotEmpty => value,
       _ => 'production',

--- a/lib/core/services/push_notification_service.dart
+++ b/lib/core/services/push_notification_service.dart
@@ -80,7 +80,8 @@ class PushNotificationService {
 
   static String get environment {
     if (_pushApiV2BaseOverride.isNotEmpty ||
-        ApiConfig.environment == ApiEnvironment.local) {
+        ApiConfig.environment == ApiEnvironment.local ||
+        ApiConfig.environment == ApiEnvironment.staging) {
       return 'sandbox';
     }
     return 'production';

--- a/test/core/config/api_config_local_test.dart
+++ b/test/core/config/api_config_local_test.dart
@@ -2,6 +2,12 @@ import 'package:clashkingapp/core/config/api_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('recognizes staging aliases as a distinct API environment', () {
+    expect(ApiConfig.environmentForName('staging'), ApiEnvironment.staging);
+    expect(ApiConfig.environmentForName('stage'), ApiEnvironment.staging);
+    expect(ApiConfig.environmentForName('StAgInG'), ApiEnvironment.staging);
+  });
+
   test('local API environment targets the local Go API server', () {
     expect(
       ApiConfig.defaultApiBaseUrlFor(ApiEnvironment.local),
@@ -17,10 +23,29 @@ void main() {
     );
   });
 
+  test('staging uses the dev API origin for v1, v2, and proxy requests', () {
+    expect(
+      ApiConfig.defaultApiBaseUrlFor(ApiEnvironment.staging),
+      'https://dev-api.clashk.ing',
+    );
+    expect(
+      ApiConfig.defaultApiV2UrlFor(ApiEnvironment.staging),
+      'https://dev-api.clashk.ing/v2',
+    );
+    expect(
+      ApiConfig.defaultProxyUrlFor(ApiEnvironment.staging),
+      'https://dev-api.clashk.ing/proxy/v1',
+    );
+  });
+
   test('production API environment targets the public v2 API', () {
     expect(
       ApiConfig.defaultApiV2UrlFor(ApiEnvironment.production),
       'https://v2-api.clashk.ing/v2',
+    );
+    expect(
+      ApiConfig.defaultProxyUrlFor(ApiEnvironment.production),
+      'https://proxy.clashk.ing/v1',
     );
   });
 }


### PR DESCRIPTION
## Summary
- add `staging` / `stage` API environment selection
- route staging legacy, v2, and Clash proxy traffic through `dev-api.clashk.ing`
- classify staging telemetry and push registration as non-production
- document the production/staging routing accurately and cover environment aliases and URLs

The unused stash-only `proxyUrlFor` helper and local `tooling/dev-app.staging.env` file are intentionally excluded.

## Validation
- `dart format lib/core/config/api_config.dart lib/core/config/observability_config.dart lib/core/services/push_notification_service.dart test/core/config/api_config_local_test.dart`
- `flutter test test/core/config/api_config_local_test.dart`
- `flutter analyze`
- `flutter gen-l10n`
- parsed all 33 `lib/l10n/*.arb` files successfully

`untranslated_messages.json` contains pre-existing gaps from `main`; this PR adds or changes no localization keys.