### PR TITLE
fix(war): use v2 historical war lookup

### DIFF
--- a/lib/features/war_cwl/data/war_cwl_service.dart
+++ b/lib/features/war_cwl/data/war_cwl_service.dart
@@ -104,6 +104,7 @@ class WarCwlService extends ChangeNotifier {
 
     final response = await client.getResponse(
       '/war/$encodedTag/previous?timestamp_end=$endTime&include_cwl=true&limit=1',
+      requiresAuth: true,
     );
     if (response.statusCode == 200) {
       String body = ApiService.decodeResponseBody(response);

--- a/lib/features/war_cwl/data/war_cwl_service.dart
+++ b/lib/features/war_cwl/data/war_cwl_service.dart
@@ -93,21 +93,28 @@ class WarCwlService extends ChangeNotifier {
     notifyListeners();
   }
 
-  static Future<WarInfo?> fetchWarDataFromTime(String tag, DateTime end) async {
-    final apiService = ApiService.shared;
-    String endTime = end.toIso8601String();
-    endTime = endTime.replaceAll('-', '').replaceAll(':', '');
+  static Future<WarInfo?> fetchWarDataFromTime(
+    String tag,
+    DateTime end, {
+    ApiService? apiService,
+  }) async {
+    final client = apiService ?? ApiService.shared;
+    final encodedTag = Uri.encodeComponent(tag);
+    final endTime = end.millisecondsSinceEpoch ~/ 1000;
 
-    final response = await apiService.getResponse(
-      '',
-      url: "${ApiService.apiUrlV1}/war/${tag.substring(1)}/previous/$endTime",
+    final response = await client.getResponse(
+      '/war/$encodedTag/previous?timestamp_end=$endTime&include_cwl=true&limit=1',
     );
     if (response.statusCode == 200) {
       String body = ApiService.decodeResponseBody(response);
       Map<String, dynamic> jsonBody = json.decode(body);
-      return WarInfo.fromJson(jsonBody);
+      final items = jsonBody['items'];
+      if (items is List && items.isNotEmpty && items.first is Map) {
+        return WarInfo.fromJson(Map<String, dynamic>.from(items.first as Map));
+      }
     } else {
       return null;
     }
+    return null;
   }
 }

--- a/test/features/war_cwl/data/war_cwl_service_test.dart
+++ b/test/features/war_cwl/data/war_cwl_service_test.dart
@@ -167,4 +167,49 @@ void main() {
       );
     });
   });
+
+  group('WarCwlService — fetchWarDataFromTime', () {
+    test('uses the v2 previous-war endpoint and parses its first item', () async {
+      final fakeApi = FakeApiService();
+      final end = DateTime.utc(2026, 8, 9, 12, 34, 56);
+      final timestamp = end.millisecondsSinceEpoch ~/ 1000;
+      final endpoint =
+          '/war/%23ABC123/previous?timestamp_end=$timestamp&include_cwl=true&limit=1';
+      fakeApi.getStubs[endpoint] = http.Response(
+        jsonEncode({
+          'items': [
+            {'war_tag': '#WAR1', 'state': 'warEnded', 'type': 'regular'},
+          ],
+        }),
+        200,
+      );
+
+      final result = await WarCwlService.fetchWarDataFromTime(
+        '#ABC123',
+        end,
+        apiService: fakeApi,
+      );
+
+      expect(fakeApi.getCallCounts[endpoint], 1);
+      expect(result?.tag, '#WAR1');
+      expect(result?.state, 'warEnded');
+    });
+
+    test('returns null when the v2 response has no historical wars', () async {
+      final fakeApi = FakeApiService();
+      final end = DateTime.utc(2026, 8, 9);
+      final timestamp = end.millisecondsSinceEpoch ~/ 1000;
+      final endpoint =
+          '/war/%23EMPTY/previous?timestamp_end=$timestamp&include_cwl=true&limit=1';
+      fakeApi.getStubs[endpoint] = http.Response('{"items":[]}', 200);
+
+      final result = await WarCwlService.fetchWarDataFromTime(
+        '#EMPTY',
+        end,
+        apiService: fakeApi,
+      );
+
+      expect(result, isNull);
+    });
+  });
 }

--- a/test/features/war_cwl/data/war_cwl_service_test.dart
+++ b/test/features/war_cwl/data/war_cwl_service_test.dart
@@ -15,6 +15,28 @@ Map<String, dynamic> _minimalWarCwl(String tag) => {
   'war_league_infos': [],
 };
 
+class _RecordingApiService extends FakeApiService {
+  bool? lastGetRequiresAuth;
+
+  @override
+  Future<http.Response> getResponse(
+    String endpoint, {
+    bool requiresAuth = false,
+    String? url,
+    Duration timeout = const Duration(seconds: 15),
+    Map<String, String>? extraHeaders,
+  }) {
+    lastGetRequiresAuth = requiresAuth;
+    return super.getResponse(
+      endpoint,
+      requiresAuth: requiresAuth,
+      url: url,
+      timeout: timeout,
+      extraHeaders: extraHeaders,
+    );
+  }
+}
+
 void main() {
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -170,7 +192,7 @@ void main() {
 
   group('WarCwlService — fetchWarDataFromTime', () {
     test('uses the v2 previous-war endpoint and parses its first item', () async {
-      final fakeApi = FakeApiService();
+      final fakeApi = _RecordingApiService();
       final end = DateTime.utc(2026, 8, 9, 12, 34, 56);
       final timestamp = end.millisecondsSinceEpoch ~/ 1000;
       final endpoint =
@@ -191,6 +213,7 @@ void main() {
       );
 
       expect(fakeApi.getCallCounts[endpoint], 1);
+      expect(fakeApi.lastGetRequiresAuth, isTrue);
       expect(result?.tag, '#WAR1');
       expect(result?.state, 'warEnded');
     });


### PR DESCRIPTION
## Summary
- migrate historical-war lookup from the legacy unversioned host to `/v2/war/{clan_tag}/previous`
- send `timestamp_end`, `include_cwl`, and `limit` through the v2 query contract
- parse the v2 `items` response envelope
- add regression coverage for the exact encoded route and empty history

Player-name search remains on the legacy endpoint because v2 has no replacement.

## Validation
- `dart format lib/features/war_cwl/data/war_cwl_service.dart test/features/war_cwl/data/war_cwl_service_test.dart`
- `flutter test test/features/war_cwl/data/war_cwl_service_test.dart`
- `flutter analyze`
- `flutter gen-l10n`
- parsed all 33 `lib/l10n/*.arb` files successfully

`untranslated_messages.json` contains pre-existing gaps from `main`; this PR adds or changes no localization keys.